### PR TITLE
Webextensions update for new schema

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -8,154 +8,154 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "clear": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "clearAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onAlarm": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -163,7 +163,7 @@
           }
         }
       }
-    }, 
+    },
     "bookmarks": {
       "BookmarkTreeNode": {
         "__compat": {
@@ -171,522 +171,522 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "BookmarkTreeNodeUnmodifiable": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "CreateDetails": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "export": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getChildren": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getRecent": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getSubTree": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getTree": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "import": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "move": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onChildrenReordered": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCreated": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onImportBegan": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onImportEnded": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onMoved": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onRemoved": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "removeTree": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "search": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "update": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -694,7 +694,7 @@
           }
         }
       }
-    }, 
+    },
     "browserAction": {
       "ColorArray": {
         "__compat": {
@@ -702,315 +702,315 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "ImageDataType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "disable": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "enable": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getBadgeBackgroundColor": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getBadgeText": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getPopup": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getTitle": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onClicked": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setBadgeBackgroundColor": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setBadgeText": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setIcon": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setPopup": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setTitle": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -1018,7 +1018,7 @@
           }
         }
       }
-    }, 
+    },
     "browsingData": {
       "DataTypeSet": {
         "__compat": {
@@ -1026,309 +1026,309 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "RemovalOptions": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "originTypes.extension": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "originTypes.protectedWeb": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.", 
+                  "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.",
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "removeCache": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "removeCookies": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "removeDownloads": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "removeFormData": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "removeHistory": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "removePasswords": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "removePluginData": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "settings": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
@@ -1336,7 +1336,7 @@
           }
         }
       }
-    }, 
+    },
     "commands": {
       "Command": {
         "__compat": {
@@ -1344,62 +1344,62 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCommand": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -1407,7 +1407,7 @@
           }
         }
       }
-    }, 
+    },
     "contextMenus": {
       "ACTION_MENU_TOP_LEVEL_LIMIT": {
         "__compat": {
@@ -1415,42 +1415,42 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "ContextType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -1460,19 +1460,19 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                ], 
+                ],
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -1482,145 +1482,145 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
-              "firefox": { 
+              },
+              "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          },      
+          },
           "launcher": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "password": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "tab": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "ItemType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "OnClickData": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "modifiers": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
@@ -1628,119 +1628,119 @@
               "chrome": {
                 "notes": [
                   "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "notes": [
                   "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onClicked": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "removeAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "update": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -1748,7 +1748,7 @@
           }
         }
       }
-    }, 
+    },
     "contextualIdentities": {
       "ContextualIdentity": {
         "__compat": {
@@ -1756,131 +1756,131 @@
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "query": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "update": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
@@ -1888,7 +1888,7 @@
           }
         }
       }
-    }, 
+    },
     "cookies": {
       "Cookie": {
         "__compat": {
@@ -1896,206 +1896,206 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "CookieStore": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "OnChangedCause": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user\u2019s machine."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAllCookieStores": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Always returns the same default cookie store with ID 0. All cookies belong to this store."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "set": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -2103,7 +2103,7 @@
           }
         }
       }
-    }, 
+    },
     "devtools.inspectedWindow": {
       "eval": {
         "__compat": {
@@ -2111,84 +2111,84 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Console helper functions are not available to injected scripts."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "options": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "reload": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "tabId": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
@@ -2196,7 +2196,7 @@
           }
         }
       }
-    }, 
+    },
     "devtools.network": {
       "onNavigated": {
         "__compat": {
@@ -2204,16 +2204,16 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
@@ -2221,7 +2221,7 @@
           }
         }
       }
-    }, 
+    },
     "devtools.panels": {
       "ExtensionPanel": {
         "__compat": {
@@ -2229,39 +2229,39 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
@@ -2269,7 +2269,7 @@
           }
         }
       }
-    }, 
+    },
     "downloads": {
       "BooleanDelta": {
         "__compat": {
@@ -2277,311 +2277,311 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "DangerType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "DoubleDelta": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "DownloadItem": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "DownloadQuery": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "DownloadTime": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "FilenameConflictAction": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "prompt": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "InterruptReason": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "State": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "StringDelta": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "acceptDanger": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "cancel": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "download": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -2591,16 +2591,16 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "52.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -2610,338 +2610,338 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "52.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "drag": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "erase": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getFileIcon": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCreated": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onErased": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "open": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "pause": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "removeFile": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "resume": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "search": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setShelfEnabled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "show": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "showDefaultFolder": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -2949,7 +2949,7 @@
           }
         }
       }
-    }, 
+    },
     "events": {
       "Event": {
         "__compat": {
@@ -2957,62 +2957,62 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "Rule": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "UrlFilter": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "50.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -3020,7 +3020,7 @@
           }
         }
       }
-    }, 
+    },
     "extension": {
       "ViewType": {
         "__compat": {
@@ -3028,292 +3028,292 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getBackgroundPage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getExtensionTabs": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "getURL": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getViews": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "inIncognitoContext": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "isAllowedFileSchemeAccess": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "isAllowedIncognitoAccess": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "lastError": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onRequest": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onRequestExternal": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "sendRequest": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "setUpdateUrlData": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -3321,7 +3321,7 @@
           }
         }
       }
-    }, 
+    },
     "extensionTypes": {
       "ImageDetails": {
         "__compat": {
@@ -3329,104 +3329,104 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "ImageFormat": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "InjectDetails": {
         "__compat": {
           "InjectDetails": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "RunAt": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -3434,7 +3434,7 @@
           }
         }
       }
-    }, 
+    },
     "history": {
       "HistoryItem": {
         "__compat": {
@@ -3442,322 +3442,322 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "typedCount": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "TransitionType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "VisitItem": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "addUrl": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "title": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "transition": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "visitTime": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "deleteAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "deleteRange": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "deleteUrl": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getVisits": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onVisitRemoved": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onVisited": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "search": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -3765,7 +3765,7 @@
           }
         }
       }
-    }, 
+    },
     "i18n": {
       "LanguageCode": {
         "__compat": {
@@ -3773,108 +3773,108 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "detectLanguage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAcceptLanguages": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getMessage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getUILanguage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
@@ -3882,7 +3882,7 @@
           }
         }
       }
-    }, 
+    },
     "identity": {
       "getRedirectURL": {
         "__compat": {
@@ -3890,39 +3890,39 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "launchWebAuthFlow": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
@@ -3930,7 +3930,7 @@
           }
         }
       }
-    }, 
+    },
     "idle": {
       "IdleState": {
         "__compat": {
@@ -3938,129 +3938,129 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onStateChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "locked": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "queryState": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "locked": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setDetectionInterval": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -4068,7 +4068,7 @@
           }
         }
       }
-    }, 
+    },
     "management": {
       "ExtensionInfo": {
         "__compat": {
@@ -4076,387 +4076,387 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51.0"
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "disabledReason": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "offlineEnabled": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "type": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "versionName": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "getAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "getPermissionWarningsById": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "getPermissionWarningsByManifest": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "getSelf": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onDisabled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "onEnabled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "onInstalled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "onUninstalled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "setEnabled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "uninstall": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "uninstallSelf": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51.0"
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "dialogMessage": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
@@ -4464,7 +4464,7 @@
           }
         }
       }
-    }, 
+    },
     "notifications": {
       "NotificationOptions": {
         "__compat": {
@@ -4472,245 +4472,245 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "TemplateType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Only the 'basic' type is supported."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Only the 'basic' type is supported."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "Only the 'basic' type is supported."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "clear": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onButtonClicked": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onClicked": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onClosed": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "byUser": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "update": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "notes": [
                   "Not supported on Macs."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
           }
         }
       }
-    }, 
+    },
     "omnibox": {
       "OnInputEnteredDisposition": {
         "__compat": {
@@ -4718,160 +4718,160 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "SuggestResult": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'description' is interpreted as plain text, and XML markup is not recognised."
-                ], 
+                ],
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "onInputCancelled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "onInputChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "onInputEntered": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "onInputStarted": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "setDefaultSuggestion": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'description' is interpreted as plain text, and XML markup is not recognised."
-                ], 
+                ],
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
@@ -4879,7 +4879,7 @@
           }
         }
       }
-    }, 
+    },
     "pageAction": {
       "ImageDataType": {
         "__compat": {
@@ -4887,231 +4887,231 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getPopup": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
-                ], 
+                ],
                 "version_added": "50.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getTitle": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "hide": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "The 'tabId' parameter is ignored, and the page action is hidden for all tabs."
-                ], 
+                ],
                 "version_added": "50.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onClicked": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "50.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setIcon": {
         "__compat": {
           "ImageData": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setPopup": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "The 'tabId' parameter is ignored, and the popup is set for all tabs."
-                ], 
+                ],
                 "version_added": "50.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setTitle": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "show": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "The 'tabId' parameter is ignored, and the page action is shown for all tabs."
-                ], 
+                ],
                 "version_added": "50.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -5119,7 +5119,7 @@
           }
         }
       }
