### PR TITLE
Update WebExtensions runtime API support on Chrome/Opera

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -250,10 +250,10 @@
   "runtime": {
     "openOptionsPage": {
       "Chrome": {
-        "support": true
+        "support": "42"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "29"
       }, 
       "Edge": {
         "support": false
@@ -267,10 +267,10 @@
     }, 
     "getURL": {
       "Chrome": {
-        "support": true
+        "support": "22"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true
@@ -284,10 +284,10 @@
     }, 
     "onRestartRequired": {
       "Chrome": {
-        "support": true
+        "support": "29"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "16"
       }, 
       "Edge": {
         "support": false
@@ -301,10 +301,10 @@
     }, 
     "MessageSender": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true
@@ -324,10 +324,10 @@
     }, 
     "onSuspendCanceled": {
       "Chrome": {
-        "support": true
+        "support": "22"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -344,7 +344,7 @@
         "support": true
       }, 
       "Opera": {
-        "support": "33"
+        "support": true
       }, 
       "Edge": {
         "support": false
@@ -358,10 +358,10 @@
     }, 
     "connect": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -375,10 +375,10 @@
     }, 
     "getPlatformInfo": {
       "Chrome": {
-        "support": true
+        "support": "29"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "16"
       }, 
       "Edge": {
         "support": false
@@ -409,10 +409,10 @@
     },
     "onMessage": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true, 
@@ -429,10 +429,10 @@
     }, 
     "id": {
       "Chrome": {
-        "support": true
+        "support": "22"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true
@@ -446,10 +446,10 @@
     }, 
     "setUninstallURL": {
       "Chrome": {
-        "support": true
+        "support": "41"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "28"
       }, 
       "Edge": {
         "support": false
@@ -463,10 +463,10 @@
     }, 
     "onConnect": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -480,10 +480,10 @@
     }, 
     "onStartup": {
       "Chrome": {
-        "support": true
+        "support": "23"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -500,7 +500,7 @@
         "support": true
       }, 
       "Opera": {
-        "support": "33"
+        "support": true
       }, 
       "Edge": {
         "support": false
@@ -514,10 +514,10 @@
     }, 
     "onConnectExternal": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -534,7 +534,7 @@
         "support": true
       }, 
       "Opera": {
-        "support": "33"
+        "support": true
       }, 
       "Edge": {
         "support": false
@@ -554,10 +554,10 @@
     }, 
     "onSuspend": {
       "Chrome": {
-        "support": true
+        "support": "22"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -574,7 +574,7 @@
         "support": true
       }, 
       "Opera": {
-        "support": "33"
+        "support": true
       }, 
       "Edge": {
         "support": false
@@ -588,10 +588,10 @@
     }, 
     "onBrowserUpdateAvailable": {
       "Chrome": {
-        "support": true
+        "support": "27"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -608,7 +608,7 @@
         "support": true
       }, 
       "Opera": {
-        "support": "33"
+        "support": true
       }, 
       "Edge": {
         "support": false
@@ -622,10 +622,10 @@
     }, 
     "requestUpdateCheck": {
       "Chrome": {
-        "support": true
+        "support": "25"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -639,10 +639,10 @@
     }, 
     "onUpdateAvailable": {
       "Chrome": {
-        "support": true
+        "support": "25"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -656,10 +656,10 @@
     }, 
     "onInstalled": {
       "Chrome": {
-        "support": true
+        "support": "22"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true
@@ -675,10 +675,10 @@
     },
     "getBackgroundPage": {
       "Chrome": {
-        "support": true
+        "support": "22"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true
@@ -692,10 +692,10 @@
     }, 
     "sendNativeMessage": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -709,10 +709,10 @@
     }, 
     "getPackageDirectoryEntry": {
       "Chrome": {
-        "support": true
+        "support": "29"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "16"
       }, 
       "Edge": {
         "support": false
@@ -726,10 +726,10 @@
     }, 
     "connectNative": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -743,10 +743,10 @@
     }, 
     "getManifest": {
       "Chrome": {
-        "support": true
+        "support": "22"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true
@@ -760,10 +760,10 @@
     }, 
     "onMessageExternal": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -780,7 +780,7 @@
         "support": true
       }, 
       "Opera": {
-        "support": "33"
+        "support": true
       }, 
       "Edge": {
         "support": true
@@ -794,10 +794,10 @@
     }, 
     "reload": {
       "Chrome": {
-        "support": true
+        "support": "25"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": false
@@ -814,7 +814,7 @@
         "support": true
       }, 
       "Opera": {
-        "support": "33"
+        "support": true
       }, 
       "Edge": {
         "support": false
@@ -828,10 +828,10 @@
     }, 
     "sendMessage": {
       "Chrome": {
-        "support": true
+        "support": "26"
       }, 
       "Opera": {
-        "support": "33"
+        "support": "15"
       }, 
       "Edge": {
         "support": true, 
@@ -854,7 +854,7 @@
         ]
       },
       "Opera": {
-        "support": "33",
+        "support": true,
         "notes": [
           "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
         ]
@@ -871,11 +871,11 @@
     }, 
     "Port": {
       "Chrome": {
-        "support": true,
+        "support": "26",
         "notes": ["'Port.error' is not supported. Use 'runtime.lastError' instead."]
       }, 
       "Opera": {
-        "support": "33",
+        "support": "15",
         "notes": ["'Port.error' is not supported. Use 'runtime.lastError' instead."]
       }, 
       "Edge": {

--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -692,10 +692,10 @@
     }, 
     "sendNativeMessage": {
       "Chrome": {
-        "support": "26"
+        "support": "29"
       }, 
       "Opera": {
-        "support": "15"
+        "support": "16"
       }, 
       "Edge": {
         "support": false
@@ -726,10 +726,10 @@
     }, 
     "connectNative": {
       "Chrome": {
-        "support": "26"
+        "support": "29"
       }, 
       "Opera": {
-        "support": "15"
+        "support": "16"
       }, 
       "Edge": {
         "support": false

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5277,7 +5277,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": true
@@ -5295,7 +5295,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5318,7 +5318,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5341,7 +5341,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5364,7 +5364,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5387,7 +5387,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -5406,7 +5406,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5429,7 +5429,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5452,7 +5452,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5463,7 +5463,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": false
@@ -5475,7 +5475,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               },
@@ -5517,7 +5517,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5528,7 +5528,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": false
@@ -5540,7 +5540,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5551,7 +5551,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": false
@@ -5563,7 +5563,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5574,7 +5574,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "22"
                   },
                   "edge": {
                     "version_added": true
@@ -5586,7 +5586,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5620,7 +5620,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "22"
                   },
                   "edge": {
                     "version_added": true
@@ -5632,7 +5632,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5643,7 +5643,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "29"
                   },
                   "edge": {
                     "version_added": false
@@ -5655,7 +5655,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "16"
                   }
                 }
               }
@@ -5666,7 +5666,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "29"
                   },
                   "edge": {
                     "version_added": false
@@ -5678,7 +5678,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "16"
                   }
                 }
               }
@@ -5689,7 +5689,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "22"
                   },
                   "edge": {
                     "version_added": true
@@ -5701,7 +5701,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5712,7 +5712,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "22"
                   },
                   "edge": {
                     "version_added": true
@@ -5724,7 +5724,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5753,7 +5753,7 @@
                     "notes": [
                       "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
                     ],
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5764,7 +5764,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "27"
                   },
                   "edge": {
                     "version_added": false
@@ -5776,7 +5776,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5787,7 +5787,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": false
@@ -5799,7 +5799,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5810,7 +5810,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": false
@@ -5822,7 +5822,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5833,7 +5833,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "22"
                   },
                   "edge": {
                     "version_added": true
@@ -5851,7 +5851,7 @@
                     "version_added": "52.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5862,7 +5862,7 @@
               "MessageSender.tlsChannelId": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "32"
                   },
                   "edge": {
                     "version_added": false
@@ -5874,14 +5874,14 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "19"
                   }
                 }
               },
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": true
@@ -5893,7 +5893,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5904,7 +5904,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": false
@@ -5916,7 +5916,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5927,7 +5927,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "29"
                   },
                   "edge": {
                     "version_added": false
@@ -5939,7 +5939,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "16"
                   }
                 }
               }
@@ -5950,7 +5950,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "23"
                   },
                   "edge": {
                     "version_added": false
@@ -5962,7 +5962,7 @@
                     "version_added": "52.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5973,7 +5973,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "22"
                   },
                   "edge": {
                     "version_added": false
@@ -5985,7 +5985,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -5996,7 +5996,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "22"
                   },
                   "edge": {
                     "version_added": false
@@ -6008,7 +6008,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -6019,7 +6019,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "25"
                   },
                   "edge": {
                     "version_added": false
@@ -6031,7 +6031,7 @@
                     "version_added": "51.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -6042,7 +6042,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "42"
                   },
                   "edge": {
                     "version_added": false
@@ -6054,7 +6054,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "29"
                   }
                 }
               }
