### PR TITLE
adding main WebVR interfaces to the BCD

### DIFF
--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -1,0 +1,711 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRDisplay": {
+        "capabilities": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "depthFar": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "depthNear": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "displayId": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "displayName": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "isConnected": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "isPresenting": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "stageParameters": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "getEyeParameters": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "getFrameData": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "getLayers": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "resetPose": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "cancelAnimationFrame": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "requestAnimationFrame": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "requestPresent": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "exitPresent": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "submitFrame": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "getPose": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -3,6 +3,45 @@
   "data": {
     "api": {
       "VRDisplay": {
+        "cancelAnimationFrame": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
         "capabilities": {
           "__compat": {
             "basic_support": {
@@ -198,85 +237,7 @@
             }
           }
         },
-        "isConnected": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "isPresenting": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "stageParameters": {
+        "exitPresent": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -432,7 +393,125 @@
             }
           }
         },
-        "resetPose": {
+        "getImmediatePose": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "getPose": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "hardwareUnitId": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "isConnected": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -471,7 +550,7 @@
             }
           }
         },
-        "cancelAnimationFrame": {
+        "isPresenting": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -549,6 +628,45 @@
             }
           }
         },
+        "resetPose": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
         "requestPresent": {
           "__compat": {
             "basic_support": {
@@ -588,7 +706,7 @@
             }
           }
         },
-        "exitPresent": {
+        "stageParameters": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -628,45 +746,6 @@
           }
         },
         "submitFrame": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "getPose": {
           "__compat": {
             "basic_support": {
               "support": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -1,0 +1,204 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRDisplayCapabilities": {
+        "canPresent": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "hasExternalDisplay": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "hasOrientation": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "hasPosition": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "maxLayers": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -81,7 +81,7 @@
             }
           }
         },
-        "hasOrientation": {
+        "hasPosition": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -120,7 +120,7 @@
             }
           }
         },
-        "hasPosition": {
+        "hasOrientation": {
           "__compat": {
             "basic_support": {
               "support": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRDisplayEvent": {
+        "VRDisplayEvent": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "display": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "reason": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -3,45 +3,6 @@
   "data": {
     "api": {
       "VRDisplayEvent": {
-        "VRDisplayEvent": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
         "display": {
           "__compat": {
             "basic_support": {
@@ -82,6 +43,45 @@
           }
         },
         "reason": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "VRDisplayEvent": {
           "__compat": {
             "basic_support": {
               "support": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -3,45 +3,6 @@
   "data": {
     "api": {
       "VREyeParameters": {
-        "offset": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
         "fieldOfView": {
           "__compat": {
             "basic_support": {
@@ -81,7 +42,81 @@
             }
           }
         },
-        "renderWidth": {
+        "maximumFieldOfView": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "minimumFieldOfView": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "offset": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -120,7 +155,120 @@
             }
           }
         },
+        "recommendedFieldOfView": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
         "renderHeight": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "renderRect": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "renderWidth": {
           "__compat": {
             "basic_support": {
               "support": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -1,0 +1,165 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VREyeParameters": {
+        "offset": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "fieldOfView": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "renderWidth": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "renderHeight": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -3,7 +3,46 @@
   "data": {
     "api": {
       "VRFieldOfView": {
-        "upDegrees": {
+        "downDegrees": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "leftDegrees": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -81,7 +120,7 @@
             }
           }
         },
-        "downDegrees": {
+        "upDegrees": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -120,24 +159,23 @@
             }
           }
         },
-        "leftDegrees": {
+        "VRFieldOfView": {
           "__compat": {
             "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
               "support": {
                 "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                  "version_added": false
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                  "version_added": false
                 },
                 "ie": {
                   "version_added": false
@@ -146,14 +184,13 @@
                   "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "ie_mobile": {
                   "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
+                  "version_added": false
                 }
               }
             }

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -1,0 +1,165 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRFieldOfView": {
+        "upDegrees": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "rightDegrees": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "downDegrees": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "leftDegrees": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -3,45 +3,6 @@
   "data": {
     "api": {
       "VRFrameData": {
-        "VRFrameData": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
         "leftProjectionMatrix": {
           "__compat": {
             "basic_support": {
@@ -238,6 +199,45 @@
           }
         },
         "timestamp": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "VRFrameData": {
           "__compat": {
             "basic_support": {
               "support": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -1,0 +1,282 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRFrameData": {
+        "VRFrameData": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "leftProjectionMatrix": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "leftViewMatrix": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "pose": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "rightProjectionMatrix": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "rightViewMatrix": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "timestamp": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRLayerInit": {
+        "leftBounds": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "rightBounds": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "source": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -1,0 +1,243 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRPose": {
+        "position": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "linearVelocity": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "linearAcceleration": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "orientation": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "angularVelocity": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "angularAcceleration": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -3,124 +3,7 @@
   "data": {
     "api": {
       "VRPose": {
-        "position": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "linearVelocity": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "linearAcceleration": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "orientation": {
+        "angularAcceleration": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -198,7 +81,81 @@
             }
           }
         },
-        "angularAcceleration": {
+        "hasOrientation": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "hasPosition": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "linearAcceleration": {
           "__compat": {
             "basic_support": {
               "support": {
@@ -232,6 +189,160 @@
                 "chrome_android": {
                   "version_added": true,
                   "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "linearVelocity": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "position": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "orientation": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "timestamp": {
+          "__compat": {
+            "basic_support": {
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": true
+              },
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
                 }
               }
             }

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.0.0",
+  "data": {
+    "api": {
+      "VRStageParameters": {
+        "sittingToStandingTransform": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "sizeX": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        },
+        "sizeY": {
+          "__compat": {
+            "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "WebVR"
+                  },
+                  "notes": "Only works on desktop in an <a href=\"https://webvr.info/get-chrome/\">experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href=\"https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/\">available in Firefox Nightly</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": true,
+                  "notes": "Currently supported only by Google Daydream."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I have added all the main WebVR interfaces to BCD:

https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API#WebVR_Interfaces

I've not tackled the Gamepad API (which has closely related features), or the additions to the Window and Navigator object (because well, they sound like pure pain).

I think I'll have a go at doing the GamePad API tomorrow.

Another question - are events represented in BCD yet?