### PR TITLE
Correct compat info for runtime.onStartup

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -483,10 +483,10 @@
         "support": false
       }, 
       "Firefox": {
-        "support": false
+        "support": "52.0"
       }, 
       "Firefox for Android": {
-        "support": "48.0"
+        "support": "52.0"
       }
     }, 
     "PlatformOs": {


### PR DESCRIPTION
`runtime.onStartup` support was added in Firefox 52 - https://bugzil.la/1247435
The existing incorrect note about compatibility in Firefox for Android 48 was accidentally added in ba69b281662993c6144f85ae8a5f45cdea881130.