### PR TITLE
Add compat data for history.onTitleChanged

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3724,6 +3724,29 @@
               }
             }
           },
+          "onTitleChanged": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
           "onVisitRemoved": {
             "__compat": {
               "basic_support": {


### PR DESCRIPTION
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1280582
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/history/onTitleChanged

This is new in Firefox 55 and is not supported in any other browsers.