### PR TITLE
Fix support of `developer` on WebExtensions manifest

### DIFF
--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -677,10 +677,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "48"
+                  "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "52"
                 },
                 "opera": {
                   "version_added": true


### PR DESCRIPTION
I was wondering why older Firefox versions was complaining about `developer` being an unknown property, turns out it's supported since Firefox 52, not 48.

https://bugzilla.mozilla.org/show_bug.cgi?id=1282977