### PR TITLE
Added Chrome/Opera version info for includeTlsChannelId

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -6396,7 +6396,7 @@
               "options.includeTlsChannelId": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "32"
                   },
                   "edge": {
                     "version_added": false
@@ -6408,7 +6408,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "19"
                   }
                 }
               },


### PR DESCRIPTION
As of [Chrome's documentation](https://developer.chrome.com/extensions/runtime#property-sendMessage-options), the `includeTlsChannelId` option of `runtime.sendMessage()` was added in Chrome 32 (Opera 19 respectively).