-    }, 
+    },
     "privacy": {
       "BrowserSetting": {
         "__compat": {
@@ -5127,138 +5127,138 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "onChange": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "network": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "websites": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "protectedContentEnabled": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "referrersEnabled": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
-          }, 
+          },
           "thirdPartyCookiesAllowed": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
@@ -5266,7 +5266,7 @@
           }
         }
       }
-    }, 
+    },
     "runtime": {
       "MessageSender": {
         "__compat": {
@@ -5274,458 +5274,458 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "OnInstalledReason": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "OnRestartRequiredReason": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "PlatformArch": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "PlatformInfo": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "nacl_arch": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "PlatformNaclArch": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "PlatformOs": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "Port": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "error": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "RequestUpdateCheckStatus": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "connect": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "connectNative": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getBackgroundPage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getBrowserInfo": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "getManifest": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getPackageDirectoryEntry": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getPlatformInfo": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getURL": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "id": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "lastError": {
         "__compat": {
           "basic_support": {
@@ -5733,456 +5733,456 @@
               "chrome": {
                 "notes": [
                   "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onBrowserUpdateAvailable": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onConnect": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onConnectExternal": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onInstalled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "This event is not triggered for temporarily installed add-ons."
-                ], 
+                ],
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "This event is not triggered for temporarily installed add-ons."
-                ], 
+                ],
                 "version_added": "52.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onMessage": {
         "__compat": {
           "MessageSender.tlsChannelId": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onMessageExternal": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onRestartRequired": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onStartup": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "52.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onSuspend": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onSuspendCanceled": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onUpdateAvailable": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "openOptionsPage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "reload": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "51.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "51.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "requestUpdateCheck": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "sendMessage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "options": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "sendNativeMessage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "50.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setUninstallURL": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -6190,7 +6190,7 @@
           }
         }
       }
-    }, 
+    },
     "sessions": {
       "Filter": {
         "__compat": {
@@ -6198,134 +6198,134 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "MAX_SESSION_RESULTS": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "Session": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
-                ], 
+                ],
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getRecentlyClosed": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "restore": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -6333,7 +6333,7 @@
           }
         }
       }
-    }, 
+    },
     "sidebarAction": {
       "ImageDataType": {
         "__compat": {
@@ -6341,131 +6341,131 @@
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "getPanel": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "getTitle": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "setIcon": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "setPanel": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
             }
           }
         }
-      }, 
+      },
       "setTitle": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "54.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": true
               }
@@ -6473,7 +6473,7 @@
           }
         }
       }
-    }, 
+    },
     "storage": {
       "StorageArea": {
         "__compat": {
@@ -6481,252 +6481,252 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "StorageArea.clear": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "StorageArea.get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "StorageArea.getBytesInUse": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "StorageArea.remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "StorageArea.set": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "storage is limited to 1MB per value."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "StorageChange": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "local": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "The storage API is supported in content scripts from version 48."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "managed": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "sync": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
@@ -6734,7 +6734,7 @@
           }
         }
       }
-    }, 
+    },
     "tabs": {
       "MutedInfo": {
         "__compat": {
@@ -6742,85 +6742,85 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "MutedInfoReason": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "TAB_ID_NONE": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "Tab": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -6830,16 +6830,16 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
-              "edge": { 
+              },
+              "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -6849,936 +6849,936 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "cookieStoreId": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "openerTabId": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "TabStatus": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "WindowType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "ZoomSettings": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "ZoomSettingsMode": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "ZoomSettingsScope": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "captureVisibleTab": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "connect": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "cookieStoreId": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "openerTabId": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "pinned": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "selected": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "detectLanguage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "duplicate": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "executeScript": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "'allFrames' and 'frameId' can't both be set at the same time.", 
+                  "'allFrames' and 'frameId' can't both be set at the same time.",
                   "Before version 50, Firefox would pass a single result value into its callback rather than an array, unless 'allFrames' had been set."
-                ], 
+                ],
                 "version_added": "43.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "'allFrames' and 'frameId' can't both be set at the same time."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "matchAboutBlank": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAllInWindow": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "getCurrent": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getSelected": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "getZoom": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getZoomSettings": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "highlight": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "insertCSS": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "cssOrigin": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "matchAboutBlank": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "move": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "46.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onActivated": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onActiveChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onAttached": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCreated": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onDetached": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onHighlightChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onHighlighted": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onMoved": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onRemoved": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onReplaced": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onSelectionChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onUpdated": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -7788,387 +7788,387 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onZoomChange": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "query": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "The 'panel', 'app', and 'devtools' values for 'WindowType' are not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."                ], 
+                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "cookieStoreId": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "highlighted": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "reload": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "removeCSS": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "49.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
-          }, 
+          },
           "matchAboutBlank": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "sendMessage": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "sendRequest": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "setZoom": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "setZoomSettings": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "update": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "highlighted": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "muted": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "pinned": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "selected": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -8176,7 +8176,7 @@
           }
         }
       }
-    }, 
+    },
     "topSites": {
       "MostVisitedURL": {
         "__compat": {
@@ -8184,39 +8184,39 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "52.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "52.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "52.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -8224,7 +8224,7 @@
           }
         }
       }
