### PR TITLE
Update runtime.connect()'s Edge support to `true`

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5462,7 +5462,7 @@
                     "version_added": "26"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": true
                   },
                   "firefox": {
                     "version_added": "45.0"


### PR DESCRIPTION
Source: https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis

There is a caveat on the MSDN page about not supporting the `options` parameter, but the [MDN documentation](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/connect) documentation for `runtime.connect()` API doesn't even show any available `options` parameter.