### PR TITLE
Add (X-)SourceMap header

### DIFF
--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -1,0 +1,85 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "http": {
+      "headers": {
+        "SourceMap": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": null
+                },
+                "chrome": [
+                  {
+                    "prefix": "X-",
+                    "version_added": true
+                  },
+                  {
+                    "version_added": true
+                  }
+                ],
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": [
+                  {
+                    "prefix": "X-",
+                    "version_added": "27.0"
+                  },
+                  {
+                    "version_added": "55.0"
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "prefix": "X-",
+                    "version_added": "27.0"
+                  },
+                  {
+                    "version_added": "55.0"
+                  }
+                ],
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": [
+                  {
+                    "prefix": "X-",
+                    "version_added": true
+                  },
+                  {
+                    "version_added": true
+                  }
+                ],
+                "safari_ios": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "obsolete": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Firefox 27+ added X-SourceMap https://bugzilla.mozilla.org/show_bug.cgi?id=765993
Firefox 55+ added SourceMap https://bugzilla.mozilla.org/show_bug.cgi?id=1346936

Chrome and Safari support both, versions unknown. 
https://bugs.webkit.org/show_bug.cgi?id=114888