-    }, 
+    },
     "webNavigation": {
       "TransitionQualifier": {
         "__compat": {
@@ -8232,22 +8232,22 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -8257,98 +8257,98 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "TransitionType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAllFrames": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getFrame": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onBeforeNavigate": {
         "__compat": {
           "basic_support": {
@@ -8356,39 +8356,39 @@
               "chrome": {
                 "notes": [
                   "If the filter parameter is empty, Chrome matches all URLs."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Filtering is not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "If the filter parameter is empty, Opera matches all URLs."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCommitted": {
         "__compat": {
           "basic_support": {
@@ -8396,77 +8396,77 @@
               "chrome": {
                 "notes": [
                   "If the filter parameter is empty, Chrome matches all URLs."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Filtering is not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "If the filter parameter is empty, Opera matches all URLs."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "transitionQualifiers": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "transitionType": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCompleted": {
         "__compat": {
           "basic_support": {
@@ -8474,87 +8474,87 @@
               "chrome": {
                 "notes": [
                   "If the filter parameter is empty, Chrome matches all URLs."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Filtering is not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "If the filter parameter is empty, Opera matches all URLs."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCreatedNavigationTarget": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "sourceProcessId": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onDOMContentLoaded": {
         "__compat": {
           "basic_support": {
@@ -8562,39 +8562,39 @@
               "chrome": {
                 "notes": [
                   "If the filter parameter is empty, Chrome matches all URLs."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Filtering is not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "If the filter parameter is empty, Opera matches all URLs."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onErrorOccurred": {
         "__compat": {
           "basic_support": {
@@ -8602,33 +8602,33 @@
               "chrome": {
                 "notes": [
                   "If the filter parameter is empty, Chrome matches all URLs."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Filtering is not supported"
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "If the filter parameter is empty, Opera matches all URLs."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
@@ -8637,87 +8637,87 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onHistoryStateUpdated": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Filtering is not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "47.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "transitionQualifiers": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "transitionType": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onReferenceFragmentUpdated": {
         "__compat": {
           "basic_support": {
@@ -8725,99 +8725,99 @@
               "chrome": {
                 "notes": [
                   "If the filter parameter is empty, Chrome matches all URLs."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Filtering is not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
-                  "Filtering is supported from version 50.", 
+                  "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "If the filter parameter is empty, Opera matches all URLs."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "transitionQualifiers": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "transitionType": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onTabReplaced": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ], 
+                ],
                 "version_added": "45"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ], 
+                ],
                 "version_added": "48"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -8825,7 +8825,7 @@
           }
         }
       }
-    }, 
+    },
     "webRequest": {
       "BlockingResponse": {
         "__compat": {
@@ -8833,85 +8833,85 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "HttpHeaders": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "RequestFilter": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -8921,16 +8921,16 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -8940,182 +8940,182 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "ResourceType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "UploadData": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "handlerBehaviorChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onAuthRequired": {
         "__compat": {
           "asyncBlocking": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "To handle a request asynchronously, return a Promise from the listener."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "To handle a request asynchronously, return a Promise from the listener."
-                ], 
+                ],
                 "version_added": "54"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onBeforeRedirect": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "46.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "originUrl": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onBeforeRequest": {
         "__compat": {
           "basic_support": {
@@ -9123,31 +9123,31 @@
               "chrome": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Asynchronous event listeners are supported from version 52."
-                ], 
+                ],
                 "version_added": "46.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Asynchronous event listeners are supported from version 52."
-                ], 
+                ],
                 "version_added": "48.0"
               },
               "opera": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
@@ -9156,16 +9156,16 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "53.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "53.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
@@ -9175,23 +9175,23 @@
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onBeforeSendHeaders": {
         "__compat": {
           "basic_support": {
@@ -9199,140 +9199,140 @@
               "chrome": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
                   "Asynchronous event listeners are supported from version 52."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
                   "Asynchronous event listeners are supported from version 52."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "originUrl": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onCompleted": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "originUrl": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onErrorOccurred": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "originUrl": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onHeadersReceived": {
         "__compat": {
           "basic_support": {
@@ -9340,135 +9340,135 @@
               "chrome": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "Modification of the 'Content-Type' header is supported from version 51.", 
+                  "Modification of the 'Content-Type' header is supported from version 51.",
                   "Asynchronous event listeners are supported from version 52."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "notes": [
-                  "Modification of the 'Content-Type' header is supported from version 51.", 
+                  "Modification of the 'Content-Type' header is supported from version 51.",
                   "Asynchronous event listeners are supported from version 52."
-                ], 
+                ],
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
-                ], 
+                ],
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "originUrl": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onResponseStarted": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "originUrl": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
             }
           }
         }
-      }, 
+      },
       "onSendHeaders": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "originUrl": {
             "support": {
               "chrome": {
                 "version_added": false
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "48.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "version_added": false
               }
@@ -9476,7 +9476,7 @@
           }
         }
       }
-    }, 
+    },
     "windows": {
       "CreateType": {
         "__compat": {
@@ -9484,404 +9484,404 @@
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "WINDOW_ID_CURRENT": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "WINDOW_ID_NONE": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "Window": {
         "__compat": {
           "alwaysOnTop": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "WindowState": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "WindowType": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "create": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "notes": [
-                  "'url' and 'tabId options can't both be set together.", 
-                  "'url' does not accept relative paths.", 
+                  "'url' and 'tabId options can't both be set together.",
+                  "'url' does not accept relative paths.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
-                ], 
+                ],
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
-          }, 
+          },
           "focused": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": false
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "get": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getAll": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getCurrent": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "getLastFocused": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onCreated": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onFocusChanged": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "onRemoved": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "remove": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": false
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }
             }
           }
         }
-      }, 
+      },
       "update": {
         "__compat": {
           "basic_support": {
             "support": {
               "chrome": {
                 "version_added": true
-              }, 
+              },
               "edge": {
                 "version_added": true
-              }, 
+              },
               "firefox": {
                 "version_added": "45.0"
-              }, 
+              },
               "firefox_android": {
                 "version_added": false
-              }, 
+              },
               "opera": {
                 "version_added": "33"
               }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1444,10 +1444,7 @@
               }, 
               "firefox": {
                 "notes": [
-                  "'browser_action' and 'page_action' are supported from version 53.", 
-                  "'password' is supported from version 53.", 
-                  "'The 'editable' context does not include password fields. Use the 'password' context for this.", 
-                  "'tab' is supported from version 53."
+                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
                 ], 
                 "version_added": "48.0"
               }, 
@@ -1458,7 +1455,48 @@
                 "version_added": "33"
               }
             }
-          }, 
+          },
+          "browser_action": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "page_action": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": { 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },      
           "launcher": {
             "support": {
               "chrome": {
@@ -1484,10 +1522,10 @@
                 "version_added": false
               }, 
               "edge": {
-                "version_added": true
+                "version_added": false
               }, 
               "firefox": {
-                "version_added": "48.0"
+                "version_added": "53.0"
               }, 
               "firefox_android": {
                 "version_added": false
@@ -1503,10 +1541,10 @@
                 "version_added": false
               }, 
               "edge": {
-                "version_added": true
+                "version_added": false
               }, 
               "firefox": {
-                "version_added": "48.0"
+                "version_added": "53.0"
               }, 
               "firefox_android": {
                 "version_added": false
@@ -1552,9 +1590,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'modifiers' is supported from version 54."
-                ], 
                 "version_added": "48.0"
               }, 
               "firefox_android": {
@@ -1574,7 +1609,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "48.0"
+                "version_added": "54.0"
               }, 
               "firefox_android": {
                 "version_added": false
@@ -1604,7 +1639,6 @@
               }, 
               "firefox": {
                 "notes": [
-                  "documentUrlPatterns is supported from Firefox 50.", 
                   "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
                 ], 
                 "version_added": "48.0"
@@ -1702,9 +1736,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "documentUrlPatterns is supported from Firefox 50."
-                ], 
                 "version_added": "48.0"
               }, 
               "firefox_android": {
@@ -2546,18 +2577,48 @@
                 "version_added": false
               }, 
               "firefox": {
-                "notes": [
-                  "'saveAs' is supported from version 52 onwards.", 
-                  "'POST' is supported as a value of 'method' from version 52 onwards."
-                ], 
                 "version_added": "47.0"
               }, 
               "firefox_android": {
-                "notes": [
-                  "'saveAs' is supported from version 52 onwards.", 
-                  "'POST' is supported as a value of 'method' from version 52 onwards."
-                ], 
                 "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "saveAs": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": "52.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "POST": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": "52.0"
               }, 
               "opera": {
                 "version_added": "33"
@@ -5398,9 +5459,6 @@
           "basic_support": {
             "support": {
               "chrome": {
-                "notes": [
-                  "'Port.error' is not supported. Use 'runtime.lastError' instead."
-                ], 
                 "version_added": true
               }, 
               "edge": {
@@ -5410,15 +5468,9 @@
                 "version_added": "45.0"
               }, 
               "firefox_android": {
-                "notes": [
-                  "'Port.error' is supported from Firefox 52 onwards."
-                ], 
                 "version_added": "48.0"
               }, 
               "opera": {
-                "notes": [
-                  "'Port.error' is not supported. Use 'runtime.lastError' instead."
-                ], 
                 "version_added": "33"
               }
             }
@@ -6761,15 +6813,47 @@
                 "version_added": true
               }, 
               "edge": {
-                "notes": [
-                  "'highlighted' and 'selected' are not supported."
-                ], 
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'cookieStoreId' is supported from version 52."
-                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "highlighted": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": { 
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "selected": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
                 "version_added": "45.0"
               }, 
               "firefox_android": {
@@ -6789,7 +6873,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "52.0"
               }, 
               "firefox_android": {
                 "version_added": false
@@ -6992,9 +7076,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'cookieStoreId' is supported from version 52."
-                ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
@@ -7014,7 +7095,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "52.0"
               }, 
               "firefox_android": {
                 "version_added": false
@@ -7350,9 +7431,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'cssOrigin' is supported from version 53."
-                ], 
                 "version_added": "47.0"
               }, 
               "firefox_android": {
@@ -7372,10 +7450,10 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "47.0"
+                "version_added": "53.0"
               }, 
               "firefox_android": {
-                "version_added": "54"
+                "version_added": "54.0"
               }, 
               "opera": {
                 "version_added": false
@@ -7696,10 +7774,26 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'changeInfo.title' is supported from version 53."
-                ], 
                 "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "changeInfo.title": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "53.0"
               }, 
               "firefox_android": {
                 "version_added": "54"
@@ -7749,9 +7843,7 @@
               }, 
               "firefox": {
                 "notes": [
-                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter.", 
-                  "'cookieStoreId' is supported from version 52."
-                ], 
+                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."                ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
@@ -7774,7 +7866,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "52.0"
               }, 
               "firefox_android": {
                 "version_added": false
@@ -8146,15 +8238,34 @@
               }, 
               "firefox": {
                 "notes": [
-                  "'server_redirect' is limited to top-level frames, 'client_redirect' is not supplied when redirections are created by JavaScript, and 'from_address_bar' is not supported. 'forward_back' is fully supported."
+                  "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
                 ], 
                 "version_added": "48.0"
               }, 
               "firefox_android": {
                 "notes": [
-                  "'server_redirect' is limited to top-level frames, 'client_redirect' is not supplied when redirections are created by JavaScript, and 'from_address_bar' is not supported. 'forward_back' is fully supported."
+                  "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
                 ], 
                 "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "from_address_bar": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
               }, 
               "opera": {
                 "version_added": "33"
@@ -8297,8 +8408,7 @@
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.", 
-                  "If the filter parameter is empty, Firefox raises an exception.", 
-                  "'transitionType' and 'transitionQualifiers' are supported from version 48."
+                  "If the filter parameter is empty, Firefox raises an exception."
                 ], 
                 "version_added": "45.0"
               }, 
@@ -8326,7 +8436,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -8345,7 +8455,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -8504,16 +8614,14 @@
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.", 
-                  "If the filter parameter is empty, Firefox raises an exception.", 
-                  "'error' is not supported."
+                  "If the filter parameter is empty, Firefox raises an exception."
                 ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
                 "notes": [
                   "Filtering is supported from version 50.", 
-                  "If the filter parameter is empty, Firefox raises an exception.", 
-                  "'error' is not supported."
+                  "If the filter parameter is empty, Firefox raises an exception."
                 ], 
                 "version_added": "48.0"
               }, 
@@ -8521,6 +8629,25 @@
                 "notes": [
                   "If the filter parameter is empty, Opera matches all URLs."
                 ], 
+                "version_added": "33"
+              }
+            }
+          },
+          "error": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
                 "version_added": "33"
               }
             }
@@ -8541,9 +8668,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'transitionType' and 'transitionQualifiers' are supported from version 48."
-                ], 
                 "version_added": "47.0"
               }, 
               "firefox_android": {
@@ -8563,7 +8687,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "47.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -8582,7 +8706,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "47.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -8613,8 +8737,7 @@
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.", 
-                  "If the filter parameter is empty, Firefox raises an exception.", 
-                  "'transitionType' and 'transitionQualifiers' are supported from version 48."
+                  "If the filter parameter is empty, Firefox raises an exception."
                 ], 
                 "version_added": "45.0"
               }, 
