### PR TITLE
Unify Firefox versions in WebExtension data

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -15,10 +15,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -38,10 +38,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -61,10 +61,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -84,10 +84,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -107,10 +107,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -130,10 +130,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -153,10 +153,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -178,7 +178,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -201,7 +201,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -224,7 +224,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -247,7 +247,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -270,7 +270,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -293,7 +293,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -316,7 +316,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -339,7 +339,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -362,7 +362,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -385,7 +385,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -408,7 +408,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -454,7 +454,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -523,7 +523,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -546,7 +546,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -569,7 +569,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -592,7 +592,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -615,7 +615,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -638,7 +638,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -663,7 +663,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -686,7 +686,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -709,7 +709,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -732,7 +732,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -755,7 +755,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -778,7 +778,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -801,7 +801,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -824,7 +824,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "55"
@@ -847,7 +847,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "55"
@@ -870,7 +870,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -893,7 +893,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -919,7 +919,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -938,7 +938,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -961,7 +961,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -984,7 +984,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "55"
@@ -1009,7 +1009,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1032,7 +1032,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1097,7 +1097,7 @@
                       "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.",
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1123,7 +1123,7 @@
                     "notes": [
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1149,7 +1149,7 @@
                     "notes": [
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1175,7 +1175,7 @@
                     "notes": [
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1201,7 +1201,7 @@
                     "notes": [
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1227,7 +1227,7 @@
                     "notes": [
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1253,7 +1253,7 @@
                     "notes": [
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1279,7 +1279,7 @@
                     "notes": [
                       "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1302,7 +1302,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1327,7 +1327,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1350,7 +1350,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1373,7 +1373,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1398,7 +1398,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1424,7 +1424,7 @@
                     "notes": [
                       "'The 'editable' context does not include password fields. Use the 'password' context for this."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1446,7 +1446,7 @@
                     "notes": [
                       "'The 'editable' context does not include password fields. Use the 'password' context for this."
                     ],
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1465,7 +1465,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1484,7 +1484,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1503,7 +1503,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1522,7 +1522,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1545,7 +1545,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1568,7 +1568,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1587,7 +1587,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "54.0"
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1619,7 +1619,7 @@
                     "notes": [
                       "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1664,7 +1664,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1687,7 +1687,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1710,7 +1710,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1733,7 +1733,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1758,10 +1758,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -1781,10 +1781,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -1804,10 +1804,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -1827,10 +1827,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -1850,10 +1850,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -1873,10 +1873,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -1898,10 +1898,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -1921,10 +1921,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -1944,10 +1944,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -1967,10 +1967,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -1993,10 +1993,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2019,10 +2019,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2042,10 +2042,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2065,10 +2065,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2088,10 +2088,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2327,10 +2327,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2350,10 +2350,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2373,10 +2373,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2396,10 +2396,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2419,10 +2419,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2442,10 +2442,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2465,10 +2465,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2507,10 +2507,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2530,10 +2530,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2553,10 +2553,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2599,10 +2599,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2622,10 +2622,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2641,10 +2641,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "opera": {
                     "version_added": true
@@ -2660,10 +2660,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "opera": {
                     "version_added": true
@@ -2706,10 +2706,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2752,10 +2752,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2775,10 +2775,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2798,10 +2798,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2821,10 +2821,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2844,10 +2844,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2867,10 +2867,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2890,10 +2890,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2913,10 +2913,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2959,10 +2959,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -2982,10 +2982,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3053,10 +3053,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "opera": {
                     "version_added": true
@@ -3078,10 +3078,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3101,10 +3101,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3152,10 +3152,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3180,10 +3180,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3203,10 +3203,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3226,10 +3226,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3249,10 +3249,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3272,10 +3272,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3404,10 +3404,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3427,10 +3427,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -3450,10 +3450,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -3475,7 +3475,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3517,7 +3517,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3540,7 +3540,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3563,7 +3563,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3582,7 +3582,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3601,7 +3601,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3620,7 +3620,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3643,7 +3643,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3666,7 +3666,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3689,7 +3689,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3712,7 +3712,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3735,7 +3735,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3758,7 +3758,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3781,7 +3781,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -3806,10 +3806,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "34"
@@ -3829,10 +3829,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "34"
@@ -3852,10 +3852,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "34"
@@ -3879,10 +3879,10 @@
                     ]
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -3902,10 +3902,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -3927,10 +3927,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -3950,10 +3950,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": true
@@ -3975,10 +3975,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4043,13 +4043,13 @@
                     "notes": [
                       "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4113,10 +4113,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "firefox_android": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "opera": {
                     "version_added": true
@@ -4310,10 +4310,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "firefox_android": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "opera": {
                     "version_added": false
@@ -4477,10 +4477,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "firefox_android": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "opera": {
                     "version_added": true
@@ -4496,10 +4496,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "firefox_android": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "opera": {
                     "version_added": false
@@ -4524,13 +4524,13 @@
                     "notes": [
                       "Only 'type', 'iconUrl', 'title', and 'message' are supported."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Only 'type', 'iconUrl', 'title', and 'message' are supported."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4553,13 +4553,13 @@
                     "notes": [
                       "Only the 'basic' type is supported."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Only the 'basic' type is supported."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -4582,10 +4582,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4605,10 +4605,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4628,10 +4628,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4674,10 +4674,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4697,10 +4697,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -4767,7 +4767,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4793,7 +4793,7 @@
                     "notes": [
                       "'description' is interpreted as plain text, and XML markup is not recognised."
                     ],
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4816,7 +4816,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4839,7 +4839,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4862,7 +4862,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4885,7 +4885,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4911,7 +4911,7 @@
                     "notes": [
                       "'description' is interpreted as plain text, and XML markup is not recognised."
                     ],
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4936,7 +4936,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -4959,13 +4959,13 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
                     ],
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "opera": {
                     "version_added": true
@@ -4985,7 +4985,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -5008,13 +5008,13 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "The 'tabId' parameter is ignored, and the page action is hidden for all tabs."
                     ],
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "opera": {
                     "version_added": true
@@ -5034,10 +5034,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "opera": {
                     "version_added": true
@@ -5060,7 +5060,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -5079,7 +5079,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -5102,13 +5102,13 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "The 'tabId' parameter is ignored, and the popup is set for all tabs."
                     ],
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "opera": {
                     "version_added": true
@@ -5128,7 +5128,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -5151,13 +5151,13 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "The 'tabId' parameter is ignored, and the page action is shown for all tabs."
                     ],
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "opera": {
                     "version_added": true
@@ -5523,13 +5523,13 @@
                     "notes": [
                       "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -5548,10 +5548,10 @@
                     ]
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -5567,10 +5567,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "19"
@@ -5586,10 +5586,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "28"
@@ -5609,10 +5609,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -5632,10 +5632,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -5655,10 +5655,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -5678,10 +5678,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -5720,10 +5720,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -5743,10 +5743,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -5766,10 +5766,10 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -5785,10 +5785,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "opera": {
                     "version_added": false
@@ -5831,10 +5831,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -5854,7 +5854,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -5877,10 +5877,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -5900,10 +5900,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "firefox_android": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "opera": {
                     "version_added": false
@@ -5923,10 +5923,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -5969,10 +5969,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "16"
@@ -5992,10 +5992,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6015,10 +6015,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6041,10 +6041,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -6095,10 +6095,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6144,13 +6144,13 @@
                     "notes": [
                       "This event is not triggered for temporarily installed add-ons."
                     ],
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "notes": [
                       "This event is not triggered for temporarily installed add-ons."
                     ],
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6170,10 +6170,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6239,10 +6239,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6308,10 +6308,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "firefox_android": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6331,7 +6331,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6354,10 +6354,10 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "firefox_android": {
-                    "version_added": "51.0"
+                    "version_added": "51"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6403,10 +6403,10 @@
                     ]
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "15"
@@ -6422,10 +6422,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "19"
@@ -6464,7 +6464,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "50.0"
+                    "version_added": "50"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6487,10 +6487,10 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "28"
@@ -6512,7 +6512,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6535,7 +6535,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6561,7 +6561,7 @@
                     "notes": [
                       "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
                     ],
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6584,7 +6584,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6607,7 +6607,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6630,7 +6630,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6655,7 +6655,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "54.0"
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6678,7 +6678,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "54.0"
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6701,7 +6701,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "54.0"
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6724,7 +6724,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "54.0"
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6747,7 +6747,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "54.0"
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6770,7 +6770,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "54.0"
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -6795,10 +6795,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -6936,10 +6936,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -6962,10 +6962,10 @@
                     "notes": [
                       "The storage API is supported in content scripts from version 48."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -7008,10 +7008,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -7031,10 +7031,10 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": false
@@ -7056,7 +7056,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7079,7 +7079,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7102,7 +7102,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7125,7 +7125,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7144,7 +7144,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7163,7 +7163,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7187,7 +7187,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7229,7 +7229,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7252,7 +7252,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7275,7 +7275,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7298,7 +7298,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7321,7 +7321,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7344,7 +7344,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7367,7 +7367,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7386,7 +7386,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7409,7 +7409,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7428,7 +7428,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7466,7 +7466,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7513,7 +7513,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7536,7 +7536,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7648,7 +7648,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7671,7 +7671,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7699,7 +7699,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7750,7 +7750,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7773,7 +7773,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7918,7 +7918,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "46.0"
+                    "version_added": "46"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -7941,7 +7941,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -7992,7 +7992,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8015,7 +8015,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8038,7 +8038,7 @@
                     "version_added": "15"
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8089,7 +8089,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8112,7 +8112,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -8135,7 +8135,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8161,7 +8161,7 @@
                     "notes": [
                       "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
@@ -8215,7 +8215,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8234,7 +8234,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8257,7 +8257,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -8286,7 +8286,7 @@
                     "notes": [
                       "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
@@ -8308,7 +8308,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -8327,7 +8327,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8350,7 +8350,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8373,7 +8373,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8396,7 +8396,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "49.0"
+                    "version_added": "49"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8422,7 +8422,7 @@
                     ]
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8441,7 +8441,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8492,7 +8492,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -8515,7 +8515,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -8538,7 +8538,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8576,7 +8576,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8595,7 +8595,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
@@ -8644,10 +8644,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "opera": {
                     "version_added": true
@@ -8667,10 +8667,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "firefox_android": {
-                    "version_added": "52.0"
+                    "version_added": "52"
                   },
                   "opera": {
                     "version_added": true
@@ -8739,13 +8739,13 @@
                     "notes": [
                       "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "notes": [
                       "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -8787,13 +8787,13 @@
                     "notes": [
                       "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
                     "notes": [
                       "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -8813,10 +8813,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -8836,10 +8836,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -8869,14 +8869,14 @@
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -8909,14 +8909,14 @@
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -8935,10 +8935,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -8954,10 +8954,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -8987,14 +8987,14 @@
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -9075,14 +9075,14 @@
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -9115,14 +9115,14 @@
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -9167,10 +9167,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "47.0"
+                    "version_added": "47"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -9186,10 +9186,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -9205,10 +9205,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -9238,14 +9238,14 @@
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Filtering is supported from version 50.",
                       "If the filter parameter is empty, Firefox raises an exception."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -9264,10 +9264,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -9283,10 +9283,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "17"
@@ -9337,10 +9337,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -9360,10 +9360,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -9383,10 +9383,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -9406,10 +9406,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -9425,10 +9425,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": true
@@ -9444,10 +9444,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": true
@@ -9467,10 +9467,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "31"
@@ -9489,10 +9489,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "36",
@@ -9511,10 +9511,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "36"
@@ -9530,10 +9530,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "45"
@@ -9549,10 +9549,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "45"
@@ -9568,10 +9568,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": "45"
@@ -9587,10 +9587,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9606,10 +9606,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9625,10 +9625,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9644,10 +9644,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9663,10 +9663,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9682,10 +9682,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9701,13 +9701,13 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "55.0",
+                    "version_added": "55",
                     "notes": [
                       "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
                     ]
                   },
                   "firefox_android": {
-                    "version_added": "55.0",
+                    "version_added": "55",
                     "notes": [
                       "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
                     ]
@@ -9730,10 +9730,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -9753,10 +9753,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -9824,10 +9824,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "46.0"
+                    "version_added": "46"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -9843,10 +9843,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9875,13 +9875,13 @@
                     "notes": [
                       "Asynchronous event listeners are supported from version 52."
                     ],
-                    "version_added": "46.0"
+                    "version_added": "46"
                   },
                   "firefox_android": {
                     "notes": [
                       "Asynchronous event listeners are supported from version 52."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -9900,10 +9900,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "firefox_android": {
-                    "version_added": "53.0"
+                    "version_added": "53"
                   },
                   "opera": {
                     "version_added": true
@@ -9919,10 +9919,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9951,13 +9951,13 @@
                     "notes": [
                       "Asynchronous event listeners are supported from version 52."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Asynchronous event listeners are supported from version 52."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -9976,10 +9976,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -9999,10 +9999,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -10018,10 +10018,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -10041,10 +10041,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -10060,10 +10060,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -10093,14 +10093,14 @@
                       "Modification of the 'Content-Type' header is supported from version 51.",
                       "Asynchronous event listeners are supported from version 52."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
                       "Modification of the 'Content-Type' header is supported from version 51.",
                       "Asynchronous event listeners are supported from version 52."
                     ],
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "notes": [
@@ -10119,10 +10119,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -10142,10 +10142,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -10161,10 +10161,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -10184,10 +10184,10 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": true
@@ -10203,10 +10203,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "firefox_android": {
-                    "version_added": "48.0"
+                    "version_added": "48"
                   },
                   "opera": {
                     "version_added": false
@@ -10228,7 +10228,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10251,7 +10251,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10274,7 +10274,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10297,7 +10297,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10316,7 +10316,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10339,7 +10339,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10362,7 +10362,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10390,7 +10390,7 @@
                       "'url' does not accept relative paths.",
                       "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
                     ],
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10432,7 +10432,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10455,7 +10455,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10478,7 +10478,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10501,7 +10501,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10524,7 +10524,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10547,7 +10547,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10570,7 +10570,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10593,7 +10593,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10616,7 +10616,7 @@
                     "version_added": true
                   },
                   "firefox": {
-                    "version_added": "45.0"
+                    "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": false


### PR DESCRIPTION
In `webextensions/javascript-apis.json` the `firefox` versions use the scheme `major.minor` (where `minor` is always `0`). Oddly enough, for `firefox_android` its sometimes just the major version, and sometimes `major.minor`. For other browsers, we always use only the major version. I looked through the compatibility data for the DOM and JavaScript APIs on MDN, and it seems that also for Firefox, only the major version is used. So this pull request makes the WebExtension data consistent.

The changes in this pull request were generated by following script:

```python
import sys
import json
from collections import OrderedDict

with open(sys.argv[1]) as file:
    data = json.load(file, object_pairs_hook=OrderedDict)

def foo(data):
    compat = data.get('__compat')
    if compat:
        for feature_data in compat.values():
            for browser_data in feature_data['support'].values():
                for key, value in browser_data.items():
                    if key.startswith('version_') and isinstance(value, str):
                        browser_data[key] = value.split('.')[0]
    else:
        for sub in data.values():
            foo(sub)

foo(data['data'])

with open(sys.argv[1], 'w') as file:
    json.dump(data, file, indent=2)
    print(file=file)
```