### PR TITLE
Added compatibility information for the framId option of tabs.sendMessage and tabs.connect

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -7351,6 +7351,25 @@
                     "version_added": "33"
                   }
                 }
+              },
+              "connectInfo.frameId": {
+                "support": {
+                  "chrome": {
+                    "version_added": "41"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "28"
+                  }
+                }
               }
             }
           },
@@ -8293,6 +8312,25 @@
                   },
                   "opera": {
                     "version_added": "33"
+                  }
+                }
+              },
+              "options.frameId": {
+                "support": {
+                  "chrome": {
+                    "version_added": "41"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "28"
                   }
                 }
               }


### PR DESCRIPTION
As of Chrome's documentation, the `frameId` option of [`tabs.sendMessage()`](https://developer.chrome.com/extensions/tabs#property-sendMessage-options) and [`tabs.connect()`](https://developer.chrome.com/extensions/tabs#property-connectInfo-frameId) was added in Chrome 41 (Opera 28 respectively). It's [not yet supported](https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis#tabs) in Microsoft Edge.