### PR TITLE
Capitalize interface name

### DIFF
--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -1,5 +1,5 @@
 {
-  "WebGL_color_buffer_float": {
+  "WEBGL_color_buffer_float": {
     "Basic support": {
       "Android": {
         "support": null


### PR DESCRIPTION
The interface name should start with WEBGL rather than WebGL (it is an extension), like the filename.