### PR TITLE
Update compat notes for runtime.onInstalled

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -6142,13 +6142,15 @@
                   },
                   "firefox": {
                     "notes": [
-                      "This event is not triggered for temporarily installed add-ons."
+                      "This event is triggered for temporarily installed add-ons from version 53.",
+                      "'previousVersion' is present from version 55."
                     ],
                     "version_added": "52"
                   },
                   "firefox_android": {
                     "notes": [
-                      "This event is not triggered for temporarily installed add-ons."
+                      "This event is triggered for temporarily installed add-ons from version 53.",
+                      "'previousVersion' is present from version 55."
                     ],
                     "version_added": "52"
                   },


### PR DESCRIPTION
runtime.onInstalled didn't have any notes about previousVersion being present only after version 55.

Triggering this event for temporarily installed extensions was fixed in version 53.

https://bugzilla.mozilla.org/show_bug.cgi?id=1313648
https://bugzilla.mozilla.org/show_bug.cgi?id=1323938