### PR TITLE
Rename obsolete to deprecated

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -102,7 +102,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -154,7 +154,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -102,7 +102,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -154,7 +154,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -206,7 +206,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -258,7 +258,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -310,7 +310,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -362,7 +362,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -414,7 +414,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -102,7 +102,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -154,7 +154,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -206,7 +206,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           },
           "RGB32F_EXT": {
@@ -98,7 +98,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -56,7 +56,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -49,7 +49,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -60,7 +60,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -58,7 +58,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -56,7 +56,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -62,7 +62,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -57,7 +57,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -116,7 +116,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -102,7 +102,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -154,7 +154,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -206,7 +206,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -258,7 +258,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -310,7 +310,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -362,7 +362,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -414,7 +414,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -466,7 +466,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -518,7 +518,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -570,7 +570,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -622,7 +622,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -674,7 +674,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -726,7 +726,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -778,7 +778,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -830,7 +830,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -882,7 +882,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -934,7 +934,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -986,7 +986,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1038,7 +1038,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1090,7 +1090,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1142,7 +1142,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1194,7 +1194,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1246,7 +1246,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1298,7 +1298,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1350,7 +1350,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1402,7 +1402,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1454,7 +1454,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1506,7 +1506,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1558,7 +1558,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1610,7 +1610,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1662,7 +1662,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1714,7 +1714,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1766,7 +1766,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1818,7 +1818,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1870,7 +1870,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1922,7 +1922,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1974,7 +1974,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2026,7 +2026,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2078,7 +2078,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2130,7 +2130,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2182,7 +2182,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2234,7 +2234,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2286,7 +2286,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2338,7 +2338,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2390,7 +2390,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2442,7 +2442,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2494,7 +2494,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2546,7 +2546,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2598,7 +2598,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2650,7 +2650,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2702,7 +2702,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2754,7 +2754,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2806,7 +2806,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2858,7 +2858,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2910,7 +2910,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2962,7 +2962,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3014,7 +3014,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3066,7 +3066,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3118,7 +3118,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3170,7 +3170,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3222,7 +3222,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3274,7 +3274,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3326,7 +3326,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3378,7 +3378,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3430,7 +3430,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3482,7 +3482,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3534,7 +3534,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3586,7 +3586,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3638,7 +3638,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3690,7 +3690,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3742,7 +3742,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3794,7 +3794,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3846,7 +3846,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3898,7 +3898,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3950,7 +3950,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4002,7 +4002,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4054,7 +4054,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4106,7 +4106,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4158,7 +4158,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4210,7 +4210,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4262,7 +4262,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4314,7 +4314,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4366,7 +4366,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4418,7 +4418,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4470,7 +4470,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4522,7 +4522,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4574,7 +4574,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4626,7 +4626,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4678,7 +4678,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4730,7 +4730,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4782,7 +4782,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4834,7 +4834,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4886,7 +4886,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4938,7 +4938,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4990,7 +4990,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5042,7 +5042,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5094,7 +5094,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5146,7 +5146,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5198,7 +5198,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -156,7 +156,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -208,7 +208,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -260,7 +260,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -156,7 +156,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -62,7 +62,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -116,7 +116,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -168,7 +168,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -220,7 +220,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -272,7 +272,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -324,7 +324,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -372,7 +372,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -424,7 +424,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -472,7 +472,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -524,7 +524,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -576,7 +576,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -624,7 +624,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -676,7 +676,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -728,7 +728,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -776,7 +776,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -828,7 +828,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -876,7 +876,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -928,7 +928,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -980,7 +980,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1032,7 +1032,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -1080,7 +1080,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1132,7 +1132,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -1180,7 +1180,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1232,7 +1232,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "OffscreenCanvas": {
@@ -1285,7 +1285,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1337,7 +1337,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -1385,7 +1385,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1437,7 +1437,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1489,7 +1489,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1541,7 +1541,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1593,7 +1593,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1645,7 +1645,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1702,7 +1702,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1754,7 +1754,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1806,7 +1806,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -1854,7 +1854,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1906,7 +1906,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -1954,7 +1954,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2006,7 +2006,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2058,7 +2058,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2110,7 +2110,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2162,7 +2162,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2214,7 +2214,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2266,7 +2266,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2318,7 +2318,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2370,7 +2370,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2422,7 +2422,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2474,7 +2474,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2526,7 +2526,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2578,7 +2578,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2630,7 +2630,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2682,7 +2682,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2734,7 +2734,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2786,7 +2786,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2838,7 +2838,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2890,7 +2890,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2942,7 +2942,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -2994,7 +2994,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3046,7 +3046,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3098,7 +3098,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3150,7 +3150,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3202,7 +3202,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3254,7 +3254,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3306,7 +3306,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3358,7 +3358,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3410,7 +3410,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3462,7 +3462,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3514,7 +3514,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -3562,7 +3562,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3614,7 +3614,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -3662,7 +3662,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3714,7 +3714,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3766,7 +3766,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -3814,7 +3814,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3866,7 +3866,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3918,7 +3918,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -3970,7 +3970,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4022,7 +4022,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4074,7 +4074,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -4122,7 +4122,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4174,7 +4174,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4226,7 +4226,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4278,7 +4278,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4330,7 +4330,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -4378,7 +4378,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4430,7 +4430,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4482,7 +4482,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4534,7 +4534,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -4582,7 +4582,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4634,7 +4634,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -4682,7 +4682,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4734,7 +4734,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4786,7 +4786,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4838,7 +4838,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4890,7 +4890,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4942,7 +4942,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -4994,7 +4994,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -5042,7 +5042,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5094,7 +5094,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -5142,7 +5142,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5194,7 +5194,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5246,7 +5246,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -5294,7 +5294,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5346,7 +5346,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5398,7 +5398,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5450,7 +5450,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5502,7 +5502,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5554,7 +5554,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -5602,7 +5602,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5654,7 +5654,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5706,7 +5706,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5758,7 +5758,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5810,7 +5810,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5862,7 +5862,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5914,7 +5914,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -5966,7 +5966,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6018,7 +6018,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -6066,7 +6066,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6118,7 +6118,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6170,7 +6170,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -6218,7 +6218,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6270,7 +6270,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -6318,7 +6318,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6370,7 +6370,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6422,7 +6422,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6474,7 +6474,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6526,7 +6526,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6578,7 +6578,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6630,7 +6630,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6682,7 +6682,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6734,7 +6734,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6786,7 +6786,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6838,7 +6838,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -6886,7 +6886,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -6938,7 +6938,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -6986,7 +6986,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7038,7 +7038,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -7086,7 +7086,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7138,7 +7138,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -7186,7 +7186,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7238,7 +7238,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7290,7 +7290,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7342,7 +7342,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7394,7 +7394,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7446,7 +7446,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7498,7 +7498,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7550,7 +7550,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7602,7 +7602,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7654,7 +7654,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7706,7 +7706,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7758,7 +7758,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7810,7 +7810,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7862,7 +7862,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7914,7 +7914,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -7966,7 +7966,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8018,7 +8018,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8070,7 +8070,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -8118,7 +8118,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8170,7 +8170,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -8218,7 +8218,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8270,7 +8270,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "WebGL2": {
@@ -8318,7 +8318,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8370,7 +8370,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8422,7 +8422,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8474,7 +8474,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8526,7 +8526,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8578,7 +8578,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8630,7 +8630,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8682,7 +8682,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8734,7 +8734,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8786,7 +8786,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8838,7 +8838,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8890,7 +8890,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -8942,7 +8942,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -156,7 +156,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -208,7 +208,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -260,7 +260,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLTransformFeedback.json
+++ b/api/WebGLTransformFeedback.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "worker_support": {
@@ -104,7 +104,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLVertexArrayObject.json
+++ b/api/WebGLVertexArrayObject.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/compat-data-schema.md
+++ b/compat-data-schema.md
@@ -306,9 +306,8 @@ conduct tests. Set to `false`, it means the functionality is mature, and no
 significant incompatible changes are expected in the future.
 * `standard_track`: a `boolean` value indicating if the feature is part of an
 active specification or specification process.
-* `obsolete`: a `"boolean"` value that indicates if the functionality is only
-kept for compatibility purpose and shouldn't be used anymore. It may be removed
-from the Web platform in the future.
+* `deprecated`: a `boolean` value that indicates if the feature is no longer recommended.
+It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality.
 
 ### Localization
 We are planning localize some of this data (e.g. notes, descriptions).

--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -57,9 +57,9 @@
       "properties": {
         "experimental": { "type": ["string", "boolean"] },
         "standard_track": { "type": ["string", "boolean"] },
-        "obsolete": { "type": ["string", "boolean"] }
+        "deprecated": { "type": ["string", "boolean"] }
       },
-      "required": ["experimental", "standard_track", "obsolete"],
+      "required": ["experimental", "standard_track", "deprecated"],
       "additionalProperties": false
     },
 

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "multiple_backgrounds": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "local": {
@@ -148,7 +148,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -54,7 +54,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "content-box": {
@@ -105,7 +105,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "text": {
@@ -161,7 +161,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -51,7 +51,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "alpha_ch_for_hex": {
@@ -100,7 +100,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -53,7 +53,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "multiple_backgrounds": {
@@ -102,7 +102,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "gradients": {
@@ -159,7 +159,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "svg_images": {
@@ -210,7 +210,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "element": {
@@ -261,7 +261,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "image-rect": {
@@ -314,7 +314,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "any_image": {
@@ -363,7 +363,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -57,7 +57,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "content-box": {
@@ -109,7 +109,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "two_value_syntax": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "2_value_syntax": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "multiple_backgrounds": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "4_value_syntax": {
@@ -148,7 +148,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "multiple_backgrounds": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "2-value": {
@@ -148,7 +148,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "round_space": {
@@ -197,7 +197,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -92,7 +92,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "contain_and_cover": {
@@ -141,7 +141,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "SVG_image_as_background": {
@@ -190,7 +190,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "multiple_backgrounds": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "SVG_image_as_background": {
@@ -148,7 +148,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "background-size": {
@@ -197,7 +197,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "background-origin": {
@@ -246,7 +246,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "background-clip": {
@@ -295,7 +295,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -88,7 +88,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -69,7 +69,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -54,7 +54,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           },
           "css_files": {
@@ -113,7 +113,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           },
           "html_files": {
@@ -162,7 +162,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           },
           "js_files": {
@@ -215,7 +215,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "obsolete": false
+              "deprecated": false
             }
           }
         }

--- a/http/headers/accept-charset.json
+++ b/http/headers/accept-charset.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/accept-encoding.json
+++ b/http/headers/accept-encoding.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/accept-language.json
+++ b/http/headers/accept-language.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/accept-ranges.json
+++ b/http/headers/accept-ranges.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/accept.json
+++ b/http/headers/accept.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-allow-credentials.json
+++ b/http/headers/access-control-allow-credentials.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-allow-origin.json
+++ b/http/headers/access-control-allow-origin.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-max-age.json
+++ b/http/headers/access-control-max-age.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-request-headers.json
+++ b/http/headers/access-control-request-headers.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/access-control-request-method.json
+++ b/http/headers/access-control-request-method.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/age.json
+++ b/http/headers/age.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "immutable": {
@@ -100,7 +100,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "stale-while-revalidate": {
@@ -151,7 +151,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "stale-if-error": {
@@ -202,7 +202,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/connection.json
+++ b/http/headers/connection.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "br": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-language.json
+++ b/http/headers/content-language.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-location.json
+++ b/http/headers/content-location.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-range.json
+++ b/http/headers/content-range.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -56,7 +56,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "meta-element-support": {
@@ -105,7 +105,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "worker_support": {
@@ -154,7 +154,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -206,7 +206,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -258,7 +258,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -310,7 +310,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -363,7 +363,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -415,7 +415,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -467,7 +467,7 @@
                 "status": {
                   "experimental": true,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -519,7 +519,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -571,7 +571,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -623,7 +623,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -675,7 +675,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -727,7 +727,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -779,7 +779,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -831,7 +831,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -883,7 +883,7 @@
                 "status": {
                   "experimental": true,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -935,7 +935,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -988,7 +988,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1045,7 +1045,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1097,7 +1097,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1149,7 +1149,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1201,7 +1201,7 @@
                 "status": {
                   "experimental": true,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1253,7 +1253,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1305,7 +1305,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1357,7 +1357,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1409,7 +1409,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1462,7 +1462,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1515,7 +1515,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }

--- a/http/headers/content-type.json
+++ b/http/headers/content-type.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/cookie.json
+++ b/http/headers/cookie.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/cookie2.json
+++ b/http/headers/cookie2.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/date.json
+++ b/http/headers/date.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/etag.json
+++ b/http/headers/etag.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/expires.json
+++ b/http/headers/expires.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/from.json
+++ b/http/headers/from.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/host.json
+++ b/http/headers/host.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/if-modified-since.json
+++ b/http/headers/if-modified-since.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/if-none-match.json
+++ b/http/headers/if-none-match.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/if-range.json
+++ b/http/headers/if-range.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/if-unmodified-since.json
+++ b/http/headers/if-unmodified-since.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/large-allocation.json
+++ b/http/headers/large-allocation.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/last-modified.json
+++ b/http/headers/last-modified.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/location.json
+++ b/http/headers/location.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": false,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/pragma.json
+++ b/http/headers/pragma.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -52,7 +52,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -51,7 +51,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "report-uri": {
@@ -101,7 +101,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/range.json
+++ b/http/headers/range.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "same-origin": {
@@ -100,7 +100,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "strict-origin": {
@@ -150,7 +150,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "strict-origin-when-cross-origin": {
@@ -200,7 +200,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -51,7 +51,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/server.json
+++ b/http/headers/server.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "Max-Age": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "HttpOnly": {
@@ -148,7 +148,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "cookie_prefixes": {
@@ -197,7 +197,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "SameSite": {
@@ -248,7 +248,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/set-cookie2.json
+++ b/http/headers/set-cookie2.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -74,7 +74,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": true
+                "deprecated": true
               }
             }
           }

--- a/http/headers/te.json
+++ b/http/headers/te.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/trailer.json
+++ b/http/headers/trailer.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/transfer-encoding.json
+++ b/http/headers/transfer-encoding.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -51,7 +51,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/user-agent.json
+++ b/http/headers/user-agent.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/vary.json
+++ b/http/headers/vary.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/via.json
+++ b/http/headers/via.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/warning.json
+++ b/http/headers/warning.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "ALLOW-FROM": {
@@ -99,7 +99,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": false,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/methods.json
+++ b/http/methods.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -102,7 +102,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -154,7 +154,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -206,7 +206,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -258,7 +258,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -310,7 +310,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -362,7 +362,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/http/status.json
+++ b/http/status.json
@@ -50,7 +50,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -102,7 +102,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -154,7 +154,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -206,7 +206,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -258,7 +258,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -310,7 +310,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -362,7 +362,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -414,7 +414,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -466,7 +466,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -518,7 +518,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -570,7 +570,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -622,7 +622,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -674,7 +674,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -726,7 +726,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -778,7 +778,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -830,7 +830,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -882,7 +882,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -934,7 +934,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -986,7 +986,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1038,7 +1038,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1090,7 +1090,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1142,7 +1142,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1194,7 +1194,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1246,7 +1246,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -1298,7 +1298,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -54,7 +54,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -110,7 +110,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -165,7 +165,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -220,7 +220,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -275,7 +275,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -330,7 +330,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -385,7 +385,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -440,7 +440,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -495,7 +495,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -550,7 +550,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -605,7 +605,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -660,7 +660,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -715,7 +715,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -770,7 +770,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -825,7 +825,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -880,7 +880,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -935,7 +935,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -990,7 +990,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1045,7 +1045,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1100,7 +1100,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1155,7 +1155,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1210,7 +1210,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1265,7 +1265,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1320,7 +1320,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "iso_8601": {
@@ -1372,7 +1372,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1427,7 +1427,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "ordinary_object": {
@@ -1479,7 +1479,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1534,7 +1534,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1589,7 +1589,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1644,7 +1644,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1699,7 +1699,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1754,7 +1754,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1809,7 +1809,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1864,7 +1864,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1919,7 +1919,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1974,7 +1974,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2029,7 +2029,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2084,7 +2084,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2139,7 +2139,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2194,7 +2194,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2249,7 +2249,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2304,7 +2304,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2359,7 +2359,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2414,7 +2414,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2469,7 +2469,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2524,7 +2524,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2579,7 +2579,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2634,7 +2634,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "locales": {
@@ -2685,7 +2685,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "options": {
@@ -2736,7 +2736,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "iana_time_zone_names": {
@@ -2788,7 +2788,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2843,7 +2843,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2898,7 +2898,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "locales": {
@@ -2949,7 +2949,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "options": {
@@ -3000,7 +3000,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "iana_time_zone_names": {
@@ -3052,7 +3052,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3107,7 +3107,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "locales": {
@@ -3158,7 +3158,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "options": {
@@ -3209,7 +3209,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "iana_time_zone_names": {
@@ -3261,7 +3261,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3316,7 +3316,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3371,7 +3371,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3426,7 +3426,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3481,7 +3481,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3536,7 +3536,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -54,7 +54,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -109,7 +109,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -164,7 +164,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -219,7 +219,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -274,7 +274,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -329,7 +329,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -384,7 +384,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -439,7 +439,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -494,7 +494,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -549,7 +549,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -604,7 +604,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -659,7 +659,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -714,7 +714,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -769,7 +769,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -824,7 +824,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -879,7 +879,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -934,7 +934,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -989,7 +989,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1044,7 +1044,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1099,7 +1099,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1154,7 +1154,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1209,7 +1209,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1264,7 +1264,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1319,7 +1319,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1374,7 +1374,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1429,7 +1429,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1484,7 +1484,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1539,7 +1539,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1594,7 +1594,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1649,7 +1649,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1704,7 +1704,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1759,7 +1759,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1814,7 +1814,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1869,7 +1869,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1924,7 +1924,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1979,7 +1979,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2034,7 +2034,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2089,7 +2089,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2144,7 +2144,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2199,7 +2199,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2254,7 +2254,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2309,7 +2309,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2364,7 +2364,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -54,7 +54,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -109,7 +109,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -164,7 +164,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -219,7 +219,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -274,7 +274,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -329,7 +329,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -384,7 +384,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -439,7 +439,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -494,7 +494,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -549,7 +549,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -604,7 +604,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -659,7 +659,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -714,7 +714,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -769,7 +769,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -824,7 +824,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -879,7 +879,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -934,7 +934,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -989,7 +989,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1046,7 +1046,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1101,7 +1101,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "locales": {
@@ -1152,7 +1152,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "options": {
@@ -1203,7 +1203,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1258,7 +1258,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1313,7 +1313,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1368,7 +1368,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1423,7 +1423,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -59,7 +59,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -114,7 +114,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -169,7 +169,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -224,7 +224,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -279,7 +279,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -334,7 +334,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -389,7 +389,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -444,7 +444,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -68,7 +68,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -123,7 +123,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "unicode_code_point_escapes": {
@@ -175,7 +175,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -231,7 +231,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -286,7 +286,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -341,7 +341,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -396,7 +396,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -451,7 +451,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -506,7 +506,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -561,7 +561,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -616,7 +616,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -671,7 +671,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -726,7 +726,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -781,7 +781,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -836,7 +836,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -891,7 +891,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -946,7 +946,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1015,7 +1015,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1070,7 +1070,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1125,7 +1125,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1180,7 +1180,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1235,7 +1235,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1290,7 +1290,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1345,7 +1345,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "locales": {
@@ -1396,7 +1396,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "options": {
@@ -1447,7 +1447,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1502,7 +1502,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "flags": {
@@ -1554,7 +1554,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1609,7 +1609,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1664,7 +1664,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1719,7 +1719,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1774,7 +1774,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1831,7 +1831,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -1886,7 +1886,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1941,7 +1941,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -1996,7 +1996,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "flags": {
@@ -2048,7 +2048,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2103,7 +2103,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "flags": {
@@ -2155,7 +2155,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2210,7 +2210,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2265,7 +2265,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2320,7 +2320,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2375,7 +2375,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2430,7 +2430,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2485,7 +2485,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2540,7 +2540,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2595,7 +2595,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2650,7 +2650,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -2705,7 +2705,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "locale": {
@@ -2756,7 +2756,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2811,7 +2811,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               },
               "locale": {
@@ -2862,7 +2862,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2917,7 +2917,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -2972,7 +2972,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3027,7 +3027,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3082,7 +3082,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3137,7 +3137,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3192,7 +3192,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3247,7 +3247,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }
@@ -3302,7 +3302,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "obsolete": false
+                  "deprecated": false
                 }
               }
             }

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -65,7 +65,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             }
           }
@@ -125,7 +125,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "chocoCookie": {
@@ -235,7 +235,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "obsolete": false
+                "deprecated": false
               }
             },
             "subfeature-no-status-few-browsers": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3136,7 +3136,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -3164,7 +3164,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -3307,7 +3307,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -3335,7 +3335,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -3363,7 +3363,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -6079,7 +6079,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -7195,7 +7195,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               },
               "width, height": {
@@ -7615,7 +7615,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               },
               "openerTabId": {
@@ -7820,7 +7820,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -7871,7 +7871,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -8113,7 +8113,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -8210,7 +8210,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -8336,7 +8336,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -8765,7 +8765,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }
@@ -8915,7 +8915,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               },
               "openerTabId": {
@@ -10802,7 +10802,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": false,
-                  "obsolete": true
+                  "deprecated": true
                 }
               }
             }


### PR DESCRIPTION
Seems like there is consensus and there are no open PRs at the moment, so good chance to avoid rebases. :slightly_smiling_face: 