### PR TITLE
Added compat info for ExtensionPanel.onSearch which does not exist on Firefox

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2297,6 +2297,25 @@
                       "version_added": true
                     }
                   }
+                },
+                "onSearch": {
+                  "support": {
+                    "chrome": {
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": false
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": true
+                    }
+                  }
                 }
               }
             },


### PR DESCRIPTION
For reference, we noticed that `ExtensionPanel.onSearch` is not implemented on Firefox while porting Adblock Plus to Firefox/WebExtensions: https://codereview.adblockplus.org/29491555/