### PR TITLE
Added more fine-grained compatibility information for webRequest.ResourceType

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -9296,7 +9296,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "44"
                   },
                   "edge": {
                     "version_added": false
@@ -9308,7 +9308,222 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "31"
+                  }
+                }
+              },
+              "ping": {
+                "support": {
+                  "chrome": {
+                    "version_added": "49",
+                    "notes": [
+                      "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
+                    ]
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "36",
+                    "notes": [
+                      "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
+                    ]
+                  }
+                }
+              },
+              "font": {
+                "support": {
+                  "chrome": {
+                    "version_added": "49"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "36"
+                  }
+                }
+              },
+              "media": {
+                "support": {
+                  "chrome": {
+                    "version_added": "58"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "45"
+                  }
+                }
+              },
+              "websocket": {
+                "support": {
+                  "chrome": {
+                    "version_added": "58"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "45"
+                  }
+                }
+              },
+              "csp_report": {
+                "support": {
+                  "chrome": {
+                    "version_added": "58"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "45"
+                  }
+                }
+              },
+              "xbl": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "xslt": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "beacon": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "xml_dtd": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "imageset": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
+              "web_manifest": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               },
@@ -9321,10 +9536,16 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "55.0"
+                    "version_added": "55.0",
+                    "notes": [
+                      "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                    ]
                   },
                   "firefox_android": {
-                    "version_added": "55.0"
+                    "version_added": "55.0",
+                    "notes": [
+                      "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                    ]
                   },
                   "opera": {
                     "version_added": false


### PR DESCRIPTION
* `webRequest.ResourceType` was added in Chrome 44 (respectively Opera 31).
* [`ping` and `font`](https://bugs.chromium.org/p/chromium/issues/detail?id=410382#c39) were added in Chrome 49 (respectively Opera 36).
* [`media`, `websocket`](https://bugs.chromium.org/p/chromium/issues/detail?id=129353#c83) and [`csp_report`](https://bugs.chromium.org/p/chromium/issues/detail?id=637577#c26) were added in Chrome 58 (respectively Opera 45).
* `xbl`, `xslt`, `beacon`, `xml_dtd`, `imageset` and `web_manifest` only exist in Firefox.