### PR TITLE
Fix WebGL buffer typos

### DIFF
--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -2,8 +2,8 @@
   "version": "1.0.0",
   "data": {
     "api": {
-      "WebGLFrameBuffer": {
-        "WebGLFrameBuffer": {
+      "WebGLFramebuffer": {
+        "WebGLFramebuffer": {
           "__compat": {
             "basic_support": {
               "support": {

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -2,8 +2,8 @@
   "version": "1.0.0",
   "data": {
     "api": {
-      "WebGLRenderBuffer": {
-        "WebGLRenderBuffer": {
+      "WebGLRenderbuffer": {
+        "WebGLRenderbuffer": {
           "__compat": {
             "basic_support": {
               "support": {


### PR DESCRIPTION
I made this mistake 100 times already when documenting these APIs.

https://developer.mozilla.org/en-US/docs/Web/API/WebGLFramebuffer
https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderbuffer

I wonder if we could/should make the {{compat("api.WebGLFramebuffer")}} call case-insensitive. If we won't, this is at least making sure we always have the identifiers correct (nothing is rendered otherwise).