### PR TITLE
Added missing compatiblity information to windows API

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -10242,10 +10242,16 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": true,
+                    "notes": [
+                      "`detached_panel` is not supported."
+                    ]
                   },
                   "edge": {
-                    "version_added": true
+                    "version_added": true,
+                    "notes": [
+                      "`panel` and `detached_panel` are not supported."
+                    ]
                   },
                   "firefox": {
                     "version_added": "45"
@@ -10254,7 +10260,10 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": true,
+                    "notes": [
+                      "`detached_panel` is not supported."
+                    ]
                   }
                 }
               }
@@ -10265,7 +10274,7 @@
               "basic_support": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": true
@@ -10277,7 +10286,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "15"
                   }
                 }
               }
@@ -10350,7 +10359,7 @@
               "alwaysOnTop": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "19"
                   },
                   "edge": {
                     "version_added": false
@@ -10362,7 +10371,26 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": "15"
+                  }
+                }
+              },
+              "sessionId": {
+                "support": {
+                  "chrome": {
+                    "version_added": "31"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "18"
                   }
                 }
               }
@@ -10388,6 +10416,87 @@
                     "version_added": true
                   }
                 }
+              },
+              "minimized": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "maximized": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "fullscreen": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "docked": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "obsolete": true
+                }
               }
             }
           },
@@ -10400,6 +10509,63 @@
                   },
                   "edge": {
                     "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "panel": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "app": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "devtools": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
                   },
                   "firefox": {
                     "version_added": "45"
@@ -10437,6 +10603,44 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              },
+              "tabId": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "state": {
+                "support": {
+                  "chrome": {
+                    "version_added": "44"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "31"
                   }
                 }
               },
@@ -10481,6 +10685,44 @@
                     "version_added": true
                   }
                 }
+              },
+              "getInfo": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "getInfo.windowTypes": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
@@ -10502,6 +10744,44 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              },
+              "populate": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "windowTypes": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
                   }
                 }
               }
@@ -10527,6 +10807,44 @@
                     "version_added": true
                   }
                 }
+              },
+              "getInfo": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "getInfo.windowTypes": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
+                }
               }
             }
           },
@@ -10548,6 +10866,44 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              },
+              "getInfo": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "getInfo.windowTypes": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
                   }
                 }
               }
@@ -10654,6 +11010,44 @@
                   },
                   "edge": {
                     "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "left, top": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
+              "drawAttention": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
                   },
                   "firefox": {
                     "version_added": "45"


### PR DESCRIPTION
I added missing compatibility information for following API features:

* `CreateType`
  * `detached_panel` is specific to Firefox (i.e. not supported in Chrome, Opera and Edge).
  * `panel` is not supported in Microsoft Edge.
* `WINDOW_ID_CURRENT`
  * Added in Chrome 18 according to [their documentation](https://developer.chrome.com/extensions/windows#property-WINDOW_ID_CURRENT) (respectively Opera 15).
* `Window.alwaysOnTop`
  * Added in Chrome 19 according to [their documentation](https://developer.chrome.com/extensions/windows#property-Window-alwaysOnTop) (respectively Opera 15).
  * Not supported on Microsoft Edge according to [their documentation][1].
* `Window.sessionId`
  * Added in Chrome 31 according to [their documentation](https://developer.chrome.com/extensions/windows#property-Window-sessionId) (respectively Opera 18).
  * It does not exist on Firefox and Microsoft Edge.
* `WindowState`
  * `minimized`, `maximized` and `fullscreen` do not exist in Microsoft Edge according to [their documentation][1].
  * `docked` does only exist in Chrome/Opera and is deprecated there.
* `WindowType`
  * `panel`, `app` and `devtools` do not exist in Microsoft Edge according to [their documentation][1].
* `windows.create()` options
  * `tabId` is not supported in Microsoft Edge according to [their documentation][1].
  * `state` was added in Chrome 44 according to [their documentation](https://developer.chrome.com/extensions/windows#property-createData-state) (respectively Opera 31).
* `windows.get()`, `windows.getCurrent()` and `windows.getLastFocused()` options
  * `getInfo` was added in Chrome 18 according to [their documentation](https://developer.chrome.com/extensions/windows#property-get-getInfo) (respectively Opera 15).
  * `getInfo.windowTypes` was added in Chrome 46 according to their documentation (respectively Opera 33).
* `windows.getAll()` options
  * `populate` is not supported in Microsoft Edge according to [their documentation][1].
  * `windowTypes` was added in Chrome 46 according to their documentation (respectively Opera 33).
* `windows.update()` options
  * `left`, `top` and `drawAttention` are not supported in Microsoft Edge according to [their documentation][1].

[1]: https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis#windows