### PR TITLE
Disallow . in features and __compat in subfeatures

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -96,11 +96,11 @@
 
     "subfeature_set": {
       "type": "object",
-      "properties": {
-        "basic_support": { "$ref": "#/definitions/subfeature" }
+      "patternProperties": {
+        "^(?!__compat).*$" : { "$ref": "#/definitions/subfeature" }
       },
       "required": ["basic_support"],
-      "additionalProperties": { "$ref": "#/definitions/subfeature" }
+      "additionalProperties": false
     },
 
     "identifier": {
@@ -109,7 +109,7 @@
         "__compat": { "$ref": "#/definitions/subfeature_set" }
       },
       "patternProperties":{
-        "^(?!__compat).*$" : { "$ref": "#/definitions/identifier" }
+        "^(?!__compat|.*\\.).*$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
     },
@@ -117,7 +117,7 @@
     "compat_data": {
       "type": "object",
       "patternProperties": {
-        "^(?!__compat).*$" : { "$ref": "#/definitions/identifier" }
+        "^(?!__compat|.*\\.).*$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
     }


### PR DESCRIPTION
Fixes #167.

This disallow dots in feature identifiers whenever we also disallow to set "__compat" with one exception: In subfeatures, I added a check to disallow "__compat", but we actually have cases in WebExtension where we also describe subfeatures that in fact have a dot. See browsingData.RemovalOptions where there is "originTypes.extension" as a sub feature, for example.

Will, I think it is fine for sub features to have this freedom, what do you think?
Attempt to summarize what this PR does:

```
{
  "version": "1.0.0",
  "data": {
    "webextensions.api": { <--nope
    "__compat": { <-- nope
      "api.alarms": { <-- nope
        "alarms.Alarm": { <-- nope
          "Alarm.foo": { <-- nope
            "__compat": { <-- yep
              "basic_support": { }
              "__compat": {} <-- nope
              "Alarm.foo": {} <-- yep
```
