### PR TITLE
Marked deprecated APIs as obsolete

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3110,6 +3110,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -3133,6 +3138,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -3271,6 +3281,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -3294,6 +3309,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -3317,6 +3337,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -6003,6 +6028,11 @@
                   "opera": {
                     "version_added": "15"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -7151,6 +7181,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               },
               "cookieStoreId": {
@@ -7449,6 +7484,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -7590,6 +7630,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -7636,6 +7681,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -7835,6 +7885,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -7927,6 +7982,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -8048,6 +8108,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -8317,6 +8382,11 @@
                   "opera": {
                     "version_added": false
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -8462,6 +8532,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }


### PR DESCRIPTION
According to Chrome's documentation following APIs are deprecated:

* [`extension.getExtensionTabs`](https://developer.chrome.com/extensions/extension#method-getExtensionTabs)
* [`extension.getURL`](https://developer.chrome.com/extensions/extension#method-getURL)
* [`extension.onRequest`](https://developer.chrome.com/extensions/extension#event-onRequest)
* [`extension.onRequestExternal`](https://developer.chrome.com/extensions/extension#event-onRequestExternal)
* [`extension.sendRequest`](https://developer.chrome.com/extensions/extension#method-sendRequest)
* [`runtime.onBrowserUpdateAvailable`](https://developer.chrome.com/extensions/runtime#event-onBrowserUpdateAvailable)
* [`tabs.Tab.selected`](https://developer.chrome.com/extensions/tabs#property-Tab-selected) (along the corresponding option in related APIs)
* [`tabs.getAllInWindow`](https://developer.chrome.com/extensions/tabs#method-getAllInWindow)
* [`tabs.getSelected`](https://developer.chrome.com/extensions/tabs#method-getSelected)
* [`tabs.onActiveChanged`](https://developer.chrome.com/extensions/tabs#event-onActiveChanged)
* [`tabs.onHighlightChanged`](https://developer.chrome.com/extensions/tabs#event-onHighlightChanged)
* [`tabs.onSelectionChanged`](https://developer.chrome.com/extensions/tabs#event-onSelectionChanged)
* [`tabs.sendRequest`](https://developer.chrome.com/extensions/tabs#method-sendRequest)