### PR TITLE
Updated Firefox/FxA versions for chrome_settings_overrides

### DIFF
--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -176,10 +176,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "54"
+                  "version_added": "55"
                 },
                 "firefox_android": {
-                  "version_added": "54"
+                  "version_added": "55"
                 },
                 "opera": {
                   "version_added": true


### PR DESCRIPTION
According to [https://bugzilla.mozilla.org/show_bug.cgi?id=1341458](https://bugzilla.mozilla.org/show_bug.cgi?id=1341458), `chrome_settings_overrides` landed in Firefox 55, not 54.