### PR TITLE
Be more specific about private cookie.set/remove

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2066,13 +2066,13 @@
                   },
                   "firefox": {
                     "notes": [
-                      "Before version 56, this function did not work in private browsing mode. From version 56 onwards this is fixed."
+                      "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
                     ],
                     "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
-                      "Before version 56, this function did not work in private browsing mode. From version 56 onwards this is fixed."
+                      "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
                     ],
                     "version_added": "48"
                   },
@@ -2095,13 +2095,13 @@
                   },
                   "firefox": {
                     "notes": [
-                      "Before version 56, this function did not work in private browsing mode. From version 56 onwards this is fixed."
+                      "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
                     ],
                     "version_added": "45"
                   },
                   "firefox_android": {
                     "notes": [
-                      "Before version 56, this function did not work in private browsing mode. From version 56 onwards this is fixed."
+                      "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
                     ],
                     "version_added": "48"
                   },

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1967,6 +1967,9 @@
                     "version_added": true
                   },
                   "firefox": {
+                    "notes": [
+                      "Provides access to cookies from private browsing mode and container tabs since version 52."
+                    ],
                     "version_added": "45"
                   },
                   "firefox_android": {
@@ -1993,6 +1996,9 @@
                     "version_added": true
                   },
                   "firefox": {
+                    "notes": [
+                      "Before version 52, the 'tabIds' list was empty and only cookies from the default cookie store were returned. From version 52 onwards, this has been fixed and the result includes cookies from private browsing mode and container tabs."
+                    ],
                     "version_added": "45"
                   },
                   "firefox_android": {
@@ -2019,6 +2025,9 @@
                     "version_added": true
                   },
                   "firefox": {
+                    "notes": [
+                      "Before version 52, only the default cookie store was visible. From version 52 onwards, the cookie stores for private browsing mode and container tabs are also readable."
+                    ],
                     "version_added": "45"
                   },
                   "firefox_android": {


### PR DESCRIPTION
@wbamberg I made the phrasing a bit more precise.

I actually wanted to add another row (also to get/getAll/query) to state that support for private browsing cookies was only added in Firefox 52 (https://bugzilla.mozilla.org/show_bug.cgi?id=1254221). How can I do that?