### PR TITLE
Note update to history.onVisited

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3856,7 +3856,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "50"
+                    "version_added": "50",
+                    "notes": [
+                      "Before version 56, the result object's 'title' was always an empty string. From version 56 onwards, it is set to the last known title, if that is available, or an empty string otherwise."
+                    ]
                   },
                   "firefox_android": {
                     "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1287928

From Firefox 56, the result object passed into [`history.onVisited`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/history/onVisited) listeners sets the `title` property to the last known title, if we have one.