### PR TITLE
Move any-link to selectors folder

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -2,8 +2,8 @@
   "version": "1.0.0",
   "data": {
     "css": {
-     "pseudo-classes" : {
-       ":any-link": {
+     "selectors" : {
+       "any-link": {
         "__compat":{
           "basic_support": {
            "support": {


### PR DESCRIPTION
I don't think we need "pseudo-classes" and "pseudo-elements", they are just all selectors. You don't have to know this level of detail in order to get some data.

I also removed the colon ":" in the identifier. Accessing the data like `['css']['selectors']['any-link']` looks better to me than `['css']['selectors'][':any-link']`.

r? @teoli2003 What do you think?