### PR TITLE
MS Edge supports options and locales in Date.prototype.toLocaleDateString

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2649,7 +2649,7 @@
                     "version_added": "26"
                   },
                   "edge": {
-                    "version_added": null
+                    "version_added": true
                   },
                   "edge_mobile": {
                     "version_added": null
@@ -2700,7 +2700,7 @@
                     "version_added": "26"
                   },
                   "edge": {
-                    "version_added": null
+                    "version_added": true
                   },
                   "edge_mobile": {
                     "version_added": null

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -1116,7 +1116,7 @@
                     "version_added": "26"
                   },
                   "edge": {
-                    "version_added": null
+                    "version_added": true
                   },
                   "edge_mobile": {
                     "version_added": null
@@ -1167,7 +1167,7 @@
                     "version_added": "26"
                   },
                   "edge": {
-                    "version_added": null
+                    "version_added": true
                   },
                   "edge_mobile": {
                     "version_added": null

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1360,7 +1360,7 @@
                     "version_added": "26"
                   },
                   "edge": {
-                    "version_added": null
+                    "version_added": true
                   },
                   "edge_mobile": {
                     "version_added": null
@@ -1411,7 +1411,7 @@
                     "version_added": "26"
                   },
                   "edge": {
-                    "version_added": null
+                    "version_added": true
                   },
                   "edge_mobile": {
                     "version_added": null


### PR DESCRIPTION
I tested several locales and several option values.

[This link](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/ecmascriptinternationalizationapi/?q=date%20category%3Ajavascript) says it's fully supported on Edge and Edge Mobile but I didn't add it as I'm not able to test.

[More docs](https://docs.microsoft.com/en-us/scripting/javascript/reference/intl-collator-object-javascript)