### PR TITLE
webNavigation: update transitionType/transistionQualifiers Firefox support

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -6060,7 +6060,7 @@
                     "support": "Unknown"
                 },
                 "Firefox": {
-                    "support": "45.0",
+                    "support": "48.0",
                     "notes": ["In Firefox, 'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."]
                 }
             }
@@ -6089,7 +6089,7 @@
                     "support": "Unknown"
                 },
                 "Firefox": {
-                    "support": "45.0",
+                    "support": "48.0",
                     "notes": ["Firefox has the following limitations: 'server_redirect' is limited to top-level frames, 'client_redirect' is not supplied when redirections are created by JavaScript, and 'from_address_bar' is not supported. 'forward_back' is fully supported."]
                 }
             }


### PR DESCRIPTION
Fix the initial desktop Firefox version supported (Firefox 48) on webNavigation TransitionType and TransitionQualifiers compat data.