@@ -8642,7 +8765,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -8661,7 +8784,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -8784,16 +8907,48 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'windowId' and 'tabId' are supported from version 53."
-                ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
-                "notes": [
-                  "'windowId' and 'tabId' are supported from version 53."
-                ], 
                 "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "windowId": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
+          "tabId": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
               }, 
               "opera": {
                 "version_added": "33"
@@ -8930,9 +9085,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'originUrl' is supported from version 48."
-                ], 
                 "version_added": "46.0"
               }, 
               "firefox_android": {
@@ -8952,7 +9104,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "46.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -8982,19 +9134,16 @@
               }, 
               "firefox": {
                 "notes": [
-                  "'originUrl' is supported from version 48.", 
-                  "'requestBody' is supported from version 50 in Nightly and Developer Edition builds, and in all builds from version 53.", 
                   "Asynchronous event listeners are supported from version 52."
                 ], 
                 "version_added": "46.0"
               }, 
               "firefox_android": {
                 "notes": [
-                  "'requestBody' is supported from version 50 in Nightly and Developer Edition builds, and in all builds from version 53.", 
                   "Asynchronous event listeners are supported from version 52."
                 ], 
                 "version_added": "48.0"
-              }, 
+              },
               "opera": {
                 "notes": [
                   "Asynchronous event listeners are not supported."
@@ -9002,7 +9151,26 @@
                 "version_added": "33"
               }
             }
