### PR TITLE
Remove data for bookmarks.import and bookmarks.export

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -259,29 +259,6 @@
               }
             }
           },
-          "export": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "33"
-                  }
-                }
-              }
-            }
-          },
           "get": {
             "__compat": {
               "basic_support": {
@@ -386,29 +363,6 @@
                   },
                   "firefox": {
                     "version_added": "45.0"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "33"
-                  }
-                }
-              }
-            }
-          },
-          "import": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
                   },
                   "firefox_android": {
                     "version_added": false


### PR DESCRIPTION
bookmarks.import() and bookmarks.export() are listed in the [Chromium JSON file that defines the bookmarks API](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json), so they made it into the compat data when we were documenting this API. However, they don't appear to be supported in any browsers, or documented in the [Chrome docs](https://developer.chrome.com/extensions/bookmarks).

Last year Sheppy archived the docs pages for them [[3]](https://developer.mozilla.org/en-US/docs/Archive/Add-ons/bookmarks.export)[[4]](https://developer.mozilla.org/en-US/docs/Archive/Add-ons/bookmarks.import).

However, the fact that they are in the JSON compat data means they appear in the [bookmarks aggregate compat table](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/bookmarks#Browser_compatibility), but the links go to these archived pages.

As @jwhitlock points out, because the archived pages don't replicate the URL structure of the originals, the macros are broken on these pages. But even if they weren't, I wouldn't want people following links from the bookmarks docs to archived pages.

So I think there are two options

1. restore the pages
2. remove the compat data for them, so the links no longer appear in the aggregate tables, then delete the pages.

Because noone seems to support these APIs (I have tested in Chrome, and am sure neither Firefox nor Edge do), it seems perverse to document them, so this PR removes the compat data. It's possible Firefox will add support in future (P5 though), and we can always reinstate if that happens.
