### PR TITLE
Update Microsoft Edge WebExtension bookmarks API

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -244,7 +244,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "40.0"
+                    "version_added": "15"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -382,7 +382,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "40.0"
+                    "version_added": "15"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -428,7 +428,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "40.0"
+                    "version_added": "15"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -612,7 +612,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "40.0"
+                    "version_added": "15"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -635,7 +635,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "40.0"
+                    "version_added": "15"
                   },
                   "firefox": {
                     "version_added": "47.0"
@@ -681,7 +681,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "40.0"
+                    "version_added": "15"
                   },
                   "firefox": {
                     "version_added": "45.0"

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -244,7 +244,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "40.0"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -382,7 +382,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "40.0"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -428,7 +428,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "40.0"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -612,7 +612,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "40.0"
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -635,7 +635,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "40.0"
                   },
                   "firefox": {
                     "version_added": "47.0"
@@ -681,7 +681,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "40.0"
                   },
                   "firefox": {
                     "version_added": "45.0"


### PR DESCRIPTION
Microsoft Edge version 40 supports a few of the bookmarks API.
All the APIs supported currently by the Microsoft Edge browser can
be found here -
https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis