### PR TITLE
storage API: add notes about initial support from content scripts

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -4859,7 +4859,8 @@
                     "support": "Unknown"
                 },
                 "Firefox": {
-                    "support": "45.0"
+                    "support": "45.0",
+                    "notes": ["Firefox supports the storage API in content scripts from version 48"]
                 }
             }
         }


### PR DESCRIPTION
content scripts didn't have access to the storage API (even if the permission is specified in the manifest.json) until [Bug 1197346](https://bugzilla.mozilla.org/show_bug.cgi?id=1197346) landed on Firefox 48. 