### PR TITLE
Add data for browserAction API for Firefox for Android

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -827,7 +827,7 @@
                     "version_added": "45.0"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "55"
                   },
                   "opera": {
                     "version_added": "33"
@@ -850,7 +850,7 @@
                     "version_added": "45.0"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "55"
                   },
                   "opera": {
                     "version_added": "33"
@@ -965,7 +965,7 @@
                     "version_added": "45.0"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "55"
                   },
                   "opera": {
                     "version_added": "33"


### PR DESCRIPTION
See:
http://searchfox.org/mozilla-central/source/mobile/android/components/extensions/schemas/browser_action.json

Only setTitle, getTitle, and onClicked are supported, and these only from version 55.
(The ColorArray and ImageDataType are not marked as unsupported in the linked JSON, but they are really, since you can't use them.)