### PR TITLE
Add JS Math and Number compat data

### DIFF
--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -59,61 +59,6 @@
               }
             }
           },
-          "LN10": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              }
-            }
-          },
           "LN2": {
             "__compat": {
               "basic_support": {
@@ -169,7 +114,7 @@
               }
             }
           },
-          "LOG10E": {
+          "LN10": {
             "__compat": {
               "basic_support": {
                 "support": {
@@ -225,6 +170,61 @@
             }
           },
           "LOG2E": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "LOG10E": {
             "__compat": {
               "basic_support": {
                 "support": {
@@ -1544,61 +1544,6 @@
               }
             }
           },
-          "log10": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              }
-            }
-          },
           "log1p": {
             "__compat": {
               "basic_support": {
@@ -1655,6 +1600,61 @@
             }
           },
           "log2": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "log10": {
             "__compat": {
               "basic_support": {
                 "support": {

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1,0 +1,2376 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "javascript": {
+      "builtins": {
+        "Math": {
+          "E": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "LN10": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "LN2": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "LOG10E": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "LOG2E": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "PI": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "SQRT1_2": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "SQRT2": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "abs": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "acos": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "acosh": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "asin": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "asinh": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "atan": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "atan2": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "atanh": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "cbrt": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "ceil": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "clz32": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "31"
+                  },
+                  "firefox_android": {
+                    "version_added": "31"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "cos": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "cosh": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "exp": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "expm1": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "floor": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "fround": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "26"
+                  },
+                  "firefox_android": {
+                    "version_added": "26"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "hypot": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "27"
+                  },
+                  "firefox_android": {
+                    "version_added": "27"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "imul": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "28"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "20"
+                  },
+                  "firefox_android": {
+                    "version_added": "20"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "16"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7"
+                  },
+                  "safari_ios": {
+                    "version_added": "7"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "log": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "log10": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "log1p": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "log2": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "max": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "min": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "pow": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "random": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "round": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "sign": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "sin": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "sinh": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "sqrt": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "tan": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "tanh": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "trunc": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "38"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "25"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "7.1"
+                  },
+                  "safari_ios": {
+                    "version_added": "8"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -1,0 +1,1445 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "javascript": {
+      "builtins": {
+        "Number": {
+          "Number": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "EPSILON": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": "9"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "MAX_SAFE_INTEGER": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "34"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "31"
+                  },
+                  "firefox_android": {
+                    "version_added": "31"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": "9"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "MAX_VALUE": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "MIN_SAFE_INTEGER": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "34"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "31"
+                  },
+                  "firefox_android": {
+                    "version_added": "31"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": "9"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "MIN_VALUE": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "NEGATIVE_INFINITY": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "NaN": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "POSITIVE_INFINITY": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "prototype": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "isFinite": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "19"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "16"
+                  },
+                  "firefox_android": {
+                    "version_added": "16"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "isInteger": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "16"
+                  },
+                  "firefox_android": {
+                    "version_added": "16"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "isNaN": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "25"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "15"
+                  },
+                  "firefox_android": {
+                    "version_added": "15"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": "9"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "isSafeInteger": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "32"
+                  },
+                  "firefox_android": {
+                    "version_added": "32"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "parseFloat": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": "9"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "parseInt": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "25"
+                  },
+                  "firefox_android": {
+                    "version_added": "25"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "9"
+                  },
+                  "safari_ios": {
+                    "version_added": "9"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toExponential": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toFixed": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toLocaleString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "locales": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              },
+              "options": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toPrecision": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toSource": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toString": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "valueOf": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
+          "toInteger": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "16",
+                      "version_removed": "32"
+                    },
+                    {
+                      "version_added": false
+                    }
+                  ],
+                  "firefox_android": [
+                    {
+                      "version_added": "16",
+                      "version_removed": "32"
+                    },
+                    {
+                      "version_added": false
+                    }
+                  ],
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -4,61 +4,6 @@
     "javascript": {
       "builtins": {
         "Number": {
-          "Number": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "obsolete": false
-                }
-              }
-            }
-          },
           "EPSILON": {
             "__compat": {
               "basic_support": {
@@ -444,7 +389,7 @@
               }
             }
           },
-          "POSITIVE_INFINITY": {
+          "Number": {
             "__compat": {
               "basic_support": {
                 "support": {
@@ -499,7 +444,7 @@
               }
             }
           },
-          "prototype": {
+          "POSITIVE_INFINITY": {
             "__compat": {
               "basic_support": {
                 "support": {
@@ -884,6 +829,61 @@
               }
             }
           },
+          "prototype": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "obsolete": false
+                }
+              }
+            }
+          },
           "toExponential": {
             "__compat": {
               "basic_support": {
@@ -990,6 +990,73 @@
                   "experimental": false,
                   "standard_track": true,
                   "obsolete": false
+                }
+              }
+            }
+          },
+          "toInteger": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "16",
+                      "version_removed": "32"
+                    },
+                    {
+                      "version_added": false
+                    }
+                  ],
+                  "firefox_android": [
+                    {
+                      "version_added": "16",
+                      "version_removed": "32"
+                    },
+                    {
+                      "version_added": false
+                    }
+                  ],
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
                 }
               }
             }
@@ -1367,73 +1434,6 @@
                   "experimental": false,
                   "standard_track": true,
                   "obsolete": false
-                }
-              }
-            }
-          },
-          "toInteger": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": [
-                    {
-                      "version_added": "16",
-                      "version_removed": "32"
-                    },
-                    {
-                      "version_added": false
-                    }
-                  ],
-                  "firefox_android": [
-                    {
-                      "version_added": "16",
-                      "version_removed": "32"
-                    },
-                    {
-                      "version_added": false
-                    }
-                  ],
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "obsolete": true
                 }
               }
             }

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -1013,24 +1013,14 @@
                   "edge_mobile": {
                     "version_added": false
                   },
-                  "firefox": [
-                    {
-                      "version_added": "16",
-                      "version_removed": "32"
-                    },
-                    {
-                      "version_added": false
-                    }
-                  ],
-                  "firefox_android": [
-                    {
-                      "version_added": "16",
-                      "version_removed": "32"
-                    },
-                    {
-                      "version_added": false
-                    }
-                  ],
+                  "firefox": {
+                    "version_added": "16",
+                    "version_removed": "32"
+                  },
+                  "firefox_android": {
+                    "version_added": "16",
+                    "version_removed": "32"
+                  },
                   "ie": {
                     "version_added": false
                   },


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toInteger is a case I haven't had before: A feature that was supported in a range, but isn't anymore. It's also obsolete.