### PR TITLE
[Schema] Flags should require type and name

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -14,7 +14,8 @@
             "name": { "type": "string" },
             "value_to_set": { "type": "string"}
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "required": ["type", "name"]
         },
         "partial_implementation": { "type": "boolean" },
         "version_added": { "type": ["string", "boolean", "null"] },


### PR DESCRIPTION
I agree to Will here https://github.com/mozilla/kumascript/pull/182#discussion_r117377657

Flags without `type` and `name` make no sense. I think `value_to_set` can be optional.