@@ -6065,7 +6065,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "25"
                   },
                   "edge": {
                     "version_added": false
@@ -6077,7 +6077,7 @@
                     "version_added": "51.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -6088,7 +6088,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "25"
                   },
                   "edge": {
                     "version_added": false
@@ -6100,7 +6100,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -6111,7 +6111,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": true
@@ -6123,7 +6123,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               },
@@ -6142,7 +6142,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6153,7 +6153,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": false
@@ -6165,7 +6165,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "15"
                   }
                 }
               }
@@ -6176,7 +6176,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "41"
                   },
                   "edge": {
                     "version_added": false
@@ -6188,7 +6188,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "28"
                   }
                 }
               }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5551,7 +5551,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": "26"
+                    "version_added": "29"
                   },
                   "edge": {
                     "version_added": false
@@ -5563,7 +5563,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "15"
+                    "version_added": "16"
                   }
                 }
               }
@@ -6153,7 +6153,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": "26"
+                    "version_added": "29"
                   },
                   "edge": {
                     "version_added": false
@@ -6165,7 +6165,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "15"
+                    "version_added": "16"
                   }
                 }
               }


### PR DESCRIPTION
Minimum Chrome versions are gathered from [Chrome's own documentation](https://developer.chrome.com/extensions/runtime) and verifying manually.

I plan to add the minimum Chrome versions for the other APIs over time.

Conflicting info:

- Chrome documentation claims `connectNative` and `sendNativeMessage` is only available since Chrome 28, but they are actually available since Chrome 26.
  
  (`typeof chrome.runtime.connectNative` === `function`, not `undefined`)