### PR TITLE
Added more information on the setIcon() method of the browserAction and pageAction API

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -910,7 +910,10 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": true,
+                    "notes": [
+                      "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
+                    ]
                   },
                   "edge": {
                     "version_added": true
@@ -922,7 +925,26 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "15"
+                  }
+                }
+              },
+              "imageData": {
+                "support": {
+                  "chrome": {
+                    "version_added": "23"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
                   }
                 }
               }
@@ -5064,29 +5086,13 @@
           },
           "setIcon": {
             "__compat": {
-              "ImageData": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45.0"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": true,
+                    "notes": [
+                      "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
+                    ]
                   },
                   "edge": {
                     "version_added": true
@@ -5098,7 +5104,26 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "15"
+                  }
+                }
+              },
+              "imageData": {
+                "support": {
+                  "chrome": {
+                    "version_added": "23"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45.0"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
                   }
                 }
               }


### PR DESCRIPTION
* The `imageData` option was added to the [`browserAction`](https://developer.chrome.com/extensions/browserAction#type-ImageDataType) and [`pageAction`](https://developer.chrome.com/extensions/pageAction#type-ImageDataType) APIs in Chrome 23.
* Since Opera 15, which is based on Chromium 28, is the first Chromium-based Opera version, `opera.version_added` for `imageData` as well as "Basic support" consequently is Opera 15.
* Microsoft Edge does not support `imageData` This, however, was already indicated for `pageAction`, but `browserAction` missed any compatiblility information on the `imageData` option.
* Also, before Chrome 23, `path` always had to be a string.