### PR TITLE
Correct Opera compatiblity information

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -21,7 +21,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -44,7 +44,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -67,7 +67,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -90,7 +90,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -113,7 +113,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -136,7 +136,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -159,7 +159,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -184,7 +184,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -207,7 +207,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -230,7 +230,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -253,7 +253,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -276,7 +276,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -299,7 +299,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -322,7 +322,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -345,7 +345,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -368,7 +368,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -391,7 +391,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -414,7 +414,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -437,7 +437,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -460,7 +460,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -483,7 +483,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -506,7 +506,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -529,7 +529,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -552,7 +552,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -575,7 +575,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -598,7 +598,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -621,7 +621,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -644,7 +644,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -669,7 +669,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -692,7 +692,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -715,7 +715,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -738,7 +738,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -761,7 +761,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -784,7 +784,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -807,7 +807,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -830,7 +830,7 @@
                     "version_added": "55"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -853,7 +853,7 @@
                     "version_added": "55"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -876,7 +876,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -899,7 +899,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -922,7 +922,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -945,7 +945,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -968,7 +968,7 @@
                     "version_added": "55"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -993,7 +993,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1016,7 +1016,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               },
@@ -1035,7 +1035,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               },
@@ -1054,7 +1054,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1081,7 +1081,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1107,7 +1107,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1133,7 +1133,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1159,7 +1159,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1185,7 +1185,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1211,7 +1211,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1237,7 +1237,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1263,7 +1263,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1286,7 +1286,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -1311,7 +1311,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1334,7 +1334,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1357,7 +1357,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1382,7 +1382,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1408,7 +1408,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -1430,7 +1430,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -1449,7 +1449,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -1468,7 +1468,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -1529,7 +1529,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1552,7 +1552,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -1606,7 +1606,7 @@
                     "notes": [
                       "Items that don't specify 'contexts' do not inherit contexts from their parents."
                     ],
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -1648,7 +1648,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1671,7 +1671,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1694,7 +1694,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1717,7 +1717,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1882,7 +1882,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1905,7 +1905,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1928,7 +1928,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1951,7 +1951,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -1977,7 +1977,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2003,7 +2003,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2026,7 +2026,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2049,7 +2049,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2072,7 +2072,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2311,7 +2311,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2334,7 +2334,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2357,7 +2357,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2380,7 +2380,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2403,7 +2403,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2426,7 +2426,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2449,7 +2449,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -2468,7 +2468,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2491,7 +2491,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2514,7 +2514,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2537,7 +2537,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2560,7 +2560,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2583,7 +2583,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2606,7 +2606,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -2625,7 +2625,7 @@
                     "version_added": "52.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -2644,7 +2644,7 @@
                     "version_added": "52.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2667,7 +2667,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2690,7 +2690,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2713,7 +2713,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2736,7 +2736,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2759,7 +2759,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2782,7 +2782,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2805,7 +2805,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2828,7 +2828,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2851,7 +2851,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2874,7 +2874,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2897,7 +2897,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2920,7 +2920,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2943,7 +2943,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2966,7 +2966,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -2991,7 +2991,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3014,7 +3014,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3037,7 +3037,7 @@
                     "version_added": "50.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3062,7 +3062,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3085,7 +3085,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3136,7 +3136,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 },
                 "status": {
@@ -3164,7 +3164,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3187,7 +3187,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3210,7 +3210,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3233,7 +3233,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3256,7 +3256,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3279,7 +3279,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 },
                 "status": {
@@ -3307,7 +3307,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 },
                 "status": {
@@ -3363,7 +3363,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3388,7 +3388,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3411,7 +3411,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3434,7 +3434,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               },
@@ -3453,7 +3453,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }
@@ -3476,7 +3476,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3501,7 +3501,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -3520,7 +3520,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3543,7 +3543,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3566,7 +3566,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3589,7 +3589,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -3669,7 +3669,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3692,7 +3692,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3715,7 +3715,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3738,7 +3738,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3761,7 +3761,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3784,7 +3784,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3807,7 +3807,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3832,7 +3832,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3855,7 +3855,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3878,7 +3878,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3901,7 +3901,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -3997,7 +3997,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4020,7 +4020,7 @@
                     "version_added": "51"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -4039,7 +4039,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4068,7 +4068,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -4087,7 +4087,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4110,7 +4110,7 @@
                     "version_added": "51"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4549,7 +4549,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4581,7 +4581,7 @@
                     "notes": [
                       "Only the 'basic' type is supported."
                     ],
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4604,7 +4604,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4627,7 +4627,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4650,7 +4650,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4673,7 +4673,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4696,7 +4696,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4719,7 +4719,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -4738,7 +4738,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4764,7 +4764,7 @@
                     "notes": [
                       "Not supported on Macs."
                     ],
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4958,7 +4958,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -4984,7 +4984,7 @@
                     "version_added": "50.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5007,7 +5007,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5033,7 +5033,7 @@
                     "version_added": "50.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5056,7 +5056,7 @@
                     "version_added": "50.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5079,7 +5079,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -5098,7 +5098,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5124,7 +5124,7 @@
                     "version_added": "50.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5147,7 +5147,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -5173,7 +5173,7 @@
                     "version_added": "50.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6528,7 +6528,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6551,7 +6551,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6577,7 +6577,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6600,7 +6600,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6623,7 +6623,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6646,7 +6646,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6811,7 +6811,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6952,7 +6952,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -6978,7 +6978,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7024,7 +7024,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7072,7 +7072,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7095,7 +7095,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7118,7 +7118,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7141,7 +7141,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7160,7 +7160,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7179,7 +7179,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 },
                 "status": {
@@ -7222,7 +7222,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7245,7 +7245,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7268,7 +7268,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7291,7 +7291,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7314,7 +7314,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7337,7 +7337,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7360,7 +7360,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7383,7 +7383,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7425,7 +7425,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7463,7 +7463,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7482,7 +7482,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7501,7 +7501,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 },
                 "status": {
@@ -7529,7 +7529,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7552,7 +7552,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7582,7 +7582,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7601,7 +7601,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7624,7 +7624,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7675,7 +7675,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7726,7 +7726,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7749,7 +7749,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7795,7 +7795,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -7833,7 +7833,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7856,7 +7856,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7879,7 +7879,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7930,7 +7930,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7953,7 +7953,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -7976,7 +7976,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8050,7 +8050,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8073,7 +8073,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8102,7 +8102,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8153,7 +8153,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -8172,7 +8172,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8195,7 +8195,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8227,7 +8227,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -8265,7 +8265,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8288,7 +8288,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8311,7 +8311,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8376,7 +8376,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -8446,7 +8446,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8469,7 +8469,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8492,7 +8492,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -8511,7 +8511,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -8530,7 +8530,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -8549,7 +8549,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -8568,7 +8568,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 },
                 "status": {
@@ -8598,7 +8598,7 @@
                     "version_added": "52.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8621,7 +8621,7 @@
                     "version_added": "52.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -8696,7 +8696,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -8715,7 +8715,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -8744,7 +8744,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -8767,7 +8767,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -8790,7 +8790,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -8830,7 +8830,7 @@
                     "notes": [
                       "If the filter parameter is empty, Opera matches all URLs."
                     ],
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -8870,7 +8870,7 @@
                     "notes": [
                       "If the filter parameter is empty, Opera matches all URLs."
                     ],
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -8889,7 +8889,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -8908,7 +8908,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -8948,7 +8948,7 @@
                     "notes": [
                       "If the filter parameter is empty, Opera matches all URLs."
                     ],
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -8977,7 +8977,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -8996,7 +8996,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -9036,7 +9036,7 @@
                     "notes": [
                       "If the filter parameter is empty, Opera matches all URLs."
                     ],
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -9076,7 +9076,7 @@
                     "notes": [
                       "If the filter parameter is empty, Opera matches all URLs."
                     ],
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -9095,7 +9095,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -9121,7 +9121,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -9140,7 +9140,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -9159,7 +9159,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -9199,7 +9199,7 @@
                     "notes": [
                       "If the filter parameter is empty, Opera matches all URLs."
                     ],
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -9218,7 +9218,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               },
@@ -9237,7 +9237,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -9266,7 +9266,7 @@
                     "version_added": "48"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": "17"
                   }
                 }
               }
