### PR TITLE
do not allow empty strings as properties

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -99,7 +99,7 @@
     "subfeature_set": {
       "type": "object",
       "patternProperties": {
-        "^(?!__compat).*$" : { "$ref": "#/definitions/subfeature" }
+        "^(?!__compat).+$" : { "$ref": "#/definitions/subfeature" }
       },
       "required": ["basic_support"],
       "additionalProperties": false
@@ -111,7 +111,7 @@
         "__compat": { "$ref": "#/definitions/subfeature_set" }
       },
       "patternProperties":{
-        "^(?!__compat|.*\\.).*$" : { "$ref": "#/definitions/identifier" }
+        "^(?!__compat|.*\\.).+$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
     },
@@ -119,7 +119,7 @@
     "compat_data": {
       "type": "object",
       "patternProperties": {
-        "^(?!__compat|.*\\.).*$" : { "$ref": "#/definitions/identifier" }
+        "^(?!__compat|.*\\.).+$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
     }


### PR DESCRIPTION
Perhaps this has already been discussed long ago, but it seems to me that we should not allow empty strings as properties on objects within ``compat-data.schema.json``? This PR adjusts ``compat-data.schema.json`` such that empty strings are not allowed as properties.