### PR TITLE
Update JS Promise data to the new schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - ajv validate -s compat-data.schema.old.json -d "api/**/*.json"
   - ajv validate -s compat-data.schema.json -d "css/**/*.json"
   - ajv validate -s compat-data.schema.old.json -d "http/**/*.json"
-  - ajv validate -s compat-data.schema.old.json -d "javascript/**/*.json"
+  - ajv validate -s compat-data.schema.json -d "javascript/**/*.json"
   - ajv validate -s compat-data.schema.json -d "webextensions/**/*.json"
 notifications:
   email: false

--- a/index.js
+++ b/index.js
@@ -29,6 +29,6 @@ module.exports = load(
     // 'api',
     'css',
     // 'http',
-    // 'javascript',
+    'javascript',
     'webextensions'
 );

--- a/javascript/promise.json
+++ b/javascript/promise.json
@@ -1,446 +1,483 @@
 {
-  "Promise": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0",
-        "notes": ["Constructor requires a new operator since version 37."]
-      },
-      "Firefox for Android": {
-        "support": "29",
-        "notes": ["Constructor requires a new operator since version 37."]
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12",
-        "notes": ["Constructor requires a new operator since version 4."]
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1",
-        "notes": ["Constructor requires a new operator since version 10."]
-      },
-      "Safari Mobile": {
-        "support": "8.0",
-        "notes": ["Constructor requires a new operator since version 10."]
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
-      }
-    }
-  },
-  "Promise.all": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0"
-      },
-      "Firefox for Android": {
-        "support": "29"
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12"
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1"
-      },
-      "Safari Mobile": {
-        "support": "8.0"
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
-      }
-    }
-  },
-  "Promise.prototype": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0"
-      },
-      "Firefox for Android": {
-        "support": "29"
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12"
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1"
-      },
-      "Safari Mobile": {
-        "support": "8.0"
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
-      }
-    }
-  },
-  "Promise.prototype.catch": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0"
-      },
-      "Firefox for Android": {
-        "support": "29"
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12"
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1"
-      },
-      "Safari Mobile": {
-        "support": "8.0"
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
-      }
-    }
-  },
-  "Promise.prototype.then": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0"
-      },
-      "Firefox for Android": {
-        "support": "29"
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12"
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1"
-      },
-      "Safari Mobile": {
-        "support": "8.0"
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
-      }
-    }
-  },
-  "Promise.race": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0"
-      },
-      "Firefox for Android": {
-        "support": "29"
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12"
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1"
-      },
-      "Safari Mobile": {
-        "support": "8.0"
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
-      }
-    }
-  },
-  "Promise.reject": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0"
-      },
-      "Firefox for Android": {
-        "support": "29"
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12"
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1"
-      },
-      "Safari Mobile": {
-        "support": "8.0"
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
-      }
-    }
-  },
-  "Promise.resolve": {
-    "Basic support": {
-      "Android": {
-        "support": "4.4.4"
-      },
-      "Chrome": {
-        "support": "32.0"
-      },
-      "Chrome for Android": {
-        "support": "32.0"
-      },
-      "Edge": {
-        "support": true
-      },
-      "Edge Mobile": {
-        "support": true
-      },
-      "Firefox": {
-        "support": "29.0"
-      },
-      "Firefox for Android": {
-        "support": "29"
-      },
-      "Internet Explorer": {
-        "support": false
-      },
-      "IE Mobile": {
-        "support": false
-      },
-      "Node.js": {
-        "support": "0.12"
-      },
-      "Opera": {
-        "support": "19"
-      },
-      "Opera Mobile": {
-        "support": true
-      },
-      "Safari": {
-        "support": "7.1"
-      },
-      "Safari Mobile": {
-        "support": "8.0"
-      },
-      "Servo": {
-        "support": false
-      },
-      "status": {
-        "experimental": false,
-        "standardized": true,
-        "stable": true,
-        "obsolete": false
+  "version": "1.0.0",
+  "data": {
+    "javascript": {
+      "Promise": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0",
+                "notes": ["Constructor requires a new operator since version 37."]
+              },
+              "firefox_android": {
+                "version_added": "29",
+                "notes": ["Constructor requires a new operator since version 37."]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12",
+                "notes": ["Constructor requires a new operator since version 4."]
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1",
+                "notes": ["Constructor requires a new operator since version 10."]
+              },
+              "safari_ios": {
+                "version_added": "8.0",
+                "notes": ["Constructor requires a new operator since version 10."]
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      },
+      "Promise.all": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      },
+      "Promise.prototype": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      },
+      "Promise.prototype.catch": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      },
+      "Promise.prototype.then": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      },
+      "Promise.race": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      },
+      "Promise.reject": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      },
+      "Promise.resolve": {
+        "__compat": {
+          "basic_support": {
+            "desc": "Basic support",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "Node.js": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
+              },
+              "servo": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
       }
     }
   }

