### PR TITLE
Added missing compatiblity information for Tab objects and related APIs

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -7198,6 +7198,63 @@
                   "obsolete": true
                 }
               },
+              "width, height": {
+                "support": {
+                  "chrome": {
+                    "version_added": "31"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "18"
+                  }
+                }
+              },
+              "audible": {
+                "support": {
+                  "chrome": {
+                    "version_added": "45"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "32"
+                  }
+                }
+              },
+              "mutedInfo": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
+              },
               "cookieStoreId": {
                 "support": {
                   "chrome": {
@@ -7220,7 +7277,7 @@
               "openerTabId": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": false
@@ -7232,7 +7289,64 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "15"
+                  }
+                }
+              },
+              "sessionId": {
+                "support": {
+                  "chrome": {
+                    "version_added": "31"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "18"
+                  }
+                }
+              },
+              "discarded": {
+                "support": {
+                  "chrome": {
+                    "version_added": "54"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "41"
+                  }
+                }
+              },
+              "autoDiscardable": {
+                "support": {
+                  "chrome": {
+                    "version_added": "54"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "41"
                   }
                 }
               }
@@ -7426,51 +7540,16 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": true
+                    "version_added": true,
+                    "notes": [
+                      "If the `url` has the `ms-browser-extension://` protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading."
+                    ]
                   },
                   "firefox": {
                     "version_added": "45"
                   },
                   "firefox_android": {
                     "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "cookieStoreId": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "openerTabId": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
                   },
                   "opera": {
                     "version_added": true
@@ -7496,6 +7575,25 @@
                   }
                 }
               },
+              "cookieStoreId": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              },
               "selected": {
                 "support": {
                   "chrome": {
@@ -7518,6 +7616,25 @@
                   "experimental": false,
                   "standard_track": false,
                   "obsolete": true
+                }
+              },
+              "openerTabId": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
                 }
               }
             }
@@ -8298,7 +8415,7 @@
                   },
                   "edge": {
                     "notes": [
-                      "The 'panel', 'app', and 'devtools' values for 'WindowType' are not supported."
+                      "The 'panel', 'app', 'devtools' and 'popup' values for 'WindowType' are not supported."
                     ],
                     "version_added": true
                   },
@@ -8316,6 +8433,139 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              },
+              "pinned": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "highlighted": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "index": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "currentWindow": {
+                "support": {
+                  "chrome": {
+                    "version_added": "19"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "lastFocusedWindow": {
+                "support": {
+                  "chrome": {
+                    "version_added": "19"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "audible": {
+                "support": {
+                  "chrome": {
+                    "version_added": "45"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "32"
+                  }
+                }
+              },
+              "muted": {
+                "support": {
+                  "chrome": {
+                    "version_added": "45"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "32"
                   }
                 }
               },
@@ -8338,22 +8588,41 @@
                   }
                 }
               },
-              "highlighted": {
+              "discarded": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "54"
                   },
                   "edge": {
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45"
+                    "version_added": false
                   },
                   "firefox_android": {
-                    "version_added": "54"
+                    "version_added": false
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "41"
+                  }
+                }
+              },
+              "autoDiscardable": {
+                "support": {
+                  "chrome": {
+                    "version_added": "54"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "41"
                   }
                 }
               }
@@ -8568,44 +8837,6 @@
                   }
                 }
               },
-              "highlighted": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "muted": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
               "pinned": {
                 "support": {
                   "chrome": {
@@ -8619,6 +8850,44 @@
                   },
                   "firefox_android": {
                     "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "muted": {
+                "support": {
+                  "chrome": {
+                    "version_added": "45"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "32"
+                  }
+                }
+              },
+              "highlighted": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
                   },
                   "opera": {
                     "version_added": true
@@ -8647,6 +8916,44 @@
                   "experimental": false,
                   "standard_track": false,
                   "obsolete": true
+                }
+              },
+              "openerTabId": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "autoDiscardable": {
+                "support": {
+                  "chrome": {
+                    "version_added": "54"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "41"
+                  }
                 }
               }
             }


### PR DESCRIPTION
I added missing compatibility information for following API features:

* `Tab.width` and `Tab.height`
  * Added in Chrome 31 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-Tab-width) (receptively Opera 18).
  * I checked on Firefox 53 and they exist, presumably they were added along basic support.
  * Not supported on Microsoft Edge according to [their documentation][1].
* `Tab.audible`
  * Added in Chrome 45 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-Tab-audible) (respectively Opera 32).
  * I checked on Firefox 53 and it exists, presumably it was added along basic support.
  * Not supported on Microsoft Edge according to [their documentation][1].
* `Tab.mutedInfo`
  * Added in Chrome 46 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-Tab-mutedInfo) (respectively Opera 33).
  * I checked on Firefox 53 and it exists, presumably it was added along basic support.
  * Not supported on Microsoft Edge according to [their documentation][1].
* `Tab.openerTabId`
  * Added in Chrome 18 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-Tab-openerTabId) (respectively Opera 15).
  * I didn't change the compatibility information for other browsers, but FWIW I confirmed that Firefox still does not support it, and it's still neither supported on Edge according to its [documentation][1].
* `Tab.sessionId`
  * Added in Chrome 31 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-Tab-sessionId) (respectively Opera 18).
  * I checked on Firefox 53 and it does not exist there.
  * Since Microsoft Edge does not have the `session` API, I assume that it does not exist there either.
* `Tab.discarded` and `Tab.autoDiscardable`
  * Added in Chrome 54 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-Tab-discarded) (respectively Opera 41).
  * I checked on Firefox 53 and they do not exist there.
  * Assuming that they do not exist on Microsoft Edge either, since it is a rather new feature.
* `tabs.create()` options
  * `openerTabId`
    * (see above)
* `tabs.update()` options
  * `openerTabId`, `autoDiscardable`
    * (see above)
  * `muted`
    * Added in Chrome 45 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-updateProperties-muted) (respectively Opera 32).
    * I didn't change the compatibility information for other browsers.
* `tabs.query()` options
  * `audible`, `muted`, `discarded`, `autoDiscardable`
    * (see above)
  * `pinned`
    * Supported in Chrome/Opera, exact version added is unknown.
    * I checked on Firefox 53 and it exists, presumably it was added along basic support.
    * Not supported on Microsoft Edge according to [their documentation][1].
  * `index`
    * Added in Chrome 18 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-queryInfo-index) (respectively Opera 15).
    * I checked on Firefox 53 and it exists, presumably it was added along basic support.
    * Assuming that it exists on Microsoft Edge as well, since not indicated otherwise.
  * `currentWindow` and `lastFocusedWindow`
    * Added in Chrome 19 according to [their documentation](https://developer.chrome.com/extensions/tabs#property-queryInfo-currentWindow) (respectively Opera 15).
    * I checked on Firefox 53 and they exist, presumably they were added along basic support.
    * Assuming that they exist on Microsoft Edge as well, since not indicated otherwise.

Other (apparent) changes in the patch are due to changing the order of the features within the API. As usual, I sorted them (for consistency) in the order they have been implemented.

[1]: https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis#tabs