### PR TITLE
Note that sessions Tab objects also don't contain title or favIconUrl…

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -5605,7 +5605,7 @@
       "Firefox": {
         "support": "52.0",
         "notes": [
-          "'Tab' objects in Sessions don't contain a 'url' property."
+          "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
         ]
       },
       "Firefox for Android": {


### PR DESCRIPTION
… in Firefox