### PR TITLE
Add 'data:' URL scheme compat data

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "http": {
+      "data-url": {
+        "__compat": {
+          "basic_support": {
+            "desc": "data URL scheme",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12",
+                "notes": ["IE9 and later, as well as Edge, supports data URLs in CSS and JS files, but not in HTML files, with a max size of 4GB."]
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "8",
+                "notes": ["IE8 only supports data URLs in CSS files, with a max size of 32kB",
+                          "IE9 and later, as well as Edge, supports data URLs in CSS and JS files, but not in HTML files, with a max size of 4GB."]
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "7.20"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -18,10 +18,11 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": ["IE9 and later, as well as Edge, supports data URLs in CSS and JS files, but not in HTML files, with a max size of 4GB."]
+                "notes": ["The maximum size supported is 4GB"]
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "notes": ["The maximum size supported is 4GB"]
               },
               "firefox": {
                 "version_added": true
@@ -31,11 +32,172 @@
               },
               "ie": {
                 "version_added": "8",
-                "notes": ["IE8 only supports data URLs in CSS files, with a max size of 32kB",
-                          "IE9 and later, as well as Edge, supports data URLs in CSS and JS files, but not in HTML files, with a max size of 4GB."]
+                "notes": ["The maximum size supported is 32kB"]
               },
               "ie_mobile": {
+                "version_added": true,
+                "notes": ["The maximum size supported is 4GB"]
+              },
+              "opera": {
+                "version_added": "7.20"
+              },
+              "opera_android": {
                 "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          },
+          "css_files": {
+            "desc": "CSS files",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12",
+                "notes": ["The maximum size supported is 4GB"]
+              },
+              "edge_mobile": {
+                "version_added": true,
+                "notes": ["The maximum size supported is 4GB"]
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": [
+                {
+                  "version_added": "8",
+                  "notes": ["The maximum size supported is 32kB"]
+                },
+                {
+                  "version_added": "9",
+                  "notes": ["The maximum size supported is 4GB"]
+                }
+              ],
+              "ie_mobile": {
+                "version_added": true,
+                "notes": ["The maximum size supported is 4GB"]
+              },
+              "opera": {
+                "version_added": "7.20"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          },
+          "html_files": {
+            "desc": "HTML files",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          },
+          "js_files": {
+            "desc": "JavaScript files",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12",
+                "notes": ["The maximum size supported is 4GB"]
+              },
+              "edge_mobile": {
+                "version_added": true,
+                "notes": ["The maximum size supported is 4GB"]
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9",
+                "notes": ["The maximum size supported is 4GB"]
+              },
+              "ie_mobile": {
+                "version_added": true,
+                "notes": ["The maximum size supported is 4GB"]
               },
               "opera": {
                 "version_added": "7.20"


### PR DESCRIPTION
If I see it correctly, this page is the last one in the MDN HTTP area that uses the old style (static) compat table :-)

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs