### PR TITLE
Allow features to have notes and a alternative long title (change json schema) [DO NOT MERGE]

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -33,6 +33,13 @@
     "feature": {
       "type": "object",
       "properties": {
+        "title": { "type": "string" },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "Android": { "$ref": "#/definitions/support_statement" },
         "Chrome": { "$ref": "#/definitions/support_statement" },
         "Chrome for Android": { "$ref": "#/definitions/support_statement" },


### PR DESCRIPTION
Modify the schema so that features (the different "lines" of the compat table) can have:
- an alternative title ('title') that, if present, will be displayed as the feature name. That way we can keep feature name short. Also the title will be localizable in the future, but the feature name not (so that it can used to identify the feature in any language).
- a notes field, tight to the feature, so that we can add notes to the feature (like why it is deprecated. See @font-face (feature set) and SVG Fonts (feature) as a use case: SVG fonts, though implemented by some browsers has been obsoleted by SVG Glyphs in OpenType and is only retained by these browsers for compat purpose; no additional browsers will support it.