### PR TITLE
Fix typo in .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 .travis.yml
 .editorconfig
-compat-data.schema.md
+compat-data-schema.md
 CODE_OF_CONDUCT.md


### PR DESCRIPTION
Things you spot when you actually install a package :)

(https://docs.npmjs.com/cli/install I learned that you can install from GitHub repos as well)