### PR TITLE
Move BrowserSetting to its own namespace

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5079,48 +5079,6 @@
           }
         },
         "privacy": {
-          "BrowserSetting": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "onChange": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
           "network": {
             "__compat": {
               "basic_support": {
@@ -8177,6 +8135,50 @@
                   },
                   "opera": {
                     "version_added": "33"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "types": {
+          "BrowserSetting": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "onChange": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
                   }
                 }
               }


### PR DESCRIPTION
The initial docs for BrowserSetting were written as part of the [privacy API](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/privacy), so they were put under that namespace. 

However, it will be used in other WebExtension modules, so we should move it out into its own namespace, "types". This is in line with [Bob Silverberg's comment in Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1312802#c49). "types" is the namespace used in Chrome for the [corresponding type](https://developer.chrome.com/extensions/types#type-ChromeSetting).