### PR TITLE
Updated manifest key data to the new schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ script:
   - ajv validate -s compat-data.schema.json -d "{css/**/*.json}"
   - ajv validate -s compat-data.schema.old.json -d "{http/**/*.json}"
   - ajv validate -s compat-data.schema.old.json -d "{javascript/**/*.json}"
-  - ajv validate -s compat-data.schema.json -d webextensions/javascript-apis.json
+  - ajv validate -s compat-data.schema.json -d "{webextensions/**/*.json}"
 notifications:
   email: false

--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -60,7 +60,10 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The 'persistent' property is mandatory."
+                  ]
                 },
                 "firefox": {
                   "version_added": "48"
@@ -79,7 +82,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": false
@@ -105,7 +108,11 @@
                   ]
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "SVG icons are not supported.",
+                    "'default_icon' must be an object, with explicit sizes."
+                  ]
                 },
                 "firefox": {
                   "version_added": "48"
@@ -166,7 +173,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "54"
@@ -185,7 +192,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -204,7 +211,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -230,7 +237,7 @@
                   ]
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "54",
@@ -258,7 +265,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -277,7 +284,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -300,7 +307,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "48"
@@ -319,7 +326,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "53"
@@ -357,7 +364,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -376,7 +383,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -395,7 +402,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -414,7 +421,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -433,7 +440,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -487,7 +494,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "52"
@@ -510,7 +517,10 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true,
+                  "notes": [
+                    "Only the default content security policy is supported: \"script-src 'self'; object-src 'self';\"."
+                  ]
                 },
                 "firefox": {
                   "version_added": "48",
@@ -539,7 +549,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "48"
@@ -562,7 +572,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "48"
@@ -585,7 +595,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "48"
@@ -608,7 +618,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "54"
@@ -631,7 +641,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "48"
@@ -654,7 +664,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "48"
@@ -677,7 +687,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "48"
@@ -700,7 +710,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "48"
@@ -723,7 +733,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -746,7 +756,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -765,7 +775,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -791,7 +801,11 @@
                   ]
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "SVG icons are not supported.",
+                    "'default_icon' must be an object, with explicit sizes."
+                  ]
                 },
                 "firefox": {
                   "version_added": "48"
@@ -871,7 +885,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": false
@@ -955,7 +969,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "48"

--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -1,311 +1,1048 @@
 {
-  "manifest": {
-    "applications": {
-      "Chrome": {
-        "support": false
-      },
-      "Opera": {
-        "support": false
-      },
-      "Edge": {
-        "support": false
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "background": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "browser_action": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "commands": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "content_scripts": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "content_security_policy": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "default_locale": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "description": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "homepage_url": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "icons": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "manifest_version": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "name": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "options_ui": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "page_action": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "permissions": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "short_name": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "version": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
-      }
-    },
-    "web_accessible_resources": {
-      "Chrome": {
-        "support": true
-      },
-      "Opera": {
-        "support": true
-      },
-      "Edge": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "45.0"
-      },
-      "Firefox for Android": {
-        "support": "48.0"
+  "version": "1.0.0",
+  "data": {
+    "webextensions": {
+      "manifest": {
+        "applications": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "author": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true,
+                  "notes": [
+                    "This key is mandatory in Microsoft Edge."
+                  ]
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "background": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "persistent": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "browser_action": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "notes": [
+                    "SVG icons are not supported."
+                  ]
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "browser_style": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            },
+            "default_area": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "chrome_settings_overrides": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "search_provider": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "startup_pages": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "chrome_url_overrides": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "notes": [
+                    "If two or more add-ons both define a custom new tab page, then in Firefox the first add-on to run wins. In Chrome and Opera, the last add-on wins."
+                  ]
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "54",
+                  "notes": [
+                    "If two or more add-ons both define a custom new tab page, then in Firefox the first add-on to run wins. In Chrome and Opera, the last add-on wins."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": "54",
+                  "notes": [
+                    "If two or more add-ons both define a custom new tab page, then in Firefox the first add-on to run wins. In Chrome and Opera, the last add-on wins."
+                  ]
+                },
+                "opera": {
+                  "version_added": true,
+                  "notes": [
+                    "If two or more add-ons both define a custom new tab page, then in Firefox the first add-on to run wins. In Chrome and Opera, the last add-on wins."
+                  ]
+                }
+              }
+            },
+            "bookmarks": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "history": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "commands": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "F1-F12": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "_execute_sidebar_action": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            },
+            "global": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "MediaNextTrack": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "MediaPlayPause": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "MediaPrevTrack": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "MediaStop": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "content_scripts": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "notes": [
+                    "Content scripts are not applied to tabs already open when the extension is loaded."
+                  ]
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48",
+                  "notes": [
+                    "Content scripts won't be injected into empty iframes at 'document_start' even if you specify that value in 'run_at'."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "notes": [
+                    "Content scripts won't be injected into empty iframes at 'document_start' even if you specify that value in 'run_at'."
+                  ]
+                },
+                "opera": {
+                  "version_added": true,
+                  "notes": [
+                    "Content scripts are not applied to tabs already open when the extension is loaded."
+                  ]
+                }
+              }
+            },
+            "match_about_blank": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "content_security_policy": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48",
+                  "notes": [
+                    "Firefox does not support 'http://127.0.0.1' or 'http://localhost' as script sources: they must be served over HTTPS."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "notes": [
+                    "Firefox does not support 'http://127.0.0.1' or 'http://localhost' as script sources: they must be served over HTTPS."
+                  ]
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "default_locale": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "description": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "developer": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "devtools_page": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "homepage_url": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "icons": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "manifest_version": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "name": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "omnibox": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "options_ui": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "chrome_style": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "page_action": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "notes": [
+                    "SVG icons are not supported."
+                  ]
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "browser_style": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "permissions": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "background": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            },
+            "unlimitedStorage": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "geolocation": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "activeTab": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "protocol_handlers": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "short_name": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "sidebar_action": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "version": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "notes": [
+                    "Valid Chrome versions are a subset of valid Firefox versions."
+                  ]
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "web_accessible_resources": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
 }
-    

--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -863,19 +863,19 @@
             "background": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "48"
+                  "version_added": false
                 },
                 "firefox_android": {
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": true
                 }
               }
             },


### PR DESCRIPTION
This updates the data for manifest keys to the new schema, and (I think) also updates Travis to check everything under /webextensions.

This data isn't yet used on MDN. I've wanted for a long time to use compat data to generate tables for the manifest keys, but have been waiting for the new schema to do so. It's great that this is now happening.

This data validates according to the schema. I've generated some tables in a local Kuma instance and they look all right. There might be a few errors in the data, but it will be easier to spot and correct these once we can generate the tables.

Once this is merged I'll update the macros to generate tables for manifest keys.
