### PR TITLE
tabs.executeScript() note

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -1306,7 +1306,8 @@
       "Firefox": {
         "support": "43.0", 
         "notes": [
-          "'matchAboutBlank' is not supported."
+          "'matchAboutBlank' is not supported.",
+          "'allFrames' and 'frameId' both set is not supported."
         ]
       }, 
       "Firefox for Android": {


### PR DESCRIPTION
tabs.executeScript() doesn't support 'allFrames' and 'frameId' both set.

References:
* Chrome API - https://developer.chrome.com/extensions/tabs#property-details-allFrames
* Mozilla source - https://dxr.mozilla.org/mozilla-central/source/browser/components/extensions/ext-tabs.js#765