### PR TITLE
Add builtins folder and JS Date data

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1210,7 +1210,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "obsolete": true
                 }
               }
             }
@@ -2359,7 +2359,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "obsolete": true
                 }
               }
             }
@@ -2469,7 +2469,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "obsolete": true
                 }
               }
             }
@@ -2843,7 +2843,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": false
+                  "obsolete": true
                 }
               }
             }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1,0 +1,3548 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "javascript": {
+      "builtins": {
+        "Date": {
+          "Date": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true,
+                    "notes": "The <a href=\"https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript\">ISO8601 Date Format</a> is not supported in Internet Explorer 8."
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "prototype": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "ordinary_object": {
+                "desc": "Ordinary object (ES2015)",
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "41"
+                  },
+                  "firefox_android": {
+                    "version_added": "41"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "UTC": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "now": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "5"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "3"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": "9"
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "10.5"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "4"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "parse": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "iso_8601": {
+                "desc": "ISO 8601 format",
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "4"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": "9"
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getDate": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getDay": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getFullYear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getHours": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getMilliseconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getMinutes": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getMonth": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getSeconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getTime": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getTimezoneOffset": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": "5"
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCDate": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCDay": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCFullYear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCHours": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCMilliseconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCMinutes": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCMonth": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getUTCSeconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "getYear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setDate": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setFullYear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setHours": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setMilliseconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setMinutes": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setMonth": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setSeconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setTime": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setUTCDate": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setUTCFullYear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setUTCHours": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setUTCMilliseconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setUTCMinutes": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setUTCMonth": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setUTCSeconds": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "setYear": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toDateString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toGMTString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toISOString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toJSON": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": "8"
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toLocaleDateString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "locales": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "options": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "iana_time_zone_names": {
+                "desc": "IANA time zone names in <code>timeZone</code> option",
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toLocaleFormat": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toLocaleString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "locales": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "options": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "iana_time_zone_names": {
+                "desc": "IANA time zone names in <code>timeZone</code> option",
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toLocaleTimeString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "locales": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "options": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "iana_time_zone_names": {
+                "desc": "IANA time zone names in <code>timeZone</code> option",
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toSource": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toTimeString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toUTCString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "valueOf": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "@@toPrimitive": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "44"
+                  },
+                  "firefox_android": {
+                    "version_added": "44"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -4,6 +4,61 @@
     "javascript": {
       "builtins": {
         "Date": {
+          "@@toPrimitive": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "44"
+                  },
+                  "firefox_android": {
+                    "version_added": "44"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
           "Date": {
             "__compat": {
               "basic_support": {
@@ -60,113 +115,6 @@
               }
             }
           },
-          "prototype": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              },
-              "ordinary_object": {
-                "desc": "Ordinary object (ES2015)",
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "41"
-                  },
-                  "firefox_android": {
-                    "version_added": "41"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              }
-            }
-          },
           "UTC": {
             "__compat": {
               "basic_support": {
@@ -200,168 +148,6 @@
                   },
                   "nodejs": {
                     "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              }
-            }
-          },
-          "now": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "5"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "3"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "10.5"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "4"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              }
-            }
-          },
-          "parse": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              },
-              "iso_8601": {
-                "desc": "ISO 8601 format",
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "4"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": null
                   },
                   "opera": {
                     "version_added": true
@@ -1429,6 +1215,275 @@
               }
             }
           },
+          "now": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "5"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "3"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": "9"
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "10.5"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "4"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "parse": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "iso_8601": {
+                "desc": "ISO 8601 format",
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "4"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": "9"
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "prototype": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "ordinary_object": {
+                "desc": "Ordinary object (ES2015)",
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "41"
+                  },
+                  "firefox_android": {
+                    "version_added": "41"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
           "setDate": {
             "__compat": {
               "basic_support": {
@@ -2445,7 +2500,7 @@
                     "version_added": true
                   },
                   "ie": {
-                    "version_added": true
+                    "version_added": "9"
                   },
                   "ie_mobile": {
                     "version_added": true
@@ -3476,61 +3531,6 @@
                   },
                   "safari_ios": {
                     "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              }
-            }
-          },
-          "@@toPrimitive": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "44"
-                  },
-                  "firefox_android": {
-                    "version_added": "44"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
                   }
                 },
                 "status": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -3,7 +3,7 @@
   "data": {
     "javascript": {
       "builtins": {
-        "promise": {
+        "Promise": {
           "Promise": {
             "__compat": {
               "basic_support": {


### PR DESCRIPTION
- Moved builtins into a builtins folder (e.g. `function` is a builtin object, a statement, and an expression, so there would be conflicts if things would be all under the same folder)
- Added Date data https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
- Renamed to uppercase `Promise` namespace to be consistent with what we have in API data.