### PR TITLE
Add data for contextMenus.create 'command' option

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1609,6 +1609,25 @@
                     "version_added": "33"
                   }
                 }
+              },
+              "command": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
Adds a subfeature for the `command` option, that as from [bug 1318791](https://bugzilla.mozilla.org/show_bug.cgi?id=1318791) can now be passed to [contextMenus.create()](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextMenus/create).
