### PR TITLE
Added IE compatibility info for'X-Frame-Options: ALLOW-FROM' header

### DIFF
--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -73,7 +73,7 @@
         "support": null
       },
       "Internet Explorer": {
-        "support": null
+        "support": true
       },
       "IE Mobile": {
         "support": null


### PR DESCRIPTION
I've tested this with IE 11 on Windows 10. Edge didn't let me call my test pages from the virtual hosts at all, so I can't say whether it supports the feature or not.

Sebastian