### PR TITLE
Add data for browserSettings API

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1315,6 +1315,31 @@
             }
           }
         },
+        "browserSettings": {
+          "cacheEnabled": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "56"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          }
+        },
         "commands": {
           "Command": {
             "__compat": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1364936

Firefox 56 adds a new API `browserSettings` which currently contains a single object `cacheEnabled`. It's only supported in Firefox and Firefox for Android.

Nascent docs: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserSettings.