### PR TITLE
Update compat details for runtime.onInstalled

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -6240,18 +6240,94 @@
                   },
                   "firefox": {
                     "notes": [
-                      "This event is not triggered for temporarily installed add-ons."
+                      "Before version 55, this event is not triggered for temporarily installed add-ons."
                     ],
                     "version_added": "52"
                   },
                   "firefox_android": {
                     "notes": [
-                      "This event is not triggered for temporarily installed add-ons."
+                      "Before version 55, this event is not triggered for temporarily installed add-ons."
                     ],
                     "version_added": "52"
                   },
                   "opera": {
                     "version_added": "15"
+                  }
+                }
+              },
+              "details.id": {
+                "support": {
+                  "chrome": {
+                    "version_added": "22"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "details.previousVersion": {
+                "support": {
+                  "chrome": {
+                    "version_added": "22"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": "55"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "details.reason": {
+                "support": {
+                  "chrome": {
+                    "version_added": "22"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": "52"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              },
+              "details.temporary": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": "55"
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }


### PR DESCRIPTION
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1354590
https://bugzilla.mozilla.org/show_bug.cgi?id=1313648

* support for details.previousVersion was added in 55
* support for details.temporary was added in 55

I also noted that details.id isn't supported, and for consistency split out details.reason into a subfeature, too.