### PR TITLE
remove RequestUpdateCheckStatus

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -591,10 +591,10 @@
         "support": false
       }, 
       "Firefox": {
-        "support": "45.0"
+        "support": false
       }, 
       "Firefox for Android": {
-        "support": "48.0"
+        "support": false
       }
     }, 
     "requestUpdateCheck": {


### PR DESCRIPTION
I can't spot an implementation of this data, just a mention of it in the schema. It looks like the result of a call to https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/Runtime/requestUpdateCheck, which we haven't implemented yet, so it probably makes sense to keep this showing as unimplemented for now.