### PR TITLE
Edge data for WebGL extensions + HTTP updates

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "33.0"

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "33.0"

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "49.0"

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "30.0"

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -11,10 +11,10 @@
         "support": "47"
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "51.0"

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "30.0"

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "28.0"

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "50.0"

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "17.0"

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "24.0"

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "10.0"

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "6.0"

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "24.0"

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "29.0"

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "30.0"

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "25.0"

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "30.0"

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "18.0"

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "51.0"

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "30.0"

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "18.0"

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "22.0",

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": false,

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": false,

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "22.0",

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "28.0",

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "22.0",

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "49"

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5902,7 +5902,7 @@
       }
     }
   },
- "WebGLRenderingContext.lineWidth": {
+  "WebGLRenderingContext.lineWidth": {
     "Basic support": {
       "Android": {
         "support": false
@@ -6206,7 +6206,7 @@
       },
       "status": {
         "experimental": false,
-               "standardized": true,
+        "standardized": true,
         "stable": true,
         "obsolete": false
       }

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -12,10 +12,11 @@
       },
       "Edge": {
         "support": "12",
-        "notes": ["To access the WebGL context, use experimental-webgl rather than the standard webgl"]        
+        "notes": ["To access the WebGL context, use experimental-webgl rather than the standard webgl"]
       },
       "Edge Mobile": {
-        "support": false
+        "support": true,
+        "notes": ["To access the WebGL context, use experimental-webgl rather than the standard webgl"]
       },
       "Firefox": {
         "support": "4.0"
@@ -5901,7 +5902,7 @@
       }
     }
   },
-  "WebGLRenderingContext.lineWidth": {
+ "WebGLRenderingContext.lineWidth": {
     "Basic support": {
       "Android": {
         "support": false
@@ -6205,7 +6206,7 @@
       },
       "status": {
         "experimental": false,
-        "standardized": true,
+               "standardized": true,
         "stable": true,
         "obsolete": false
       }
@@ -6221,10 +6222,10 @@
         "support": false
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "51.0"
@@ -8382,7 +8383,7 @@
         "obsolete": false
       }
     }
-  },  
+  },
   "WebGLRenderingContext.vertexAttrib1fv": {
     "Basic support": {
       "Android": {

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "11.0"

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -14,7 +14,7 @@
         "support": "12"
       },
       "Edge Mobile": {
-        "support": false
+        "support": true
       },
       "Firefox": {
         "support": "4.0"

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": false
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "25.0"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -116,10 +116,10 @@
         "support": true
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "50.0"
@@ -327,7 +327,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0",
@@ -380,7 +380,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -484,7 +484,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -640,7 +640,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -692,7 +692,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -796,7 +796,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -900,7 +900,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -1116,7 +1116,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -1220,7 +1220,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "50.0"
@@ -1272,7 +1272,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -1376,7 +1376,7 @@
         "support": "14"
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "23.0"
@@ -1425,7 +1425,8 @@
         "support": "43"
       },
       "Edge": {
-        "support": false
+        "support": false,
+        "notes":["<a href=\"https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective\">Under consideration</a> for future release."]
       },
       "Edge Mobile": {
         "support": false

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -11,7 +11,8 @@
         "support": true
       },
       "Edge": {
-        "support": null
+        "support": false,
+        "notes": ["<a href=\"https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp\">Under consideration</a> for future release."]
       },
       "Edge Mobile": {
         "support": null

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -11,7 +11,8 @@
         "support": true
       },
       "Edge": {
-        "support": null
+        "support": false,
+        "notes": ["<a href=\"https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp\">Under consideration</a> for future release."]
       },
       "Edge Mobile": {
         "support": null

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -11,10 +11,10 @@
         "support": null
       },
       "Edge": {
-        "support": null
+        "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": false,

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -11,10 +11,11 @@
         "support": "44"
       },
       "Edge": {
-        "support": null
+        "support": false,
+        "notes": ["<a href=\"https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective\">Under consideration</a> for future release."]
       },
       "Edge Mobile": {
-        "support": null
+        "support": false
       },
       "Firefox": {
         "support": "48.0"

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -64,7 +64,7 @@
         "support": true
       },
       "Edge Mobile": {
-        "support": null
+        "support": true
       },
       "Firefox": {
         "support": "18"


### PR DESCRIPTION
With this PR, everything (in this repo; still working through the manual MDN tables) should be up to date for the current stable release of Edge (EdgeHTML 14). Thanks!