### PR TITLE
add files for creating npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.travis.yml
+.editorconfig
+compat-data.schema.md
+CODE_OF_CONDUCT.md

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function load() {
     }
 
     for (dir of arguments) {
-        dir = path.resolve(dir);
+        dir = path.resolve(__dirname, dir);
         fs.readdirSync(dir).forEach(processFilename);
     }
 
@@ -26,9 +26,9 @@ function load() {
 }
 
 module.exports = load(
-    'api',
+    // 'api',
     'css',
-    'http',
-    'javascript',
+    // 'http',
+    // 'javascript',
     'webextensions'
 );

--- a/index.js
+++ b/index.js
@@ -1,0 +1,42 @@
+var fs = require('fs'),
+    path = require('path');
+
+function load(dir, result) {
+    var duplicates = [],
+        result = result || {};
+
+    dir = path.normalize(dir);
+
+    function processFilename(fn) {
+        // If the given filename is a directory, recursively load it.
+        var fp = path.join(dir, fn),
+            basename = path.parse(fn).name;
+
+        if (result.hasOwnProperty(basename)) {
+            // Keep track of the duplicates and throw error later.
+            duplicates.push(fp);
+        } else if (fs.statSync(fp).isDirectory()) {
+            result[basename] = {};
+            load(fp, result[basename]);
+        } else {
+            result[basename] = require(fp);
+        }
+    }
+
+    fs.readdirSync(dir).forEach(processFilename);
+
+    if (duplicates.length > 0) {
+        // Duplicate template names
+        throw new Error("duplicates:\n" + duplicates.join("\n"));
+    }
+
+    return result;
+}
+
+module.exports = {
+  api: load('./api'),
+  css: load('./css'),
+  http: load('./http'),
+  javascript: load('./javascript'),
+  webextensions: load('./webextensions'),
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "dependencies": {
     "extend": "3.0.1"
   },
-  "scripts": {
-    "test": "npm test"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mdn/browser-compat-data.git"
@@ -21,7 +18,7 @@
     "mdn",
     "mozilla"
   ],
-  "author": "mozilla",
+  "author": "Mozilla Developer Network",
   "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/mdn/browser-compat-data/issues"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "mdn-browser-compat-data",
+  "version": "1.0.0",
+  "description": "Browser compatibility data provided by the Mozilla Developer Network",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdn/browser-compat-data.git"
+  },
+  "keywords": [
+    "browser-compat-data",
+    "browser",
+    "compatibility",
+    "data",
+    "mdn",
+    "mozilla"
+  ],
+  "author": "mozilla",
+  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/mdn/browser-compat-data/issues"
+  },
+  "homepage": "https://github.com/mdn/browser-compat-data#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "mdn-browser-compat-data",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Browser compatibility data provided by the Mozilla Developer Network",
   "main": "index.js",
+  "dependencies": {
+    "extend": "3.0.1"
+  },
   "scripts": {
     "test": "npm test"
   },
@@ -19,7 +22,7 @@
     "mozilla"
   ],
   "author": "mozilla",
-  "license": "MPL-2.0",
+  "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/mdn/browser-compat-data/issues"
   },


### PR DESCRIPTION
I created an initial ``package.json`` and ``index.js`` as part of preparing this repo for npm publication. Both are probably not in final form, but ready for feedback and discussion!

One question that I still have is "What is the best practice for the ``index.js`` file?" This implementation was written with the intent of making the "load" easy to maintain (e.g., additional JSON files within additional directories would be automatically discovered), but are there reasons not to do that?

Also, JavaScript is not my native language, so please let me know where I can improve!