### PR TITLE
Add data for tabs.print() and associated APIs

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -7312,6 +7312,29 @@
               }
             }
           },
+          "PageSettings": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "56"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
           "TAB_ID_NONE": {
             "__compat": {
               "basic_support": {
@@ -8627,6 +8650,52 @@
               }
             }
           },
+          "print": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "56"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "printPreview": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "56"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
           "query": {
             "__compat": {
               "basic_support": {
@@ -8910,6 +8979,29 @@
                   },
                   "firefox_android": {
                     "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
+          },
+          "saveAsPDF": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "56"
+                  },
+                  "firefox_android": {
+                    "version_added": false
                   },
                   "opera": {
                     "version_added": false


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1269300

This adds one type and three methods to Firefox desktop only, in version 56:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/print
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/printPreview
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/saveAsPDF
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/PageSettings

