### PR TITLE
Add compat data for devtools.inspectedWindow.eval helpers functions

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2114,10 +2114,45 @@
                       "version_added": false
                     },
                     "firefox": {
-                      "notes": [
-                        "Console helper functions are not available to injected scripts."
-                      ],
                       "version_added": "54"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                },
+                "$0": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "55"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
+                },
+                "inspect()": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "55"
                     },
                     "firefox_android": {
                       "version_added": false


### PR DESCRIPTION
Firefox 55 added support for $0 and inspect().

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1300590
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.inspectedWindow/eval#Helper_functions

I've slightly changed the emphasis of the docs: the old docs talks about how the WebExtensions `inspectedWindow.eval` supports "the same helpers as the Web Console only Firefox doesn't support this yet" (although now it does support these two helpers). But I'm not very comfortable referring out to the devtools docs for this, because WE is supposed to be cross-browser, and the devtools docs are clearly not. So instead I'm intending to document the helpers inside the `inspectedWindow.eval` docs page, and add them as they land in Firefox.

