### PR TITLE
Browser compat for <html>, <base>, <head>, <link>, <style>, <title>, and <meta> elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ JSON file containing the compatibility data.
 
 - [css/](https://github.com/mdn/browser-compat-data/tree/master/css) contains data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties, selectors and at-rules.
 
+- [html/](https://github.com/mdn/browser-compat-data/tree/master/html) contains data for
+[HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements, attributes and global attributes.
+
 - [http/](https://github.com/mdn/browser-compat-data/tree/master/http) contains data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers, statuses and methods.
 
 - [javascript/](https://github.com/mdn/browser-compat-data/tree/master/javascript) contains data for [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in Objects, statement, operators and or other ECMAScript language features.

--- a/compat-data-schema.md
+++ b/compat-data-schema.md
@@ -13,6 +13,8 @@ JSON file containing the compatibility data.
 
 - [css/](https://github.com/mdn/browser-compat-data/tree/master/css) contains data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties, selectors and at-rules.
 
+- [html/](https://github.com/mdn/browser-compat-data/tree/master/html) contains data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements, attributes and global attributes.
+
 - [http/](https://github.com/mdn/browser-compat-data/tree/master/http) contains data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers, statuses and methods.
 
 - [javascript/](https://github.com/mdn/browser-compat-data/tree/master/javascript) contains data for [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in Objects, statement, operators and or other ECMAScript language features.

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -1,0 +1,215 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "html": {
+      "elements": {
+        "base": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true,
+                  "notes": "Before Internet Explorer 7, <code>&lt;base&gt;</code> can be positioned anywhere in the document and the nearest value of <code>&lt;>base&gt;</code> is used."
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "href": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "relative_url": {
+                "desc": "Relative URIs.",
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "4.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "4.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "target": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -1,0 +1,113 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "html": {
+      "elements": {
+        "head": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": "1.0"
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "profile": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -1,0 +1,217 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "html": {
+      "elements": {
+        "html": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "manifest": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "3.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            }
+          },
+          "version": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": true
+                }
+              }
+            }
+          },
+          "xmlns": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1,0 +1,1282 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "html": {
+      "elements": {
+        "link": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": "1.0"
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "charset": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": true
+                }
+              }
+            }
+          },
+          "crossorigin": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": "25.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "18.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "18.0"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15.0"
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "disabled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            }
+          },
+          "href": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "hreflang": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "integrity": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "45.0"
+                  },
+                  "chrome": {
+                    "version_added": "45.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "45.0"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": null
+                  },
+                  "firefox_android": {
+                    "version_added": null
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "media": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "methods": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": "4.0"
+                  },
+                  "ie_mobile": {
+                    "version_added": "4.0"
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            }
+          },
+          "prefetch": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "56.0"
+                  },
+                  "chrome": {
+                    "version_added": "56.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "56.0"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": null
+                  },
+                  "firefox_android": {
+                    "version_added": null
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "43.0"
+                  },
+                  "opera_android": {
+                    "version_added": "43.0"
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "referrerpolicy": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "58.0"
+                  },
+                  "chrome": {
+                    "version_added": "58.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "58.0"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "50.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "50.0"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "rel": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "alternate_stylesheet": {
+                "desc": "Alternative stylesheets.",
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "3.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "4.0"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "prefetch": {
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": null
+                  },
+                  "firefox_android": {
+                    "version_added": null
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "prerender": {
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": null
+                  },
+                  "firefox_android": {
+                    "version_added": null
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "preconnect": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "46.0"
+                  },
+                  "chrome": {
+                    "version_added": "46.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "42.0"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "39",
+                    "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
+                  },
+                  "firefox_android": {
+                    "version_added": "39.0",
+                    "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "dns-prefetch": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "46.0"
+                  },
+                  "chrome": {
+                    "version_added": "46.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "3.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "preload": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "50.0"
+                  },
+                  "chrome": {
+                    "version_added": "50.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "50.0"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": null
+                  },
+                  "firefox_android": {
+                    "version_added": null
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": false,
+                  "deprecated": false
+                }
+              },
+              "noopener": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "49.0"
+                  },
+                  "chrome": {
+                    "version_added": "49.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "49.0"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": "52.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "52.0"
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "36.0"
+                  },
+                  "opera_android": {
+                    "version_added": "32.0"
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": false,
+                  "deprecated": false
+                }
+              },
+              "manifest": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "39.0"
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": "39.09"
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": null
+                  },
+                  "firefox_android": {
+                    "version_added": null
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": false,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "rev": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "sizes": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=441770'>bug 441770</a>."
+                  },
+                  "firefox_android": {
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=441770'>bug 441770</a>."
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "target": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": true
+                }
+              }
+            }
+          },
+          "title": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -1,0 +1,628 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "html": {
+      "elements": {
+        "meta": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "charset": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "content": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "http-equiv": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "content-language": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "webview_android": {
+                      "version_added": true
+                    },
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "chrome_android": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "edge_mobile": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "1.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "1.0"
+                    },
+                    "ie": {
+                      "version_added": true
+                    },
+                    "ie_mobile": {
+                      "version_added": true
+                    },
+                    "opera": {
+                      "version_added": true
+                    },
+                    "opera_android": {
+                      "version_added": true
+                    },
+                    "safari": {
+                      "version_added": true
+                    },
+                    "safari_ios": {
+                      "version_added": true
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": true
+                  }
+                }
+              }
+            },
+            "content-security-policy": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "webview_android": {
+                      "version_added": true
+                    },
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "chrome_android": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "edge_mobile": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "1.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "1.0"
+                    },
+                    "ie": {
+                      "version_added": true
+                    },
+                    "ie_mobile": {
+                      "version_added": true
+                    },
+                    "opera": {
+                      "version_added": true
+                    },
+                    "opera_android": {
+                      "version_added": true
+                    },
+                    "safari": {
+                      "version_added": true
+                    },
+                    "safari_ios": {
+                      "version_added": true
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              }
+            },
+            "content-type": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "webview_android": {
+                      "version_added": true
+                    },
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "chrome_android": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "edge_mobile": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "1.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "1.0"
+                    },
+                    "ie": {
+                      "version_added": true
+                    },
+                    "ie_mobile": {
+                      "version_added": true
+                    },
+                    "opera": {
+                      "version_added": true
+                    },
+                    "opera_android": {
+                      "version_added": true
+                    },
+                    "safari": {
+                      "version_added": true
+                    },
+                    "safari_ios": {
+                      "version_added": true
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              }
+            },
+            "refresh": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "webview_android": {
+                      "version_added": true
+                    },
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "chrome_android": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "edge_mobile": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "1.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "1.0"
+                    },
+                    "ie": {
+                      "version_added": true
+                    },
+                    "ie_mobile": {
+                      "version_added": true
+                    },
+                    "opera": {
+                      "version_added": true
+                    },
+                    "opera_android": {
+                      "version_added": true
+                    },
+                    "safari": {
+                      "version_added": true
+                    },
+                    "safari_ios": {
+                      "version_added": true
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              }
+            },
+            "set-cookie": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "webview_android": {
+                      "version_added": true
+                    },
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "chrome_android": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "edge_mobile": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "1.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "1.0"
+                    },
+                    "ie": {
+                      "version_added": true
+                    },
+                    "ie_mobile": {
+                      "version_added": true
+                    },
+                    "opera": {
+                      "version_added": true
+                    },
+                    "opera_android": {
+                      "version_added": true
+                    },
+                    "safari": {
+                      "version_added": true
+                    },
+                    "safari_ios": {
+                      "version_added": true
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": true
+                  }
+                }
+              }
+            }
+          },
+          "name": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": true
+                  },
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "ie_mobile": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "referer": {
+                "desc": "referrer value",
+                "support": {
+                  "webview_android": {
+                    "version_added": null
+                  },
+                  "chrome": {
+                    "version_added": "17.0",
+                    "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "36.0",
+                    "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
+                  },
+                  "firefox_android": {
+                    "version_added": "36.0",
+                    "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "ie_mobile": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  }
+                }
+              }
+            },
+            "scheme": {
+              "__compat": {
+                "basic_support": {
+                  "support": {
+                    "webview_android": {
+                      "version_added": true
+                    },
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "chrome_android": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": true
+                    },
+                    "edge_mobile": {
+                      "version_added": true
+                    },
+                    "firefox": {
+                      "version_added": "1.0"
+                    },
+                    "firefox_android": {
+                      "version_added": "1.0"
+                    },
+                    "ie": {
+                      "version_added": true
+                    },
+                    "ie_mobile": {
+                      "version_added": true
+                    },
+                    "opera": {
+                      "version_added": true
+                    },
+                    "opera_android": {
+                      "version_added": true
+                    },
+                    "safari": {
+                      "version_added": true
+                    },
+                    "safari_ios": {
+                      "version_added": true
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -1,0 +1,279 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "html": {
+      "elements": {
+        "style": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": "1.0"
+                },
+                "chrome": {
+                  "version_added": "1.0"
+                },
+                "chrome_android": {
+                  "version_added": "1.0"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": "3.0"
+                },
+                "ie_mobile": {
+                  "version_added": "9.0",
+                  "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+                },
+                "opera": {
+                  "version_added": "3.5"
+                },
+                "opera_android": {
+                  "version_added": "6.0"
+                },
+                "safari": {
+                  "version_added": "1.0"
+                },
+                "safari_ios": {
+                  "version_added": "1.0"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "1.0"
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "1.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": "3.0"
+                  },
+                  "ie_mobile": {
+                    "version_added": "9.0",
+                    "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+                  },
+                  "opera": {
+                    "version_added": "3.5"
+                  },
+                  "opera_android": {
+                    "version_added": "6.0"
+                  },
+                  "safari": {
+                    "version_added": "1.0"
+                  },
+                  "safari_ios": {
+                    "version_added": "1.0"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "media": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "1.0"
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "1.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": "3.0"
+                  },
+                  "ie_mobile": {
+                    "version_added": "9.0",
+                    "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+                  },
+                  "opera": {
+                    "version_added": "3.5"
+                  },
+                  "opera_android": {
+                    "version_added": "6.0"
+                  },
+                  "safari": {
+                    "version_added": "1.0"
+                  },
+                  "safari_ios": {
+                    "version_added": "1.0"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "title": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": "1.0"
+                  },
+                  "chrome": {
+                    "version_added": "1.0"
+                  },
+                  "chrome_android": {
+                    "version_added": "1.0"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "1.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "1.0"
+                  },
+                  "ie": {
+                    "version_added": "3.0"
+                  },
+                  "ie_mobile": {
+                    "version_added": "9.0",
+                    "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+                  },
+                  "opera": {
+                    "version_added": "3.5"
+                  },
+                  "opera_android": {
+                    "version_added": "6.0"
+                  },
+                  "safari": {
+                    "version_added": "1.0"
+                  },
+                  "safari_ios": {
+                    "version_added": "1.0"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "scoped": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "chrome": {
+                    "version_added": "19.0",
+                    "version_removed": "35.0",
+                    "flag": {
+                      "type": "preference",
+                      "name": "Enable &lt;style scoped&gt;",
+                      "value_to_set": "true"
+                    }
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "21.0"
+                  },
+                  "firefox_android": {
+                    "version_added": "21.0"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "ie_mobile": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/title.json
+++ b/html/elements/title.json
@@ -1,0 +1,61 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "html": {
+      "elements": {
+        "title": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": "1.0"
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": "1.0"
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": "1.0"
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": "1.0"
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ function load() {
 module.exports = load(
     'api',
     'css',
+    'html',
     'http',
     'javascript',
     'webextensions'

--- a/test/lint.js
+++ b/test/lint.js
@@ -81,6 +81,7 @@ if (process.argv[2]) {
   load(
     'api',
     'css',
+    'html',
     'http',
     'javascript',
     'test',


### PR DESCRIPTION
Added compat data for the <html> element (first html element with compat data).

A few points:
- 5 commits, 'set-up for html' updates the travis/npm files so that they use html/. The other onres iare the compat data itself for <html>, <base>, <head>, and <link>.
- Structure is html/elements/'element-name'[/'attribute-name'].
- There will be html/global-attributes/'globla-attribute-name' in the future.
- The MDN page is not yet updated. I will wait for a merge before going further ahead.
