### PR TITLE
Update privacy.websites for Firefox 56

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5498,6 +5498,25 @@
                   }
                 }
               },
+              "hyperlinkAuditingEnabled": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              },
               "protectedContentEnabled": {
                 "support": {
                   "chrome": {
@@ -5526,10 +5545,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": false
+                    "version_added": "56"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "56"
                   },
                   "opera": {
                     "version_added": true


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1362787

Firefox 56 added support for privacy.websites.referrersEnabled, which is noted in this update. For clarity I also split privacy.websites.hyperlinkAuditingEnabled out of basic_support.
