### PR TITLE
Add correct Chrome/Opera versions and notes for Edge to i18n API

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3820,7 +3820,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "47"
                   },
                   "edge": {
                     "version_added": true
@@ -3832,7 +3832,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "34"
                   }
                 }
               }
@@ -3843,7 +3843,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "47"
                   },
                   "edge": {
                     "version_added": false
@@ -3855,7 +3855,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "34"
                   }
                 }
               }
@@ -3866,7 +3866,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "47"
                   },
                   "edge": {
                     "version_added": true
@@ -3878,7 +3878,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "34"
                   }
                 }
               }
@@ -3889,10 +3889,14 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "17"
                   },
                   "edge": {
-                    "version_added": true
+                    "version_added": true,
+                    "notes": [
+                      "Throws an exception instead returning an empty string if the message does not exist.",
+                      "Expects substitutions to be strings, while other browsers allow any value which is then converted to a string."
+                    ]
                   },
                   "firefox": {
                     "version_added": "45.0"
@@ -3901,7 +3905,7 @@
                     "version_added": "48.0"
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "15"
                   }
                 }
               }
@@ -3912,7 +3916,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "35"
                   },
                   "edge": {
                     "version_added": true


### PR DESCRIPTION
According to [Chrome's documentation](https://developer.chrome.com/extensions/i18n):

* `LanguageCode` was introduced in Chrome 47 (respectively Opera 34). Since `i18n.getAcceptLanguages` gives an array of `LanguageCode` it certainly was added at the same time.
* `i18n.getUILanguage` was added in Chrome 35 (it [does not exist in Opera](https://dev.opera.com/extensions/apis/)).
* `i18n.detectLanugage` was added in Chrome 47 (respectively Opera 34).
* The only other method here is `i18n.getMessage()`, and since the _Availability_ at the top of the documentation page states Chrome 17, this is when it had to be introduced.
* [On Microsoft Edge](https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis#i18n), `i18n.getMessage`has some limitations which I added as notes.