### PR TITLE
Disallow additionalProperties in compat_block

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -80,7 +80,7 @@
         "safari_ios": { "$ref": "#/definitions/support_statement" },
         "servo": { "$ref": "#/definitions/support_statement" }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
 
     "subfeature": {


### PR DESCRIPTION
This should protect us from typos like "friefox" and "chome".
Fixes #173. 