### PR TITLE
Add compat data for WebGL1 'small' interfaces

### DIFF
--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -1,0 +1,261 @@
+{
+  "WebGLActiveInfo": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  },
+  "WebGLActiveInfo.name": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  },
+  "WebGLActiveInfo.size": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  },
+  "WebGLActiveInfo.type": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -1,0 +1,105 @@
+{
+  "WebGLBuffer": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -1,0 +1,157 @@
+{
+  "WebGLContextEvent": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "49"
+      },
+      "Firefox for Android": {
+        "support": "49"
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 49; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  },
+  "WebGLContextEvent.statusMessage": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "49"
+      },
+      "Firefox for Android": {
+        "support": "49"
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -1,0 +1,105 @@
+{
+  "WebGLFramebuffer": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -1,0 +1,105 @@
+{
+  "WebGLProgram": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -1,0 +1,105 @@
+{
+  "WebGLRenderbuffer": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -1,0 +1,105 @@
+{
+  "WebGLShader": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -1,0 +1,261 @@
+{
+  "WebGLShaderPrecisionFormat": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "11.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  },
+  "WebGLShaderPrecisionFormat.rangeMin": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "11.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  },
+  "WebGLShaderPrecisionFormat.rangeMax": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "11.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  },
+  "WebGLShaderPrecisionFormat.precision": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "11.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -1,0 +1,105 @@
+{
+  "WebGLTexture": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -1,0 +1,105 @@
+{
+  "WebGLUniformLocation": {
+    "Basic support": {
+      "Android": {
+        "support": true
+      },
+      "Chrome": {
+        "support": "9"
+      },
+      "Chrome for Android": {
+        "support": "25"
+      },
+      "Edge": {
+        "support": "12"
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": "4.0"
+      },
+      "Firefox for Android": {
+        "support": true
+      },
+      "Internet Explorer": {
+        "support": "11"
+      },
+      "IE Mobile": {
+        "support": "11"
+      },
+      "Opera": {
+        "support": "12"
+      },
+      "Opera Mobile": {
+        "support": "12"
+      },
+      "Safari": {
+        "support": "5.1"
+      },
+      "Safari Mobile": {
+        "support": "8.1"
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    },
+    "Available in workers": {
+      "Android": {
+        "support": false
+      },
+      "Chrome": {
+        "support": false
+      },
+      "Chrome for Android": {
+        "support": false
+      },
+      "Edge": {
+        "support": false
+      },
+      "Edge Mobile": {
+        "support": false
+      },
+      "Firefox": {
+        "support": false,
+        "notes": ["This feature is experimentally implemented since Firefox 44; to activate it, in about:config, set gfx.offscreencanvas.enabled to true"]
+      },
+      "Firefox for Android": {
+        "support": false
+      },
+      "Internet Explorer": {
+        "support": false
+      },
+      "IE Mobile": {
+        "support": false
+      },
+      "Opera": {
+        "support": false
+      },
+      "Opera Mobile": {
+        "support": false
+      },
+      "Safari": {
+        "support": false
+      },
+      "Safari Mobile": {
+        "support": false
+      },
+      "Servo": {
+        "support": false
+      },
+      "status": {
+        "experimental": true,
+        "standardized": true,
+        "stable": false,
+        "obsolete": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
Note: only WebGL1 small interfaces; WebGL2 i/f will be in a separate PR.