### PR TITLE
Add 'nodejs' as an allowed compat property

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -75,6 +75,7 @@
         "firefox_android": { "$ref": "#/definitions/support_statement" },
         "ie_mobile": { "$ref": "#/definitions/support_statement" },
         "ie": { "$ref": "#/definitions/support_statement" },
+        "nodejs": { "$ref": "#/definitions/support_statement" },
         "opera": { "$ref": "#/definitions/support_statement" },
         "opera_android": { "$ref": "#/definitions/support_statement" },
         "safari": { "$ref": "#/definitions/support_statement" },


### PR DESCRIPTION
Needed for #206.

We don't display node.js on MDN yet as we need the redesigned tables that don't use the "mobile" and "desktop" categories in which node.js makes no sense. However, I think we should start allowing to add node.js data now.

(Another reason to get to the redesign! Node.js data was requested several times and will be a true benefit to MDN readers)