-          }, 
+          },
+          "requestBody": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          },
           "originUrl": {
             "support": {
               "chrome": {
@@ -9012,7 +9180,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "46.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -9042,7 +9210,6 @@
               }, 
               "firefox": {
                 "notes": [
-                  "'originUrl' is supported from version 48.", 
                   "Asynchronous event listeners are supported from version 52."
                 ], 
                 "version_added": "45.0"
@@ -9070,7 +9237,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -9093,9 +9260,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'originUrl' is supported from version 48."
-                ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
@@ -9115,7 +9279,7 @@
                 "version_added": true
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -9138,9 +9302,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'originUrl' is supported from version 48."
-                ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
@@ -9160,7 +9321,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -9242,9 +9403,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'originUrl' is supported from version 48."
-                ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
@@ -9264,7 +9422,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"
@@ -9287,9 +9445,6 @@
                 "version_added": true
               }, 
               "firefox": {
-                "notes": [
-                  "'originUrl' is supported from version 48."
-                ], 
                 "version_added": "45.0"
               }, 
               "firefox_android": {
@@ -9309,7 +9464,7 @@
                 "version_added": false
               }, 
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "48.0"
               }, 
               "firefox_android": {
                 "version_added": "48.0"

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1,9893 +1,9899 @@
 {
   "version": "1.0.0",
   "data": {
-    "alarms": {
-      "Alarm": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "clear": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "clearAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onAlarm": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bookmarks": {
-      "BookmarkTreeNode": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "BookmarkTreeNodeUnmodifiable": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "CreateDetails": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "export": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getChildren": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getRecent": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getSubTree": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getTree": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "import": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "move": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onChildrenReordered": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onCreated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onImportBegan": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onImportEnded": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onMoved": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onRemoved": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "removeTree": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "search": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "update": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "browserAction": {
-      "ColorArray": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "ImageDataType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "disable": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "enable": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getBadgeBackgroundColor": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getBadgeText": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getPopup": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getTitle": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onClicked": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setBadgeBackgroundColor": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setBadgeText": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setIcon": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setPopup": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setTitle": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "browsingData": {
-      "DataTypeSet": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "RemovalOptions": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+    "webextensions": {
+      "api": {
+        "alarms": {
+          "Alarm": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "originTypes.extension": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          "clear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "originTypes.protectedWeb": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.",
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "removeCache": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "removeCookies": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "removeDownloads": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "removeFormData": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "removeHistory": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "removePasswords": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "removePluginData": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "settings": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      }
-    },
-    "commands": {
-      "Command": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onCommand": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "contextMenus": {
-      "ACTION_MENU_TOP_LEVEL_LIMIT": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "ContextType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                ],
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+          "clearAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "browser_action": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                ],
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+          "create": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "page_action": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "launcher": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+          "getAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "password": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          "onAlarm": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "bookmarks": {
+          "BookmarkTreeNode": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "tab": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "ItemType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "OnClickData": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+          "BookmarkTreeNodeUnmodifiable": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "modifiers": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
-                ],
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "notes": [
-                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ],
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onClicked": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "removeAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "update": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "contextualIdentities": {
-      "ContextualIdentity": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "query": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "update": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      }
-    },
-    "cookies": {
-      "Cookie": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "CookieStore": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "OnChangedCause": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user\u2019s machine."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAllCookieStores": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Always returns the same default cookie store with ID 0. All cookies belong to this store."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "set": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "devtools.inspectedWindow": {
-      "eval": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "Console helper functions are not available to injected scripts."
-                ],
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
+          "CreateDetails": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "options": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "reload": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "tabId": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      }
-    },
-    "devtools.network": {
-      "onNavigated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      }
-    },
-    "devtools.panels": {
-      "ExtensionPanel": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      }
-    },
-    "downloads": {
-      "BooleanDelta": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "DangerType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "DoubleDelta": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "DownloadItem": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "DownloadQuery": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "DownloadTime": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "FilenameConflictAction": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+          "create": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "prompt": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "InterruptReason": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "State": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "StringDelta": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "acceptDanger": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "cancel": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "download": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+          "export": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "saveAs": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": "52.0"
-              },
-              "opera": {
-                "version_added": "33"
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
-          "POST": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": "52.0"
-              },
-              "opera": {
-                "version_added": "33"
+          "getChildren": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getRecent": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getSubTree": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getTree": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "import": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "move": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onChildrenReordered": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCreated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onImportBegan": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onImportEnded": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onMoved": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onRemoved": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "removeTree": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "search": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "update": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "drag": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "browserAction": {
+          "ColorArray": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "ImageDataType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "disable": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "enable": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getBadgeBackgroundColor": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getBadgeText": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getPopup": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getTitle": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onClicked": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setBadgeBackgroundColor": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setBadgeText": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setIcon": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setPopup": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setTitle": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "erase": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
+        },
+        "browsingData": {
+          "DataTypeSet": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "RemovalOptions": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
               },
-              "edge": {
-                "version_added": false
+              "originTypes.extension": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
               },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+              "originTypes.protectedWeb": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.",
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "removeCache": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "removeCookies": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "removeDownloads": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "removeFormData": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "removeHistory": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "removePasswords": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "removePluginData": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "settings": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "getFileIcon": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "commands": {
+          "Command": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCommand": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "onChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
+        },
+        "contextMenus": {
+          "ACTION_MENU_TOP_LEVEL_LIMIT": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "ContextType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               },
-              "edge": {
-                "version_added": false
+              "browser_action": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                    ],
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               },
-              "firefox": {
-                "version_added": "47.0"
+              "page_action": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               },
-              "firefox_android": {
-                "version_added": "48.0"
+              "launcher": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               },
-              "opera": {
-                "version_added": "33"
+              "password": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "tab": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "ItemType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "OnClickData": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "modifiers": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "create": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "notes": [
+                      "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onClicked": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "removeAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "update": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "onCreated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "contextualIdentities": {
+          "ContextualIdentity": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "create": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "query": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "update": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "onErased": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "cookies": {
+          "Cookie": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "CookieStore": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "OnChangedCause": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user\u2019s machine."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAllCookieStores": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Always returns the same default cookie store with ID 0. All cookies belong to this store."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "set": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "open": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "devtools": {
+          "inspectedWindow": {
+            "eval": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "notes": [
+                        "Console helper functions are not available to injected scripts."
+                      ],
+                      "version_added": "54"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                },
+                "options": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": false
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                }
+              }
+            },
+            "reload": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "54"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "54"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "network": {
+            "onNavigated": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "54"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "panels": {
+            "ExtensionPanel": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "54"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                }
+              }
+            },
+            "create": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "54"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "pause": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
+        },
+        "downloads": {
+          "BooleanDelta": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "DangerType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "DoubleDelta": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "DownloadItem": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "DownloadQuery": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "DownloadTime": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "FilenameConflictAction": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               },
-              "edge": {
-                "version_added": false
+              "prompt": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "InterruptReason": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "State": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "StringDelta": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "acceptDanger": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "cancel": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "download": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               },
-              "firefox": {
-                "version_added": "48.0"
+              "saveAs": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "52.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+              "POST": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "52.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "drag": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "erase": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getFileIcon": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCreated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onErased": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "open": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "pause": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "removeFile": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "resume": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "search": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setShelfEnabled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "show": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "showDefaultFolder": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "removeFile": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "events": {
+          "Event": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "Rule": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "UrlFilter": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "50.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "resume": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "extension": {
+          "ViewType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getBackgroundPage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getExtensionTabs": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "getURL": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getViews": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "inIncognitoContext": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "isAllowedFileSchemeAccess": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "isAllowedIncognitoAccess": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "lastError": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onRequest": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onRequestExternal": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "sendRequest": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "setUpdateUrlData": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           }
-        }
-      },
-      "search": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
+        },
+        "extensionTypes": {
+          "ImageDetails": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
-          }
-        }
-      },
-      "setShelfEnabled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
+          },
+          "ImageFormat": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
-          }
-        }
-      },
-      "show": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "showDefaultFolder": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "events": {
-      "Event": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "Rule": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "UrlFilter": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": "50.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "extension": {
-      "ViewType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getBackgroundPage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getExtensionTabs": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "getURL": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getViews": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "inIncognitoContext": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "isAllowedFileSchemeAccess": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "isAllowedIncognitoAccess": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "lastError": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onRequest": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onRequestExternal": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "sendRequest": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "setUpdateUrlData": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "extensionTypes": {
-      "ImageDetails": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "ImageFormat": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "InjectDetails": {
-        "__compat": {
+          },
           "InjectDetails": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "RunAt": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "history": {
-      "HistoryItem": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "typedCount": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "TransitionType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "VisitItem": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "addUrl": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "title": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "transition": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "visitTime": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "deleteAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "deleteRange": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "deleteUrl": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getVisits": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onVisitRemoved": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onVisited": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "search": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "i18n": {
-      "LanguageCode": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "detectLanguage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAcceptLanguages": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getMessage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getUILanguage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      }
-    },
-    "identity": {
-      "getRedirectURL": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "launchWebAuthFlow": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      }
-    },
-    "idle": {
-      "IdleState": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onStateChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": {
-                "version_added": "51"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "locked": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "queryState": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "locked": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setDetectionInterval": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": {
-                "version_added": "51"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "management": {
-      "ExtensionInfo": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": "51.0"
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "disabledReason": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "offlineEnabled": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "type": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "versionName": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "getAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "getPermissionWarningsById": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "getPermissionWarningsByManifest": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "getSelf": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": "51.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onDisabled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "onEnabled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "onInstalled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "onUninstalled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "setEnabled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "uninstall": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "uninstallSelf": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": "51.0"
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "dialogMessage": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": "51.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      }
-    },
-    "notifications": {
-      "NotificationOptions": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "TemplateType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "Only the 'basic' type is supported."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Only the 'basic' type is supported."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "Only the 'basic' type is supported."
-                ],
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "clear": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onButtonClicked": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onClicked": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onClosed": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "byUser": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "update": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "notes": [
-                  "Not supported on Macs."
-                ],
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "omnibox": {
-      "OnInputEnteredDisposition": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "SuggestResult": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'description' is interpreted as plain text, and XML markup is not recognised."
-                ],
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "onInputCancelled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "onInputChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "onInputEntered": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "onInputStarted": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "setDefaultSuggestion": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'description' is interpreted as plain text, and XML markup is not recognised."
-                ],
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      }
-    },
-    "pageAction": {
-      "ImageDataType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getPopup": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
-                ],
-                "version_added": "50.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getTitle": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "hide": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "The 'tabId' parameter is ignored, and the page action is hidden for all tabs."
-                ],
-                "version_added": "50.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onClicked": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "50.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setIcon": {
-        "__compat": {
-          "ImageData": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setPopup": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "The 'tabId' parameter is ignored, and the popup is set for all tabs."
-                ],
-                "version_added": "50.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setTitle": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "show": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "The 'tabId' parameter is ignored, and the page action is shown for all tabs."
-                ],
-                "version_added": "50.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "privacy": {
-      "BrowserSetting": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "onChange": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "network": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "websites": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "protectedContentEnabled": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "referrersEnabled": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          },
-          "thirdPartyCookiesAllowed": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      }
-    },
-    "runtime": {
-      "MessageSender": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "OnInstalledReason": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "OnRestartRequiredReason": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "PlatformArch": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "PlatformInfo": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "nacl_arch": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "PlatformNaclArch": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "PlatformOs": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "Port": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "error": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "RequestUpdateCheckStatus": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "connect": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "connectNative": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getBackgroundPage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getBrowserInfo": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": "51.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "getManifest": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getPackageDirectoryEntry": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getPlatformInfo": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getURL": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "id": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "lastError": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
-                ],
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onBrowserUpdateAvailable": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onConnect": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onConnectExternal": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onInstalled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This event is not triggered for temporarily installed add-ons."
-                ],
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "This event is not triggered for temporarily installed add-ons."
-                ],
-                "version_added": "52.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onMessage": {
-        "__compat": {
-          "MessageSender.tlsChannelId": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onMessageExternal": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onRestartRequired": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onStartup": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": "52.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onSuspend": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onSuspendCanceled": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onUpdateAvailable": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": "51.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "openOptionsPage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "reload": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": "51.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "requestUpdateCheck": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "sendMessage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "options": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "sendNativeMessage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setUninstallURL": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "sessions": {
-      "Filter": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "MAX_SESSION_RESULTS": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "Session": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
-                ],
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getRecentlyClosed": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "restore": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "sidebarAction": {
-      "ImageDataType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "getPanel": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "getTitle": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "setIcon": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "setPanel": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
-      "setTitle": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        }
-      }
-    },
-    "storage": {
-      "StorageArea": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "StorageArea.clear": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "StorageArea.get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "StorageArea.getBytesInUse": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "StorageArea.remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "StorageArea.set": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "storage is limited to 1MB per value."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "StorageChange": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "local": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "The storage API is supported in content scripts from version 48."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "managed": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "sync": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      }
-    },
-    "tabs": {
-      "MutedInfo": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "MutedInfoReason": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "TAB_ID_NONE": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "Tab": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "highlighted": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "selected": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "cookieStoreId": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "openerTabId": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "TabStatus": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "WindowType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "ZoomSettings": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "ZoomSettingsMode": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "ZoomSettingsScope": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "captureVisibleTab": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "connect": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "cookieStoreId": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "openerTabId": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "pinned": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "selected": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "detectLanguage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "duplicate": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "executeScript": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "'allFrames' and 'frameId' can't both be set at the same time.",
-                  "Before version 50, Firefox would pass a single result value into its callback rather than an array, unless 'allFrames' had been set."
-                ],
-                "version_added": "43.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "'allFrames' and 'frameId' can't both be set at the same time."
-                ],
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "matchAboutBlank": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAllInWindow": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "getCurrent": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getSelected": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "getZoom": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getZoomSettings": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "highlight": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "insertCSS": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "cssOrigin": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "54.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "matchAboutBlank": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "move": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "46.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onActivated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onActiveChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onAttached": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onCreated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onDetached": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onHighlightChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onHighlighted": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onMoved": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onRemoved": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onReplaced": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ],
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onSelectionChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onUpdated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "changeInfo.title": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onZoomChange": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "query": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "The 'panel', 'app', and 'devtools' values for 'WindowType' are not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
-                ],
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "cookieStoreId": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "highlighted": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "reload": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "removeCSS": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          },
-          "matchAboutBlank": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "sendMessage": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "sendRequest": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "setZoom": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "setZoomSettings": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "update": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "highlighted": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "muted": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "pinned": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "selected": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "topSites": {
-      "MostVisitedURL": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": "52.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "52.0"
-              },
-              "firefox_android": {
-                "version_added": "52.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "webNavigation": {
-      "TransitionQualifier": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
-                ],
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "from_address_bar": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "TransitionType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "notes": [
-                  "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
-                ],
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAllFrames": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getFrame": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onBeforeNavigate": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "If the filter parameter is empty, Chrome matches all URLs."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Filtering is not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "If the filter parameter is empty, Opera matches all URLs."
-                ],
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onCommitted": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "If the filter parameter is empty, Chrome matches all URLs."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Filtering is not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "If the filter parameter is empty, Opera matches all URLs."
-                ],
-                "version_added": "33"
-              }
-            }
-          },
-          "transitionQualifiers": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "transitionType": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onCompleted": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "If the filter parameter is empty, Chrome matches all URLs."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Filtering is not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "If the filter parameter is empty, Opera matches all URLs."
-                ],
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onCreatedNavigationTarget": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "notes": [
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "sourceProcessId": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onDOMContentLoaded": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "If the filter parameter is empty, Chrome matches all URLs."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Filtering is not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "If the filter parameter is empty, Opera matches all URLs."
-                ],
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onErrorOccurred": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "If the filter parameter is empty, Chrome matches all URLs."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Filtering is not supported"
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "If the filter parameter is empty, Opera matches all URLs."
-                ],
-                "version_added": "33"
-              }
-            }
-          },
-          "error": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onHistoryStateUpdated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Filtering is not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "47.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "transitionQualifiers": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "transitionType": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onReferenceFragmentUpdated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "If the filter parameter is empty, Chrome matches all URLs."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Filtering is not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Filtering is supported from version 50.",
-                  "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "If the filter parameter is empty, Opera matches all URLs."
-                ],
-                "version_added": "33"
-              }
-            }
-          },
-          "transitionQualifiers": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "transitionType": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onTabReplaced": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ],
-                "version_added": "45"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ],
-                "version_added": "48"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      }
-    },
-    "webRequest": {
-      "BlockingResponse": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "HttpHeaders": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "RequestFilter": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "windowId": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "tabId": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "ResourceType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "UploadData": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "handlerBehaviorChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onAuthRequired": {
-        "__compat": {
-          "asyncBlocking": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "To handle a request asynchronously, return a Promise from the listener."
-                ],
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "notes": [
-                  "To handle a request asynchronously, return a Promise from the listener."
-                ],
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onBeforeRedirect": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "46.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onBeforeRequest": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "46.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": "33"
-              }
-            }
-          },
-          "requestBody": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "53.0"
-              },
-              "firefox_android": {
-                "version_added": "53.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onBeforeSendHeaders": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onCompleted": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onErrorOccurred": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onHeadersReceived": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "Modification of the 'Content-Type' header is supported from version 51.",
-                  "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Modification of the 'Content-Type' header is supported from version 51.",
-                  "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "48.0"
-              },
-              "opera": {
-                "notes": [
-                  "Asynchronous event listeners are not supported."
-                ],
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onResponseStarted": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      },
-      "onSendHeaders": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "originUrl": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "48.0"
-              },
-              "firefox_android": {
-                "version_added": "48.0"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        }
-      }
-    },
-    "windows": {
-      "CreateType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "WINDOW_ID_CURRENT": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "WINDOW_ID_NONE": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "Window": {
-        "__compat": {
-          "alwaysOnTop": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "WindowState": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "WindowType": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "create": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "'url' and 'tabId options can't both be set together.",
-                  "'url' does not accept relative paths.",
-                  "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
-                ],
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          },
-          "focused": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getAll": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getCurrent": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "getLastFocused": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onCreated": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onFocusChanged": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "onRemoved": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "remove": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
-      },
-      "update": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45.0"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "33"
-              }
-            }
-          }
-        }
+            "__compat": {
+              "matchAboutBlank": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "RunAt": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "history": {
+          "HistoryItem": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "typedCount": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "TransitionType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "VisitItem": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "addUrl": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "title": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "transition": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "visitTime": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "deleteAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "deleteRange": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "deleteUrl": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getVisits": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onVisitRemoved": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onVisited": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "search": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "i18n": {
+          "LanguageCode": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "detectLanguage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAcceptLanguages": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getMessage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getUILanguage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "identity": {
+          "getRedirectURL": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "launchWebAuthFlow": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "idle": {
+          "IdleState": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onStateChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51"
+                  },
+                  "firefox_android": {
+                    "version_added": "51"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "locked": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "queryState": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "locked": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setDetectionInterval": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51"
+                  },
+                  "firefox_android": {
+                    "version_added": "51"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "management": {
+          "ExtensionInfo": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "51.0"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "disabledReason": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "offlineEnabled": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "type": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "versionName": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "getAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "getPermissionWarningsById": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "getPermissionWarningsByManifest": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "getSelf": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "51.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onDisabled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "onEnabled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "onInstalled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "onUninstalled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "setEnabled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "uninstall": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "uninstallSelf": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "51.0"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "dialogMessage": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "51.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "notifications": {
+          "NotificationOptions": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Only 'type', 'iconUrl', 'title', and 'message' are supported."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Only 'type', 'iconUrl', 'title', and 'message' are supported."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "TemplateType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Only the 'basic' type is supported."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Only the 'basic' type is supported."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "Only the 'basic' type is supported."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "clear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "create": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onButtonClicked": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onClicked": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onClosed": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "byUser": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "update": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "notes": [
+                      "Not supported on Macs."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "omnibox": {
+          "OnInputEnteredDisposition": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "SuggestResult": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'description' is interpreted as plain text, and XML markup is not recognised."
+                    ],
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "onInputCancelled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "onInputChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "onInputEntered": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "onInputStarted": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "setDefaultSuggestion": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'description' is interpreted as plain text, and XML markup is not recognised."
+                    ],
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pageAction": {
+          "ImageDataType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getPopup": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
+                    ],
+                    "version_added": "50.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getTitle": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "hide": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "The 'tabId' parameter is ignored, and the page action is hidden for all tabs."
+                    ],
+                    "version_added": "50.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onClicked": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "50.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setIcon": {
+            "__compat": {
+              "ImageData": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setPopup": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "The 'tabId' parameter is ignored, and the popup is set for all tabs."
+                    ],
+                    "version_added": "50.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setTitle": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "show": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "The 'tabId' parameter is ignored, and the page action is shown for all tabs."
+                    ],
+                    "version_added": "50.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "privacy": {
+          "BrowserSetting": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "onChange": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "network": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "websites": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "protectedContentEnabled": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "referrersEnabled": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "thirdPartyCookiesAllowed": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "runtime": {
+          "MessageSender": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "OnInstalledReason": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "OnRestartRequiredReason": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "PlatformArch": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "PlatformInfo": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "nacl_arch": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "PlatformNaclArch": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "PlatformOs": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "Port": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "error": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "52.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "RequestUpdateCheckStatus": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "connect": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "connectNative": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getBackgroundPage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getBrowserInfo": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "51.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "getManifest": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getPackageDirectoryEntry": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getPlatformInfo": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getURL": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "id": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "lastError": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onBrowserUpdateAvailable": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onConnect": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onConnectExternal": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onInstalled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "This event is not triggered for temporarily installed add-ons."
+                    ],
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "This event is not triggered for temporarily installed add-ons."
+                    ],
+                    "version_added": "52.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onMessage": {
+            "__compat": {
+              "MessageSender.tlsChannelId": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onMessageExternal": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onRestartRequired": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onStartup": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "52.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onSuspend": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onSuspendCanceled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onUpdateAvailable": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "51.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "openOptionsPage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "reload": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "51.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "51.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "requestUpdateCheck": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "sendMessage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "options": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "sendNativeMessage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setUninstallURL": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "sessions": {
+          "Filter": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "MAX_SESSION_RESULTS": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "Session": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
+                    ],
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getRecentlyClosed": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "restore": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "sidebarAction": {
+          "ImageDataType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "getPanel": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "getTitle": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "setIcon": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "setPanel": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "setTitle": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "storage": {
+          "StorageArea": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            },
+            "clear": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "45.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "48.0"
+                    },
+                    "opera": {
+                      "version_added": "33"
+                    }
+                  }
+                }
+              }
+            },
+            "get": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "45.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "48.0"
+                    },
+                    "opera": {
+                      "version_added": "33"
+                    }
+                  }
+                }
+              }
+            },
+            "getBytesInUse": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": false
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": "33"
+                    }
+                  }
+                }
+              }
+            },
+            "remove": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "45.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "48.0"
+                    },
+                    "opera": {
+                      "version_added": "33"
+                    }
+                  }
+                }
+              }
+            },
+            "set": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "notes": [
+                        "storage is limited to 1MB per value."
+                      ],
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "45.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "48.0"
+                    },
+                    "opera": {
+                      "version_added": "33"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "StorageChange": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "local": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "The storage API is supported in content scripts from version 48."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "managed": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "sync": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tabs": {
+          "MutedInfo": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "MutedInfoReason": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "TAB_ID_NONE": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "Tab": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "highlighted": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "selected": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "cookieStoreId": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "openerTabId": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "TabStatus": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "WindowType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "ZoomSettings": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "ZoomSettingsMode": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "ZoomSettingsScope": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "captureVisibleTab": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "connect": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "create": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "cookieStoreId": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "openerTabId": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "pinned": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "selected": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "detectLanguage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "duplicate": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "executeScript": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'allFrames' and 'frameId' can't both be set at the same time.",
+                      "Before version 50, Firefox would pass a single result value into its callback rather than an array, unless 'allFrames' had been set."
+                    ],
+                    "version_added": "43.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "'allFrames' and 'frameId' can't both be set at the same time."
+                    ],
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "matchAboutBlank": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAllInWindow": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "getCurrent": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getSelected": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "getZoom": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getZoomSettings": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "highlight": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "insertCSS": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "cssOrigin": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "matchAboutBlank": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "move": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "46.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onActivated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onActiveChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onAttached": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCreated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onDetached": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onHighlightChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onHighlighted": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onMoved": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onRemoved": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onReplaced": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                    ],
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onSelectionChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onUpdated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "changeInfo.title": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onZoomChange": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "query": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "The 'panel', 'app', and 'devtools' values for 'WindowType' are not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."                ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
+                    ],
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "cookieStoreId": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "highlighted": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "reload": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "removeCSS": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "49.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "matchAboutBlank": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "sendMessage": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "sendRequest": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "setZoom": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "setZoomSettings": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "update": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "highlighted": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "muted": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "pinned": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "selected": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "topSites": {
+          "MostVisitedURL": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "52.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "52.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "webNavigation": {
+          "TransitionQualifier": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "from_address_bar": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "TransitionType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAllFrames": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getFrame": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onBeforeNavigate": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "If the filter parameter is empty, Chrome matches all URLs."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Filtering is not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "If the filter parameter is empty, Opera matches all URLs."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCommitted": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "If the filter parameter is empty, Chrome matches all URLs."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Filtering is not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "If the filter parameter is empty, Opera matches all URLs."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              },
+              "transitionQualifiers": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "transitionType": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCompleted": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "If the filter parameter is empty, Chrome matches all URLs."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Filtering is not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "If the filter parameter is empty, Opera matches all URLs."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCreatedNavigationTarget": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "sourceProcessId": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onDOMContentLoaded": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "If the filter parameter is empty, Chrome matches all URLs."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Filtering is not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "If the filter parameter is empty, Opera matches all URLs."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onErrorOccurred": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "If the filter parameter is empty, Chrome matches all URLs."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Filtering is not supported"
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "If the filter parameter is empty, Opera matches all URLs."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              },
+              "error": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onHistoryStateUpdated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Filtering is not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "47.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "transitionQualifiers": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "transitionType": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onReferenceFragmentUpdated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "If the filter parameter is empty, Chrome matches all URLs."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Filtering is not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Filtering is supported from version 50.",
+                      "If the filter parameter is empty, Firefox raises an exception."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "If the filter parameter is empty, Opera matches all URLs."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              },
+              "transitionQualifiers": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "transitionType": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onTabReplaced": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                    ],
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                    ],
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "webRequest": {
+          "BlockingResponse": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "HttpHeaders": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "RequestFilter": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "windowId": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "tabId": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "ResourceType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "UploadData": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "handlerBehaviorChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onAuthRequired": {
+            "__compat": {
+              "asyncBlocking": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "To handle a request asynchronously, return a Promise from the listener."
+                    ],
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "To handle a request asynchronously, return a Promise from the listener."
+                    ],
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onBeforeRedirect": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onBeforeRequest": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Asynchronous event listeners are supported from version 52."
+                    ],
+                    "version_added": "46.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Asynchronous event listeners are supported from version 52."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              },
+              "requestBody": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "53.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onBeforeSendHeaders": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Asynchronous event listeners are supported from version 52."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Asynchronous event listeners are supported from version 52."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onCompleted": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onErrorOccurred": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onHeadersReceived": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "Modification of the 'Content-Type' header is supported from version 51.",
+                      "Asynchronous event listeners are supported from version 52."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "notes": [
+                      "Modification of the 'Content-Type' header is supported from version 51.",
+                      "Asynchronous event listeners are supported from version 52."
+                    ],
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "notes": [
+                      "Asynchronous event listeners are not supported."
+                    ],
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onResponseStarted": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "onSendHeaders": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "originUrl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "windows": {
+          "CreateType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "WINDOW_ID_CURRENT": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "WINDOW_ID_NONE": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "Window": {
+            "__compat": {
+              "alwaysOnTop": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "WindowState": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "WindowType": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "create": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "notes": [
+                      "'url' and 'tabId options can't both be set together.",
+                      "'url' does not accept relative paths.",
+                      "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
+                    ],
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
+              "focused": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getAll": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getCurrent": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "getLastFocused": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onCreated": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onFocusChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "onRemoved": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          },
+          "update": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        }  
       }
     }
   }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1,0 +1,9739 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "alarms": {
+      "Alarm": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "clear": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "clearAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onAlarm": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "bookmarks": {
+      "BookmarkTreeNode": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "BookmarkTreeNodeUnmodifiable": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "CreateDetails": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "export": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getChildren": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getRecent": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getSubTree": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getTree": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "import": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "move": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onChildrenReordered": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCreated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onImportBegan": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onImportEnded": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onMoved": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onRemoved": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "removeTree": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "search": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "update": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "browserAction": {
+      "ColorArray": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "ImageDataType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "disable": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "enable": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getBadgeBackgroundColor": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getBadgeText": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getPopup": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getTitle": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onClicked": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setBadgeBackgroundColor": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setBadgeText": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setIcon": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setPopup": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setTitle": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "browsingData": {
+      "DataTypeSet": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "RemovalOptions": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "originTypes.extension": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "originTypes.protectedWeb": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.", 
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "removeCache": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "removeCookies": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "removeDownloads": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "removeFormData": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "removeHistory": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "removePasswords": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "removePluginData": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ], 
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "settings": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "commands": {
+      "Command": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCommand": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "contextMenus": {
+      "ACTION_MENU_TOP_LEVEL_LIMIT": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "ContextType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'browser_action' and 'page_action' are supported from version 53.", 
+                  "'password' is supported from version 53.", 
+                  "'The 'editable' context does not include password fields. Use the 'password' context for this.", 
+                  "'tab' is supported from version 53."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "launcher": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "password": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "tab": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "ItemType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "OnClickData": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'modifiers' is supported from version 54."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "modifiers": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "documentUrlPatterns is supported from Firefox 50.", 
+                  "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onClicked": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "removeAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "update": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "documentUrlPatterns is supported from Firefox 50."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "contextualIdentities": {
+      "ContextualIdentity": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "query": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "update": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "cookies": {
+      "Cookie": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "CookieStore": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "OnChangedCause": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user\u2019s machine."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAllCookieStores": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Always returns the same default cookie store with ID 0. All cookies belong to this store."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "set": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "devtools.inspectedWindow": {
+      "eval": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "Console helper functions are not available to injected scripts."
+                ], 
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "options": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "reload": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "tabId": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "devtools.network": {
+      "onNavigated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "devtools.panels": {
+      "ExtensionPanel": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "downloads": {
+      "BooleanDelta": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "DangerType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "DoubleDelta": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "DownloadItem": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "DownloadQuery": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "DownloadTime": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "FilenameConflictAction": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "prompt": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "InterruptReason": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "State": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "StringDelta": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "acceptDanger": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "cancel": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "download": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'saveAs' is supported from version 52 onwards.", 
+                  "'POST' is supported as a value of 'method' from version 52 onwards."
+                ], 
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "'saveAs' is supported from version 52 onwards.", 
+                  "'POST' is supported as a value of 'method' from version 52 onwards."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "drag": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "erase": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getFileIcon": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCreated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onErased": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "open": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "pause": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "removeFile": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "resume": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "search": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setShelfEnabled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "show": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "showDefaultFolder": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "events": {
+      "Event": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "Rule": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "UrlFilter": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": "50.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "extension": {
+      "ViewType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getBackgroundPage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getExtensionTabs": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "getURL": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getViews": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "inIncognitoContext": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "isAllowedFileSchemeAccess": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "isAllowedIncognitoAccess": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "lastError": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onRequest": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onRequestExternal": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "sendRequest": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "setUpdateUrlData": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "extensionTypes": {
+      "ImageDetails": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "ImageFormat": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "InjectDetails": {
+        "__compat": {
+          "InjectDetails": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "RunAt": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "history": {
+      "HistoryItem": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "typedCount": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "TransitionType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "VisitItem": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "addUrl": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "title": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "transition": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "visitTime": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "deleteAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "deleteRange": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "deleteUrl": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getVisits": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onVisitRemoved": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onVisited": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "search": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "i18n": {
+      "LanguageCode": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "detectLanguage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAcceptLanguages": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getMessage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getUILanguage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "identity": {
+      "getRedirectURL": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "launchWebAuthFlow": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "idle": {
+      "IdleState": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onStateChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51"
+              }, 
+              "firefox_android": {
+                "version_added": "51"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "locked": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "queryState": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "locked": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setDetectionInterval": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51"
+              }, 
+              "firefox_android": {
+                "version_added": "51"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "management": {
+      "ExtensionInfo": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51.0"
+              }, 
+              "firefox_android": {
+                "version_added": "51.0"
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "disabledReason": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "offlineEnabled": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "type": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "versionName": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "getAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "getPermissionWarningsById": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "getPermissionWarningsByManifest": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "getSelf": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51.0"
+              }, 
+              "firefox_android": {
+                "version_added": "51.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onDisabled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "onEnabled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "onInstalled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "onUninstalled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "setEnabled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "uninstall": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "uninstallSelf": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51.0"
+              }, 
+              "firefox_android": {
+                "version_added": "51.0"
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "dialogMessage": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51.0"
+              }, 
+              "firefox_android": {
+                "version_added": "51.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "notifications": {
+      "NotificationOptions": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "TemplateType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "Only the 'basic' type is supported."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Only the 'basic' type is supported."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "Only the 'basic' type is supported."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "clear": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onButtonClicked": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onClicked": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onClosed": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "byUser": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "update": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "notes": [
+                  "Not supported on Macs."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "omnibox": {
+      "OnInputEnteredDisposition": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "SuggestResult": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'description' is interpreted as plain text, and XML markup is not recognised."
+                ], 
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "onInputCancelled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "onInputChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "onInputEntered": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "onInputStarted": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "setDefaultSuggestion": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'description' is interpreted as plain text, and XML markup is not recognised."
+                ], 
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "pageAction": {
+      "ImageDataType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getPopup": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
+                ], 
+                "version_added": "50.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getTitle": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "hide": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored, and the page action is hidden for all tabs."
+                ], 
+                "version_added": "50.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onClicked": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "50.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setIcon": {
+        "__compat": {
+          "ImageData": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setPopup": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored, and the popup is set for all tabs."
+                ], 
+                "version_added": "50.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setTitle": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "show": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored, and the page action is shown for all tabs."
+                ], 
+                "version_added": "50.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "privacy": {
+      "BrowserSetting": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "onChange": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "network": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "websites": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "protectedContentEnabled": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "referrersEnabled": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }, 
+          "thirdPartyCookiesAllowed": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "runtime": {
+      "MessageSender": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "OnInstalledReason": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "OnRestartRequiredReason": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "PlatformArch": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "PlatformInfo": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "nacl_arch": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "PlatformNaclArch": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "PlatformOs": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "Port": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "'Port.error' is not supported. Use 'runtime.lastError' instead."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "'Port.error' is supported from Firefox 52 onwards."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "'Port.error' is not supported. Use 'runtime.lastError' instead."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }, 
+          "error": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "RequestUpdateCheckStatus": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "connect": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "connectNative": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getBackgroundPage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getBrowserInfo": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51.0"
+              }, 
+              "firefox_android": {
+                "version_added": "51.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "getManifest": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getPackageDirectoryEntry": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getPlatformInfo": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getURL": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "id": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "lastError": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onBrowserUpdateAvailable": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onConnect": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onConnectExternal": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onInstalled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "This event is not triggered for temporarily installed add-ons."
+                ], 
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "This event is not triggered for temporarily installed add-ons."
+                ], 
+                "version_added": "52.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onMessage": {
+        "__compat": {
+          "MessageSender.tlsChannelId": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onMessageExternal": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onRestartRequired": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onStartup": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": "52.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onSuspend": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onSuspendCanceled": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onUpdateAvailable": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51.0"
+              }, 
+              "firefox_android": {
+                "version_added": "51.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "openOptionsPage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "reload": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "51.0"
+              }, 
+              "firefox_android": {
+                "version_added": "51.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "requestUpdateCheck": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "sendMessage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "options": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "sendNativeMessage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "50.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setUninstallURL": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "sessions": {
+      "Filter": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "MAX_SESSION_RESULTS": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "Session": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
+                ], 
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getRecentlyClosed": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "restore": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "sidebarAction": {
+      "ImageDataType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "getPanel": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "getTitle": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "setIcon": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "setPanel": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }, 
+      "setTitle": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "54.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "storage": {
+      "StorageArea": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "StorageArea.clear": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "StorageArea.get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "StorageArea.getBytesInUse": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "StorageArea.remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "StorageArea.set": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "storage is limited to 1MB per value."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "StorageChange": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "local": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "The storage API is supported in content scripts from version 48."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "managed": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "sync": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "53.0"
+              }, 
+              "firefox_android": {
+                "version_added": "53.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "tabs": {
+      "MutedInfo": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "MutedInfoReason": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "TAB_ID_NONE": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "Tab": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "'highlighted' and 'selected' are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'cookieStoreId' is supported from version 52."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "cookieStoreId": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "openerTabId": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "TabStatus": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "WindowType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "ZoomSettings": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "ZoomSettingsMode": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "ZoomSettingsScope": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "captureVisibleTab": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "connect": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'cookieStoreId' is supported from version 52."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "cookieStoreId": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "openerTabId": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "pinned": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "selected": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "detectLanguage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "duplicate": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "executeScript": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'allFrames' and 'frameId' can't both be set at the same time.", 
+                  "Before version 50, Firefox would pass a single result value into its callback rather than an array, unless 'allFrames' had been set."
+                ], 
+                "version_added": "43.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "'allFrames' and 'frameId' can't both be set at the same time."
+                ], 
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "matchAboutBlank": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAllInWindow": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "getCurrent": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getSelected": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "getZoom": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getZoomSettings": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "highlight": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "insertCSS": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'cssOrigin' is supported from version 53."
+                ], 
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "cssOrigin": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "matchAboutBlank": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "move": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "46.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onActivated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onActiveChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onAttached": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCreated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onDetached": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onHighlightChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onHighlighted": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onMoved": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onRemoved": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onReplaced": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ], 
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onSelectionChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onUpdated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'changeInfo.title' is supported from version 53."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onZoomChange": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "query": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "The 'panel', 'app', and 'devtools' values for 'WindowType' are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter.", 
+                  "'cookieStoreId' is supported from version 52."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
+                ], 
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "cookieStoreId": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "highlighted": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "reload": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "removeCSS": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "49.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }, 
+          "matchAboutBlank": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "sendMessage": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "sendRequest": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "setZoom": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "setZoomSettings": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "update": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "highlighted": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "muted": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "pinned": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "selected": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "topSites": {
+      "MostVisitedURL": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": "52.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "52.0"
+              }, 
+              "firefox_android": {
+                "version_added": "52.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "webNavigation": {
+      "TransitionQualifier": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'server_redirect' is limited to top-level frames, 'client_redirect' is not supplied when redirections are created by JavaScript, and 'from_address_bar' is not supported. 'forward_back' is fully supported."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "'server_redirect' is limited to top-level frames, 'client_redirect' is not supplied when redirections are created by JavaScript, and 'from_address_bar' is not supported. 'forward_back' is fully supported."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "TransitionType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "notes": [
+                  "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAllFrames": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getFrame": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onBeforeNavigate": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCommitted": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception.", 
+                  "'transitionType' and 'transitionQualifiers' are supported from version 48."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }, 
+          "transitionQualifiers": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "transitionType": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCompleted": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCreatedNavigationTarget": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "sourceProcessId": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onDOMContentLoaded": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onErrorOccurred": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Filtering is not supported"
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception.", 
+                  "'error' is not supported."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception.", 
+                  "'error' is not supported."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onHistoryStateUpdated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'transitionType' and 'transitionQualifiers' are supported from version 48."
+                ], 
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "transitionQualifiers": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "transitionType": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "47.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onReferenceFragmentUpdated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception.", 
+                  "'transitionType' and 'transitionQualifiers' are supported from version 48."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.", 
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }, 
+          "transitionQualifiers": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "transitionType": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onTabReplaced": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ], 
+                "version_added": "45"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ], 
+                "version_added": "48"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "webRequest": {
+      "BlockingResponse": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "HttpHeaders": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "RequestFilter": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'windowId' and 'tabId' are supported from version 53."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "'windowId' and 'tabId' are supported from version 53."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "ResourceType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "UploadData": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "handlerBehaviorChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onAuthRequired": {
+        "__compat": {
+          "asyncBlocking": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "To handle a request asynchronously, return a Promise from the listener."
+                ], 
+                "version_added": "54"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "To handle a request asynchronously, return a Promise from the listener."
+                ], 
+                "version_added": "54"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onBeforeRedirect": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'originUrl' is supported from version 48."
+                ], 
+                "version_added": "46.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "46.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onBeforeRequest": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'originUrl' is supported from version 48.", 
+                  "'requestBody' is supported from version 50 in Nightly and Developer Edition builds, and in all builds from version 53.", 
+                  "Asynchronous event listeners are supported from version 52."
+                ], 
+                "version_added": "46.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "'requestBody' is supported from version 50 in Nightly and Developer Edition builds, and in all builds from version 53.", 
+                  "Asynchronous event listeners are supported from version 52."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "46.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onBeforeSendHeaders": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'originUrl' is supported from version 48.", 
+                  "Asynchronous event listeners are supported from version 52."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Asynchronous event listeners are supported from version 52."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onCompleted": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'originUrl' is supported from version 48."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onErrorOccurred": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'originUrl' is supported from version 48."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onHeadersReceived": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "edge": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "Modification of the 'Content-Type' header is supported from version 51.", 
+                  "Asynchronous event listeners are supported from version 52."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "notes": [
+                  "Modification of the 'Content-Type' header is supported from version 51.", 
+                  "Asynchronous event listeners are supported from version 52."
+                ], 
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ], 
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onResponseStarted": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'originUrl' is supported from version 48."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }, 
+      "onSendHeaders": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'originUrl' is supported from version 48."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "originUrl": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": "48.0"
+              }, 
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "windows": {
+      "CreateType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "WINDOW_ID_CURRENT": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "WINDOW_ID_NONE": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "Window": {
+        "__compat": {
+          "alwaysOnTop": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "WindowState": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "WindowType": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "create": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "notes": [
+                  "'url' and 'tabId options can't both be set together.", 
+                  "'url' does not accept relative paths.", 
+                  "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
+                ], 
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }, 
+          "focused": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": false
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "get": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getAll": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getCurrent": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "getLastFocused": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onCreated": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onFocusChanged": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "onRemoved": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "remove": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": false
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }, 
+      "update": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              }, 
+              "edge": {
+                "version_added": true
+              }, 
+              "firefox": {
+                "version_added": "45.0"
+              }, 
+              "firefox_android": {
+                "version_added": false
+              }, 
+              "opera": {
+                "version_added": "33"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Here's the WebExtensions data updated to use the new schema.

I've done it by adding a new file, rather than editing the existing one, in order to avoid breaking the MDN pages while I work on the new macro. Also this file seems like a better name.

It validates, according to the schema here: https://github.com/teoli2003/browser-compat-data/blob/98625481d521fa0ec902590a93fb328f31f92eb2/compat-data.schema.json .

The old schema used `"notes"` for everything: in this version I've used subfeatures for anything that could reasonably fit in one.

