### PR TITLE
Add WEBGL_compressed_texture_astc WebGL extension data

### DIFF
--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -1,0 +1,106 @@
+{
+  "WEBGL_compressed_texture_astc": {
+    "Basic support": {
+      "Android": {
+        "support": null
+      },
+      "Chrome": {
+        "support": null
+      },
+      "Chrome for Android": {
+        "support": null
+      },
+      "Edge": {
+        "support": null
+      },
+      "Edge Mobile": {
+        "support": null
+      },
+      "Firefox": {
+        "support": "53.0"
+      },
+      "Firefox for Android": {
+        "support": "53.0"
+      },
+      "Internet Explorer": {
+        "support": null
+      },
+      "IE Mobile": {
+        "support": null
+      },
+      "Opera": {
+        "support": null
+      },
+      "Opera Mobile": {
+        "support": null
+      },
+      "Safari": {
+        "support": null
+      },
+      "Safari Mobile": {
+        "support": null
+      },
+      "Servo": {
+        "support": null
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  },
+  "WEBGL_compressed_texture_ast.getSupportedProfiles": {
+    "Basic support": {
+      "Android": {
+        "support": null
+      },
+      "Chrome": {
+        "support": null
+      },
+      "Chrome for Android": {
+        "support": null
+      },
+      "Edge": {
+        "support": null
+      },
+      "Edge Mobile": {
+        "support": null
+      },
+      "Firefox": {
+        "support": "53.0"
+      },
+      "Firefox for Android": {
+        "support": "53.0"
+      },
+      "Internet Explorer": {
+        "support": null
+      },
+      "IE Mobile": {
+        "support": null
+      },
+      "Opera": {
+        "support": null
+      },
+      "Opera Mobile": {
+        "support": null
+      },
+      "Safari": {
+        "support": null
+      },
+      "Safari Mobile": {
+        "support": null
+      },
+      "Servo": {
+        "support": null
+      },
+      "status": {
+        "experimental": false,
+        "standardized": true,
+        "stable": true,
+        "obsolete": false
+      }
+    }
+  }
+}

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -1,14 +1,14 @@
 {
   "WEBGL_compressed_texture_astc": {
     "Basic support": {
-      "Android": {
-        "support": null
+      "Android Webview": {
+        "support": false
       },
       "Chrome": {
-        "support": null
+        "support": "47"
       },
       "Chrome for Android": {
-        "support": null
+        "support": "47"
       },
       "Edge": {
         "support": null
@@ -53,14 +53,14 @@
   },
   "WEBGL_compressed_texture_ast.getSupportedProfiles": {
     "Basic support": {
-      "Android": {
-        "support": null
+      "Android Webview": {
+        "support": false
       },
       "Chrome": {
-        "support": null
+        "support": false
       },
       "Chrome for Android": {
-        "support": null
+        "support": false
       },
       "Edge": {
         "support": null


### PR DESCRIPTION
MDN pages are
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_astc
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_astc/getSupportedProfiles

Maybe @jpmedley can review and tell me in which Chrome version this is supported?