### PR TITLE
Added more detailed compatibility information for runtime.onMessage.sender

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -6084,6 +6084,45 @@
           },
           "onMessage": {
             "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "MessageSender.url": {
+                "support": {
+                  "chrome": {
+                    "version_added": "28"
+                  },
+                  "edge": {
+                    "version_added": true,
+                    "notes": ["The `url` is missing when the message was sent by an extension view."]
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "48.0"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
               "MessageSender.tlsChannelId": {
                 "support": {
                   "chrome": {
@@ -6103,10 +6142,10 @@
                   }
                 }
               },
-              "basic_support": {
+              "MessageSender.frameId": {
                 "support": {
                   "chrome": {
-                    "version_added": "26"
+                    "version_added": "41"
                   },
                   "edge": {
                     "version_added": true
@@ -6118,7 +6157,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "15"
+                    "version_added": "28"
                   }
                 }
               }


### PR DESCRIPTION
As per [Chrome's documentation](https://developer.chrome.com/extensions/runtime#type-MessageSender), `MessageSender.url` was added in Chrome 28, and `MessageSender.frameId` was added in Chrome 41.

Moreover, on Microsoft Edge, `MessageSender.url` is missing if the message was sent by an extension view (like the options page or browser action popup).

I also sorted the features in the order they were introduced, like done everywhere else.