### PR TITLE
Corrected compatibility data for webRequest.ResourceType

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -9257,7 +9257,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": true
+                    "version_added": false
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -9267,6 +9267,25 @@
                   },
                   "opera": {
                     "version_added": "33"
+                  }
+                }
+              },
+              "object_subrequest": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "55.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "55.0"
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }


### PR DESCRIPTION
Before Firefox 55, `object_subrequest` is not exposed in `webRequest.ResourceType` ([Bug 1366862](https://bugzilla.mozilla.org/show_bug.cgi?id=1366862)).

On Microsoft Edge, `webRequest.ResourceType` doesn't exist at all, so far.