### PR TITLE
Add Upgrade-Insecure-Requests header support for Opera

### DIFF
--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -36,10 +36,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "31"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "31"
                 },
                 "safari": {
                   "version_added": null


### PR DESCRIPTION
While I was researching the `Upgrade-Insecure-Requests` header, I confirm that Opera 31 adds support for it