--- a/javascript/promise.json
+++ b/javascript/promise.json
@@ -2,479 +2,475 @@
   "version": "1.0.0",
   "data": {
     "javascript": {
-      "Promise": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0",
-                "notes": ["Constructor requires a new operator since version 37."]
-              },
-              "firefox_android": {
-                "version_added": "29",
-                "notes": ["Constructor requires a new operator since version 37."]
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12",
-                "notes": ["Constructor requires a new operator since version 4."]
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1",
-                "notes": ["Constructor requires a new operator since version 10."]
-              },
-              "safari_ios": {
-                "version_added": "8.0",
-                "notes": ["Constructor requires a new operator since version 10."]
-              },
-              "servo": {
-                "version_added": false
+      "builtins": {
+        "promise": {
+          "Promise": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0",
+                    "notes": ["Constructor requires a new operator since version 37."]
+                  },
+                  "firefox_android": {
+                    "version_added": "29",
+                    "notes": ["Constructor requires a new operator since version 37."]
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12",
+                    "notes": ["Constructor requires a new operator since version 4."]
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1",
+                    "notes": ["Constructor requires a new operator since version 10."]
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0",
+                    "notes": ["Constructor requires a new operator since version 10."]
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
-          }
-        }
-      },
-      "Promise.all": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1"
-              },
-              "safari_ios": {
-                "version_added": "8.0"
-              },
-              "servo": {
-                "version_added": false
+          },
+          "all": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "29"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0"
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
-          }
-        }
-      },
-      "Promise.prototype": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1"
-              },
-              "safari_ios": {
-                "version_added": "8.0"
-              },
-              "servo": {
-                "version_added": false
+          },
+          "prototype": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "29"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0"
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
-          }
-        }
-      },
-      "Promise.prototype.catch": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1"
-              },
-              "safari_ios": {
-                "version_added": "8.0"
-              },
-              "servo": {
-                "version_added": false
+          },
+          "catch": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "29"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0"
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
-          }
-        }
-      },
-      "Promise.prototype.then": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1"
-              },
-              "safari_ios": {
-                "version_added": "8.0"
-              },
-              "servo": {
-                "version_added": false
+          },
+          "then": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "29"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0"
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
-          }
-        }
-      },
-      "Promise.race": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1"
-              },
-              "safari_ios": {
-                "version_added": "8.0"
-              },
-              "servo": {
-                "version_added": false
+          },
+          "race": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "29"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0"
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
-          }
-        }
-      },
-      "Promise.reject": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1"
-              },
-              "safari_ios": {
-                "version_added": "8.0"
-              },
-              "servo": {
-                "version_added": false
+          },
+          "reject": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "29"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0"
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
-          }
-        }
-      },
-      "Promise.resolve": {
-        "__compat": {
-          "basic_support": {
-            "desc": "Basic support",
-            "support": {
-              "webview_android": {
-                "version_added": "4.4.4"
-              },
-              "chrome": {
-                "version_added": "32.0"
-              },
-              "chrome_android": {
-                "version_added": "32.0"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "Node.js": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "7.1"
-              },
-              "safari_ios": {
-                "version_added": "8.0"
-              },
-              "servo": {
-                "version_added": false
+          },
+          "resolve": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "4.4.4"
+                  },
+                  "chrome": {
+                    "version_added": "32.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "32.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "29.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "29"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8.0"
+                  },
+                  "servo": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "obsolete": false
             }
           }
         }


### PR DESCRIPTION
Replaces #174, rebased and with comments addressed.
Also activates the "javascript" directory in the loader.

[update] Rebased again, so that PR #207 is included.