### PR TITLE
Add Chrome/Opera version supporting `devtools.panels.themeName`

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2273,7 +2273,7 @@
                 "basic_support": {
                   "support": {
                     "chrome": {
-                      "version_added": true
+                      "version_added": "54"
                     },
                     "edge": {
                       "version_added": false
@@ -2285,7 +2285,7 @@
                       "version_added": false
                     },
                     "opera": {
-                      "version_added": true
+                      "version_added": "41"
                     }
                   }
                 }


### PR DESCRIPTION
I checked https://chromium.googlesource.com/chromium/src/+/426dd8915fd31f70e7dcb37de79e3975a66b72fd/chrome/VERSION and self-verified

I commented on https://bugs.chromium.org/p/chromium/issues/detail?id=608869#c8 to fix the [official Chrome doc](https://developer.chrome.com/extensions/devtools_panels#property-themeName)