@@ -9291,7 +9291,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -9314,7 +9314,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -9337,7 +9337,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -9360,7 +9360,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9379,7 +9379,7 @@
                     "version_added": "53.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9398,7 +9398,7 @@
                     "version_added": "53.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -9684,7 +9684,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -9707,7 +9707,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -9730,7 +9730,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9755,7 +9755,7 @@
                     "version_added": "54"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -9778,7 +9778,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9835,7 +9835,7 @@
                     "notes": [
                       "Asynchronous event listeners are not supported."
                     ],
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9854,7 +9854,7 @@
                     "version_added": "53.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9911,7 +9911,7 @@
                     "notes": [
                       "Asynchronous event listeners are not supported."
                     ],
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9953,7 +9953,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -9995,7 +9995,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -10054,7 +10054,7 @@
                     "notes": [
                       "Asynchronous event listeners are not supported."
                     ],
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -10096,7 +10096,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -10138,7 +10138,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -10182,7 +10182,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10205,7 +10205,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10228,7 +10228,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10251,7 +10251,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -10270,7 +10270,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10293,7 +10293,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10316,7 +10316,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10344,7 +10344,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               },
@@ -10363,7 +10363,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10386,7 +10386,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10409,7 +10409,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10432,7 +10432,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10455,7 +10455,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10478,7 +10478,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10501,7 +10501,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10524,7 +10524,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10547,7 +10547,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }
@@ -10570,7 +10570,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "33"
+                    "version_added": true
                   }
                 }
               }


### PR DESCRIPTION
Opera 15 is the first version that supported Chrome-like extensions, still `opera.version_added` is set to 33 for most APIs and features, even if the Chrome version in which they were added is unknown. So with this pull request, I set `opera.version_added` to `true` for all features where `chrome.version_added` is set to `true`, with the exception of the [documented differences](https://dev.opera.com/extensions/apis/).

However, for all features in the `webNavigation` API, I set `opera.version_added` to 17. Despite not being documented in the Opera documentation, I remember (from my work on Adblock Plus) that Opera 17 was the first version that had the `webNavigation` API (despite the Chromium version earlier Opera versions were based on had the `webNavigation` API already).

For reference, in the cases where `chrome.version_added` is set to a version string, `opera.version_added` is already set to the respective version of Opera. I checked that.