### PR TITLE
Update management.get and getAll for Firefox 56

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4310,10 +4310,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": false
+                    "version_added": "56"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "56"
                   },
                   "opera": {
                     "version_added": true
@@ -4335,13 +4335,13 @@
                   "firefox": {
                     "version_added": "55",
                     "notes": [
-                      "Only extensions whose 'type' is 'theme' are returned."
+                      "Before version 56, only extensions whose 'type' is 'theme' are returned."
                     ]
                   },
                   "firefox_android": {
                     "version_added": "55",
                     "notes": [
-                      "Only extensions whose 'type' is 'theme' are returned."
+                      "Before version 56, only extensions whose 'type' is 'theme' are returned."
                     ]
                   },
                   "opera": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1282981

In Firefox 56:
* management.get support was added
* management.getAll support was extended to include extensions as well as themes