### PR TITLE
Bug 1325113: WEBGL_compressed_texture_s3tc_srgb now in Firefox

### DIFF
--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -1,0 +1,59 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "WEBGL_compressed_texture_s3tc_srgb": {
+        "__compat": {
+          "basic_support": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "obsolete": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1325113
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_s3tc_srgb
https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/