### PR TITLE
Updated background-clip:text compatibility on Edge

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -124,12 +124,12 @@
                 },
                 "edge": [
                   {
-                    "version_added": 12,
+                    "version_added": "12",
                     "prefix": "-webkit-",
                     "notes": "Support the prefixed version of the property only; according to the <a href=\"https://webkit.org/blog/164/background-clip-text/\">official blog</a>, WebKit does not include text decorations or shadows in the clipping."
                   },
                   {
-                    "version_added": 15
+                    "version_added": "15"
                   }
                 ],
                 "edge_mobile": {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -116,14 +116,22 @@
                 },
                 "chrome": {
                   "version_added": true,
+                  "prefix": "-webkit-",
                   "notes": "Support the prefixed version of the property only; according to the <a href=\"https://webkit.org/blog/164/background-clip-text/\">official blog</a>, WebKit does not include text decorations or shadows in the clipping."
                 },
                 "chrome_android": {
                   "version_added": null
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": 12,
+                    "prefix": "-webkit-",
+                    "notes": "Support the prefixed version of the property only; according to the <a href=\"https://webkit.org/blog/164/background-clip-text/\">official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                  },
+                  {
+                    "version_added": 15
+                  }
+                ],
                 "edge_mobile": {
                   "version_added": true
                 },
@@ -143,18 +151,22 @@
                 },
                 "opera": {
                   "version_added": true,
+                  "prefix": "-webkit-",
                   "notes": "Support the prefixed version of the property only; according to the <a href=\"https://webkit.org/blog/164/background-clip-text/\">official blog</a>, WebKit does not include text decorations or shadows in the clipping."
                 },
                 "opera_android": {
                   "version_added": true,
+                  "prefix": "-webkit-",
                   "notes": "Support the prefixed version of the property only; according to the <a href=\"https://webkit.org/blog/164/background-clip-text/\">official blog</a>, WebKit does not include text decorations or shadows in the clipping."
                 },
                 "safari": {
                   "version_added": true,
+                  "prefix": "-webkit-",
                   "notes": "Support the prefixed version of the property only; according to the <a href=\"https://webkit.org/blog/164/background-clip-text/\">official blog</a>, WebKit does not include text decorations or shadows in the clipping."
                 },
                 "safari_ios": {
                   "version_added": true,
+                  "prefix": "-webkit-",
                   "notes": "Support the prefixed version of the property only; according to the <a href=\"https://webkit.org/blog/164/background-clip-text/\">official blog</a>, WebKit does not include text decorations or shadows in the clipping."
                 }
               },


### PR DESCRIPTION
According to [this answer](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10945389-background-clip-text).
Tested on Edge 15.