### PR TITLE
Improved data structure (issue 283)

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -1,162 +1,153 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "ANGLE_instanced_arrays": {
-        "drawArraysInstancedANGLE": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "33.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "api": {
+    "ANGLE_instanced_arrays": {
+      "drawArraysInstancedANGLE": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "33.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "drawElementsInstancedANGLE": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "33.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "drawElementsInstancedANGLE": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "33.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttribDivisorANGLE": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "33.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttribDivisorANGLE": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "33.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_blend_minmax": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "33.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "EXT_blend_minmax": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "33.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_color_buffer_float": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "49.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "EXT_color_buffer_float": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "49.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_color_buffer_half_float": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "30.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "EXT_color_buffer_half_float": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "30.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -1,422 +1,403 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_disjoint_timer_query": {
-        "createQueryEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "api": {
+    "EXT_disjoint_timer_query": {
+      "createQueryEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "deleteQueryEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "deleteQueryEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "isQueryEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "isQueryEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "beginQueryEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "beginQueryEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "endQueryEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "endQueryEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "queryCounterEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "queryCounterEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "getQueryEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getQueryEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "getQueryObjectEXT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getQueryObjectEXT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_frag_depth": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "30.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "EXT_frag_depth": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "30.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_sRGB": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "28.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "EXT_sRGB": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "28.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_shader_texture_lod": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "50.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "EXT_shader_texture_lod": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "50.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "EXT_texture_filter_anisotropic": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "17.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "EXT_texture_filter_anisotropic": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "17.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -1,707 +1,682 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "Gamepad": {
-        "axes": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+  "api": {
+    "Gamepad": {
+      "axes": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
-        },
-        "buttons": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+        }
+      },
+      "buttons": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
-        },
-        "connected": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+        }
+      },
+      "connected": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
-        },
-        "displayId": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "56",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "displayId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "56",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "hand": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "hand": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "hapticActuators": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "hapticActuators": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "id": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+        }
+      },
+      "id": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
-        },
-        "index": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+        }
+      },
+      "index": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
-        },
-        "mapping": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+        }
+      },
+      "mapping": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
-        },
-        "pose": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "pose": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "timestamp": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+        }
+      },
+      "timestamp": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
         }

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -1,149 +1,142 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "GamepadButton": {
-        "pressed": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+  "api": {
+    "GamepadButton": {
+      "pressed": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
-        },
-        "value": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+        }
+      },
+      "value": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
         }

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -1,77 +1,72 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "GamepadEvent": {
-        "gamepad": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "35"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "21",
-                    "version_removed": "34"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "29"
-                  },
-                  {
-                    "version_added": "24",
-                    "version_removed": "28",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.gamepad.enabled",
-                      "value_to_set": "true"
-                    }
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "opera": [
-                  {
-                    "version_added": "22"
-                  },
-                  {
-                    "prefix": "webkit",
-                    "version_added": "15",
-                    "version_removed": "21"
-                  }
-                ],
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "32"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true
+  "api": {
+    "GamepadEvent": {
+      "gamepad": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "21",
+                "version_removed": "34"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
                 }
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "21"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
             }
           }
         }

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -1,111 +1,104 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "GamepadHapticActuator": {
-        "pulse": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+  "api": {
+    "GamepadHapticActuator": {
+      "pulse": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "type": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "type": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
         }

--- a/api/GamepadPose.json
+++ b/api/GamepadPose.json
@@ -1,429 +1,410 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "GamepadPose": {
-        "angularAcceleration": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+  "api": {
+    "GamepadPose": {
+      "angularAcceleration": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "angularVelocity": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "angularVelocity": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "hasOrientation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "hasOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "hasPosition": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "hasPosition": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "linearAcceleration": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "linearAcceleration": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "linearVelocity": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "linearVelocity": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "orientation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "orientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "position": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "true",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.gamepad-extensions.enabled",
-                    "value_to_set": "true"
-                  },
-                  "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+        }
+      },
+      "position": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "true",
+              "flag": {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
         }

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -1,352 +1,333 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "IntersectionObserver": {
       "IntersectionObserver": {
-        "IntersectionObserver": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "root": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "root": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "rootMargin": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "rootMargin": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "thresholds": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "thresholds": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "disconnect": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15",
-                  "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "disconnect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15",
+              "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "observe": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "observe": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "takeRecords": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15",
-                  "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "takeRecords": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15",
+              "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "unobserve": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15",
-                  "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "unobserve": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15",
+              "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
         }

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -1,306 +1,289 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "IntersectionObserverEntry": {
-        "boundingClientRect": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+  "api": {
+    "IntersectionObserverEntry": {
+      "boundingClientRect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "intersectionRatio": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "intersectionRatio": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "intersectionRect": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "intersectionRect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "isIntersecting": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "isIntersecting": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "rootBounds": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "rootBounds": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "target": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "target": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
-        },
-        "time": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": [
-                  {
-                    "version_added": "53",
-                    "version_removed": "55",
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.IntersectionObserver.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "55"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": "51"
+        }
+      },
+      "time": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": [
+              {
+                "version_added": "53",
+                "version_removed": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              {
+                "version_added": "55"
               }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "51"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "51"
             }
           }
         }

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "OES_element_index_uint": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "24.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "OES_element_index_uint": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "24.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "OES_standard_derivatives": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "10.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "OES_standard_derivatives": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "10.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "OES_texture_float": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "6.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "OES_texture_float": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "6.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "OES_texture_float_linear": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "24.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "OES_texture_float_linear": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "24.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "OES_texture_half_float": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "29.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "OES_texture_half_float": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "29.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "OES_texture_half_float_linear": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "30.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "OES_texture_half_float_linear": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "30.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -1,214 +1,203 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "OES_vertex_array_object": {
-        "createVertexArrayOES": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "25.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "api": {
+    "OES_vertex_array_object": {
+      "createVertexArrayOES": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "25.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "deleteVertexArrayOES": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "25.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "deleteVertexArrayOES": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "25.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "isVertexArrayOES": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "25.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "isVertexArrayOES": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "25.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "bindVertexArrayOES": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "25.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "bindVertexArrayOES": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "25.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -1,786 +1,743 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "VRDisplay": {
-        "cancelAnimationFrame": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "capabilities": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "depthFar": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "depthNear": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "displayId": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "displayName": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "exitPresent": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "getEyeParameters": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "getFrameData": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "getLayers": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "getImmediatePose": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+  "api": {
+    "VRDisplay": {
+      "cancelAnimationFrame": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "getPose": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": true
+        }
+      },
+      "capabilities": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "hardwareUnitId": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+        }
+      },
+      "depthFar": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "isConnected": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "depthNear": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "isPresenting": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "displayId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "requestAnimationFrame": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "displayName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "resetPose": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "exitPresent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "requestPresent": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "getEyeParameters": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "stageParameters": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "getFrameData": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "submitFrame": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "getLayers": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "getImmediatePose": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "getPose": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "hardwareUnitId": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "isConnected": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "isPresenting": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "requestAnimationFrame": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "resetPose": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "requestPresent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "stageParameters": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "submitFrame": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
         }

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -1,200 +1,187 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "VRDisplayCapabilities": {
-        "canPresent": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+  "api": {
+    "VRDisplayCapabilities": {
+      "canPresent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "hasExternalDisplay": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "hasExternalDisplay": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "hasPosition": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "hasPosition": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "hasOrientation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "hasOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "maxLayers": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "maxLayers": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
         }

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -1,122 +1,113 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "VRDisplayEvent": {
+      "display": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "reason": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
       "VRDisplayEvent": {
-        "display": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "reason": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "VRDisplayEvent": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
         }

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -1,309 +1,290 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "VREyeParameters": {
-        "fieldOfView": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "maximumFieldOfView": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+  "api": {
+    "VREyeParameters": {
+      "fieldOfView": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "minimumFieldOfView": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+        }
+      },
+      "maximumFieldOfView": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "minimumFieldOfView": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "offset": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "offset": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "recommendedFieldOfView": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "recommendedFieldOfView": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+        }
+      },
+      "renderHeight": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "renderHeight": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "renderRect": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "renderRect": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+        }
+      },
+      "renderWidth": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
-            }
-          }
-        },
-        "renderWidth": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
         }

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -1,198 +1,185 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "VRFieldOfView": {
-        "downDegrees": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "leftDegrees": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "rightDegrees": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "upDegrees": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "VRFieldOfView": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+  "api": {
+    "VRFieldOfView": {
+      "downDegrees": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "leftDegrees": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "rightDegrees": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "upDegrees": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "VRFieldOfView": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
         }

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -1,278 +1,261 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "VRFrameData": {
+      "leftProjectionMatrix": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "leftViewMatrix": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "pose": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "rightProjectionMatrix": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "rightViewMatrix": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "timestamp": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
       "VRFrameData": {
-        "leftProjectionMatrix": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "leftViewMatrix": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "pose": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "rightProjectionMatrix": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "rightViewMatrix": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "timestamp": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "VRFrameData": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
         }

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -1,122 +1,113 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "VRLayerInit": {
-        "leftBounds": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+  "api": {
+    "VRLayerInit": {
+      "leftBounds": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "rightBounds": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "rightBounds": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "source": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "source": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
         }

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -1,350 +1,329 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "VRPose": {
-        "angularAcceleration": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "angularVelocity": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "hasOrientation": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+  "api": {
+    "VRPose": {
+      "angularAcceleration": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "hasPosition": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+        }
+      },
+      "angularVelocity": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "linearAcceleration": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "hasOrientation": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "linearVelocity": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "hasPosition": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
-        },
-        "position": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "orientation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
-            }
-          }
-        },
-        "timestamp": {
-          "__compat": {
-            "basic_support": {
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
+        }
+      },
+      "linearAcceleration": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
               },
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                }
-              }
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "linearVelocity": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "position": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "orientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
+            }
+          }
+        }
+      },
+      "timestamp": {
+        "__compat": {
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          },
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             }
           }
         }

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -1,122 +1,113 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "VRStageParameters": {
-        "sittingToStandingTransform": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+  "api": {
+    "VRStageParameters": {
+      "sittingToStandingTransform": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "sizeX": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "sizeX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
-        },
-        "sizeY": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "WebVR"
-                  },
-                  "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Currently supported only by Google Daydream."
-                }
-              }
+        }
+      },
+      "sizeY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "WebVR"
+              },
+              "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             }
           }
         }

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -1,105 +1,102 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_color_buffer_float": {
+  "api": {
+    "WEBGL_color_buffer_float": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "30.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "RGB32F_EXT": {
         "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "30.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+          "description": "<code>RGB32F_EXT</code> constant",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "30.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
           },
-          "RGB32F_EXT": {
-            "desc": "<code>RGB32F_EXT</code> constant",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "30.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_compressed_texture_astc": {
-        "getSupportedProfiles": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "53.0"
-                },
-                "firefox_android": {
-                  "version_added": "53.0"
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "api": {
+    "WEBGL_compressed_texture_astc": {
+      "getSupportedProfiles": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "53.0"
+            },
+            "firefox_android": {
+              "version_added": "53.0"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_compressed_texture_atc": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "18.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "WEBGL_compressed_texture_atc": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "18.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_compressed_texture_etc": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "51.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "WEBGL_compressed_texture_etc": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "51.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_compressed_texture_etc1": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "30.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "WEBGL_compressed_texture_etc1": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "30.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_compressed_texture_pvrtc": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "18.0"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "WEBGL_compressed_texture_pvrtc": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "18.0"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -1,64 +1,59 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_compressed_texture_s3tc": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": [
-                {
-                  "prefix": "MOZ_",
-                  "version_added": "15.0",
-                  "version_removed": "21.0"
-                },
-                {
-                  "version_added": "22.0"
-                }
-              ],
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+  "api": {
+    "WEBGL_compressed_texture_s3tc": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": [
+            {
+              "prefix": "MOZ_",
+              "version_added": "15.0",
+              "version_removed": "21.0"
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            {
+              "version_added": "22.0"
             }
+          ],
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -1,57 +1,52 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_compressed_texture_s3tc_srgb": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
+  "api": {
+    "WEBGL_compressed_texture_s3tc_srgb": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "55"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -1,68 +1,63 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_debug_renderer_info": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": [
-                {
-                  "version_added": true,
-                  "version_removed": "53.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "webgl.enable-debug-renderer-info",
-                    "value_to_set": "true"
-                  }
-                },
-                {
-                  "version_added": "53.0"
-                }
-              ],
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
+  "api": {
+    "WEBGL_debug_renderer_info": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": [
+            {
+              "version_added": true,
+              "version_removed": "53.0",
+              "flag": {
+                "type": "preference",
+                "name": "webgl.enable-debug-renderer-info",
+                "value_to_set": "true"
               }
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            {
+              "version_added": "53.0"
             }
+          ],
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -1,66 +1,61 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_debug_shaders": {
-        "getTranslatedShaderSource": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "47"
-                },
-                "chrome_android": {
-                  "version_added": "47"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "30.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "webgl.enable-privileged-extensions",
-                    "value_to_set": "true"
-                  },
-                  "notes": [
-                    "The extension is activated by default to privileged contexts (chrome context)."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+  "api": {
+    "WEBGL_debug_shaders": {
+      "getTranslatedShaderSource": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "30.0",
+              "flag": {
+                "type": "preference",
+                "name": "webgl.enable-privileged-extensions",
+                "value_to_set": "true"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+              "notes": [
+                "The extension is activated by default to privileged contexts (chrome context)."
+              ]
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -1,64 +1,59 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_depth_texture": {
-        "__compat": {
-          "basic_support": {
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": [
-                {
-                  "prefix": "MOZ_",
-                  "version_added": true,
-                  "version_removed": "22.0"
-                },
-                {
-                  "version_added": "22.0"
-                }
-              ],
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+  "api": {
+    "WEBGL_depth_texture": {
+      "__compat": {
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": [
+            {
+              "prefix": "MOZ_",
+              "version_added": true,
+              "version_removed": "22.0"
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            {
+              "version_added": "22.0"
             }
+          ],
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -1,70 +1,65 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_draw_buffers": {
-        "drawBuffersWEBGL": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": [
-                  {
-                    "prefix": "MOZ_",
-                    "version_added": true,
-                    "version_removed": "28.0",
-                    "flag": {
-                      "type": "preference",
-                      "name": "webgl.enable-draft-extensions",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "28.0"
-                  }
-                ],
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
+  "api": {
+    "WEBGL_draw_buffers": {
+      "drawBuffersWEBGL": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "prefix": "MOZ_",
+                "version_added": true,
+                "version_removed": "28.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "webgl.enable-draft-extensions",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              {
+                "version_added": "28.0"
               }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -1,124 +1,117 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
-      "WEBGL_lose_context": {
-        "loseContext": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": [
-                  {
-                    "prefix": "MOZ_",
-                    "version_added": "19.0",
-                    "version_removed": "22.0"
-                  },
-                  {
-                    "version_added": "22.0"
-                  }
-                ],
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+  "api": {
+    "WEBGL_lose_context": {
+      "loseContext": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "prefix": "MOZ_",
+                "version_added": "19.0",
+                "version_removed": "22.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              {
+                "version_added": "22.0"
               }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "restoreContext": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": [
-                  {
-                    "prefix": "MOZ_",
-                    "version_added": "19.0",
-                    "version_removed": "22.0"
-                  },
-                  {
-                    "version_added": "22.0"
-                  }
-                ],
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+        }
+      },
+      "restoreContext": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "prefix": "MOZ_",
+                "version_added": "19.0",
+                "version_removed": "22.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              {
+                "version_added": "22.0"
               }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -1,5206 +1,5003 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGL2RenderingContext": {
       "WebGL2RenderingContext": {
-        "WebGL2RenderingContext": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "beginQuery": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "beginTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bindBufferBase": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bindBufferRange": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bindSampler": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bindTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bindVertexArray": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "blitFramebuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "clearBufferfi": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "clearBufferfv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "clearBufferiv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "clearBufferuiv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "clientWaitSync": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "compressedTexImage3D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "compressedTexSubImage3D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "copyBufferSubData": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "copyTexSubImage3D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createQuery": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createSampler": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createVertexArray": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteQuery": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteSampler": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteSync": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteVertexArray": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawArraysInstanced": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawBuffers": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawElementsInstanced": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawRangeElements": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "endQuery": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "endTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "fenceSync": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "framebufferTextureLayer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getActiveUniformBlockName": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getActiveUniformBlockParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getActiveUniforms": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getBufferSubData": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getFragDataLocation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getInternalformatParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getQuery": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getQueryParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getSamplerParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getSyncParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getTransformFeedbackVarying": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getUniformBlockIndex": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getUniformIndices": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getIndexedParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "invalidateFramebuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "invalidateSubFramebuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isQuery": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isSampler": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isSync": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isVertexArray": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "pauseTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "readBuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "renderbufferStorageMultisample": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "resumeTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "samplerParameteri": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "samplerParameterf": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "texImage3D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "texStorage2D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "texStorage3D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "texSubImage3D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "transformFeedbackVaryings": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform1uiv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform1ui": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform1i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform1f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2uiv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2ui": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3uiv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3ui": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4uiv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4ui": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformBlockBinding": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix2fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix2x3fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix2x4fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix3fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix3x2fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix3x4fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix4fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix4x2fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix4x3fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "vertexAttribDivisor": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "vertexAttribI4i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "vertexAttribI4iv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "vertexAttribI4ui": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "vertexAttribI4uiv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "vertexAttribIPointer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "waitSync": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beginQuery": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beginTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindBufferBase": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindBufferRange": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindSampler": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindVertexArray": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blitFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clearBufferfi": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clearBufferfv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clearBufferiv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clearBufferuiv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clientWaitSync": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compressedTexImage3D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compressedTexSubImage3D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyBufferSubData": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyTexSubImage3D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createQuery": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createSampler": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createVertexArray": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteQuery": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteSampler": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteSync": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteVertexArray": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawArraysInstanced": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawBuffers": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawElementsInstanced": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawRangeElements": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "endQuery": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "endTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fenceSync": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "framebufferTextureLayer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getActiveUniformBlockName": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getActiveUniformBlockParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getActiveUniforms": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getBufferSubData": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getFragDataLocation": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getInternalformatParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getQuery": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getQueryParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getSamplerParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getSyncParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getTransformFeedbackVarying": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getUniformBlockIndex": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getUniformIndices": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getIndexedParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "invalidateFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "invalidateSubFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isQuery": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isSampler": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isSync": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isVertexArray": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pauseTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readBuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "renderbufferStorageMultisample": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resumeTransformFeedback": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "samplerParameteri": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "samplerParameterf": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texImage3D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texStorage2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texStorage3D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texSubImage3D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transformFeedbackVaryings": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1uiv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1ui": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2uiv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2ui": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3uiv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3ui": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4uiv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4ui": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformBlockBinding": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix2fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix2x3fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix2x4fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix3fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix3x2fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix3x4fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix4fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix4x2fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix4x3fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribDivisor": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribI4i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribI4iv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribI4ui": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribI4uiv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribIPointer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "waitSync": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -1,268 +1,259 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLActiveInfo": {
       "WebGLActiveInfo": {
-        "WebGLActiveInfo": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "name": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "size": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "size": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "type": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "type": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -1,111 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLBuffer": {
       "WebGLBuffer": {
-        "WebGLBuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -1,164 +1,159 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLContextEvent": {
       "WebGLContextEvent": {
-        "WebGLContextEvent": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49"
-                },
-                "firefox_android": {
-                  "version_added": "49"
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "49",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "statusMessage": {
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49"
-                },
-                "firefox_android": {
-                  "version_added": "49"
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
+          }
+        }
+      },
+      "statusMessage": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -1,111 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLFramebuffer": {
       "WebGLFramebuffer": {
-        "WebGLFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -1,111 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLProgram": {
       "WebGLProgram": {
-        "WebGLProgram": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLQuery": {
       "WebGLQuery": {
-        "WebGLQuery": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -1,111 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLRenderbuffer": {
       "WebGLRenderbuffer": {
-        "WebGLRenderbuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -1,8950 +1,8731 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLRenderingContext": {
       "WebGLRenderingContext": {
-        "WebGLRenderingContext": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12",
+              "notes": [
+                "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
+              ]
+            },
+            "edge_mobile": {
+              "version_added": true,
+              "notes": [
+                "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
+              ]
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
+              ]
+            },
+            "ie_mobile": {
+              "version_added": "11",
+              "notes": [
+                "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
+              ]
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12",
-                  "notes": [
-                    "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
-                  ]
-                },
-                "edge_mobile": {
-                  "version_added": true,
-                  "notes": [
-                    "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
-                  ]
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11",
-                  "notes": [
-                    "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
-                  ]
-                },
-                "ie_mobile": {
-                  "version_added": "11",
-                  "notes": [
-                    "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
-                  ]
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "activeTexture": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "activeTexture": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "attachShader": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindAttribLocation": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindBuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "attachShader": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bindAttribLocation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bindBuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "bindFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "bindFramebuffer": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "bindRenderbuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "bindRenderbuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindTexture": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "bindTexture": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "blendColor": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "blendColor": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendEquation": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "blendEquation": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "blendEquationSeparate": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "blendEquationSeparate": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "blendFunc": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "blendFunc": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendFuncSeparate": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bufferData": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "blendFuncSeparate": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "bufferData": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "bufferSubData": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "bufferSubData": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "canvas": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "canvas": {
+        "OffscreenCanvas": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "OffscreenCanvas": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "checkFramebufferStatus": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "checkFramebufferStatus": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "clear": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "clear": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "clearColor": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "clearColor": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "clearDepth": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "clearDepth": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "clearStencil": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "clearStencil": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "colorMask": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "colorMask": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "commit": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "compileShader": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "compressedTexImage2D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+        }
+      },
+      "commit": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "44.0",
+              "flag": {
+                "type": "preference",
+                "name": "gfx.offscreencanvas.enabled",
+                "value_to_set": "true"
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compileShader": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compressedTexImage2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "compressedTexSubImage2D": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "copyTexImage2D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "compressedTexSubImage2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "copyTexSubImage2D": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createBuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createFramebuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createProgram": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createRenderbuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createShader": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "createTexture": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox_android": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "cullFace": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "ie": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteBuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "ie_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteFramebuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "opera": {
+                "version_added": "43"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteProgram": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "opera_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteRenderbuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "safari": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteShader": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "deleteTexture": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "depthFunc": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "depthMask": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "depthRange": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "detachShader": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "disable": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "disableVertexAttribArray": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawArrays": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawElements": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawingBufferHeight": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "drawingBufferWidth": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "enable": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "enableVertexAttribArray": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "finish": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "flush": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "framebufferRenderbuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "copyTexImage2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyTexSubImage2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createBuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createProgram": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createRenderbuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createShader": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createTexture": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cullFace": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteBuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteProgram": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteRenderbuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteShader": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteTexture": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "depthFunc": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "depthMask": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "depthRange": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "detachShader": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disable": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disableVertexAttribArray": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawArrays": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawElements": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawingBufferHeight": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawingBufferWidth": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "enable": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "enableVertexAttribArray": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "finish": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "flush": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "framebufferRenderbuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "framebufferTexture2D": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "frontFace": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "framebufferTexture2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "generateMipmap": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "getActiveAttrib": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "frontFace": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "generateMipmap": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "getActiveUniform": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getAttachedShaders": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getAttribLocation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getBufferParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "getContextAttributes": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getActiveAttrib": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getActiveUniform": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getAttachedShaders": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getAttribLocation": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getBufferParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "getError": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getExtension": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getFramebufferAttachmentParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "getParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getContextAttributes": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getError": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getExtension": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getFramebufferAttachmentParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "getProgramInfoLog": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getProgramParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "getParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getProgramInfoLog": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getProgramParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "getRenderbufferParameter": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "getShaderInfoLog": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getRenderbufferParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "getShaderParameter": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getShaderPrecisionFormat": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getShaderSource": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getSupportedExtensions": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "getTexParameter": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "getShaderInfoLog": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getShaderParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getShaderPrecisionFormat": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getShaderSource": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getSupportedExtensions": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getTexParameter": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "getUniform": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "getUniformLocation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getUniform": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "getVertexAttrib": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "getVertexAttribOffset": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getUniformLocation": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getVertexAttrib": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "hint": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isBuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isContextLost": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isEnabled": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "isFramebuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "getVertexAttribOffset": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hint": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isBuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isContextLost": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isEnabled": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "isProgram": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isRenderbuffer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isShader": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "isTexture": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "lineWidth": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+              "edge_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "linkProgram": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "pixelStorei": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox_android": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "polygonOffset": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "isFramebuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isProgram": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isRenderbuffer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isShader": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isTexture": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lineWidth": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "linkProgram": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pixelStorei": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "readPixels": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "polygonOffset": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readPixels": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "renderbufferStorage": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "sampleCoverage": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "renderbufferStorage": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "scissor": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "shaderSource": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "stencilFunc": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "stencilFuncSeparate": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "stencilMask": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "stencilMaskSeparate": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "stencilOp": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox_android": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "stencilOpSeparate": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "ie": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "texImage2D": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "ie_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "sampleCoverage": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scissor": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shaderSource": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilFunc": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilFuncSeparate": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilMask": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilMaskSeparate": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilOp": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilOpSeparate": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texImage2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "texParameterf": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "texParameterf": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "texParameteri": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "texParameteri": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "texSubImage2D": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "uniform1f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "texSubImage2D": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "uniform1fv": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform1i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome": {
+                "version_added": "56"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform1iv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "chrome_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "edge_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform2iv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "firefox_android": {
+                "version_added": "51.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "ie": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "ie_mobile": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "opera": {
+                "version_added": "43"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform3iv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "opera_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+              "safari": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4i": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniform4iv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "uniformMatrix2fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "uniform1f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1iv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2iv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3iv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4i": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4iv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniformMatrix2fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "uniformMatrix3fv": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
+        }
+      },
+      "uniformMatrix3fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         },
-        "uniformMatrix4fv": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "WebGL2": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": "51.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "useProgram": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "uniformMatrix4fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
-        "validateProgram": {
+        "WebGL2": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51.0"
+              },
+              "firefox_android": {
+                "version_added": "51.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "vertexAttrib1f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "useProgram": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttrib1fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "validateProgram": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttrib2f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib1f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttrib2fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib1fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttrib3f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib2f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttrib3fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib2fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttrib4f": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib3f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttrib4fv": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib3fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "vertexAttribPointer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib4f": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "viewport": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "vertexAttrib4fv": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribPointer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "viewport": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLSampler": {
       "WebGLSampler": {
-        "WebGLSampler": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -1,111 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLShader": {
       "WebGLShader": {
-        "WebGLShader": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -1,268 +1,259 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLShaderPrecisionFormat": {
       "WebGLShaderPrecisionFormat": {
-        "WebGLShaderPrecisionFormat": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
-        },
-        "rangeMin": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "rangeMin": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "rangeMax": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "rangeMax": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "precision": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "precision": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLSync": {
       "WebGLSync": {
-        "WebGLSync": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -1,111 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLTexture": {
       "WebGLTexture": {
-        "WebGLTexture": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WebGLTransformFeedback.json
+++ b/api/WebGLTransformFeedback.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLTransformFeedback": {
       "WebGLTransformFeedback": {
-        "WebGLTransformFeedback": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -1,111 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLUniformLocation": {
       "WebGLUniformLocation": {
-        "WebGLUniformLocation": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "9"
-                },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": "11"
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "8.1"
+            "description": "Available in workers",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "worker_support": {
-              "desc": "Available in workers",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WebGLVertexArrayObject.json
+++ b/api/WebGLVertexArrayObject.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLVertexArrayObject": {
       "WebGLVertexArrayObject": {
-        "WebGLVertexArrayObject": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "56"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "43"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51.0"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "api": {
+  "api": {
+    "WebGLVertexArrayObjectOES": {
       "WebGLVertexArrayObjectOES": {
-        "WebGLVertexArrayObjectOES": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "25.0"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "25.0"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -84,10 +84,10 @@
       "additionalProperties": false
     },
 
-    "subfeature": {
+    "compat_statement": {
       "type": "object",
       "properties": {
-        "desc": { "type": ["string"] },
+        "description": { "type": "string" },
         "support": { "$ref": "#/definitions/compat_block" },
         "status": { "$ref": "#/definitions/status_statement" }
       },
@@ -95,41 +95,21 @@
       "additionalProperties": false
     },
 
-    "subfeature_set": {
-      "type": "object",
-      "patternProperties": {
-        "^(?!__compat).+$" : { "$ref": "#/definitions/subfeature" }
-      },
-      "required": ["basic_support"],
-      "additionalProperties": false
-    },
-
     "identifier": {
       "type": "object",
       "properties": {
-        "__compat": { "$ref": "#/definitions/subfeature_set" }
+        "__compat": { "$ref": "#/definitions/compat_statement" }
       },
       "patternProperties":{
         "^(?!__compat|.*\\.).+$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
-    },
-
-    "compat_data": {
-      "type": "object",
-      "patternProperties": {
-        "^(?!__compat|.*\\.).+$" : { "$ref": "#/definitions/identifier" }
-      },
-      "additionalProperties": false
     }
-
   },
 
   "type": "object",
-  "properties": {
-    "version": { "type": "string"},
-    "data": { "$ref" : "#/definitions/compat_data" }
+  "patternProperties": {
+    "^(?!__compat|.*\\.).+$": { "$ref": "#/definitions/identifier" }
   },
-  "required": ["version", "data"],
   "additionalProperties": false
 }

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -1,155 +1,154 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-attachment": {
+  "css": {
+    "properties": {
+      "background-attachment": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "10.0"
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multiple_backgrounds": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "4"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "3.5"
-                },
-                "opera_android": {
-                  "version_added": "10.0"
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
+            "description": "Multiple backgrounds",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": "10.0"
+              },
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
               }
             },
-            "multiple_backgrounds": {
-              "desc": "Multiple backgrounds",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "10.0"
-                },
-                "safari": {
-                  "version_added": "1.3"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "local": {
+          "__compat": {
+            "description": "<code>local</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "5.0"
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "local": {
-              "desc": "<code>local</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "25"
-                },
-                "firefox_android": {
-                  "version_added": "25"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "5.0"
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -1,180 +1,179 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-clip": {
+  "css": {
+    "properties": {
+      "background-clip": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "4.1"
+            },
+            "chrome": {
+              "version_added": "1.0",
+              "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0",
+              "notes": "Gecko supported, from version 1.1 to version 1.9.2, corresponding to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+            },
+            "firefox_android": {
+              "version_added": "14.0"
+            },
+            "ie": {
+              "version_added": "9.0",
+              "notes": "In IE 7 and IE 8 of Internet Explorer, this property always behaved like <code>background-clip: padding</code> when <code>overflow</code> was <code>hidden</code>, <code>auto</code>, or <code>scroll</code>."
+            },
+            "ie_mobile": {
+              "version_added": "7.1"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "3.0",
+              "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "content-box": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "4.1"
-                },
-                "chrome": {
-                  "version_added": "1.0",
-                  "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0",
-                  "notes": "Gecko supported, from version 1.1 to version 1.9.2, corresponding to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
-                },
-                "firefox_android": {
-                  "version_added": "14.0"
-                },
-                "ie": {
-                  "version_added": "9.0",
-                  "notes": "In IE 7 and IE 8 of Internet Explorer, this property always behaved like <code>background-clip: padding</code> when <code>overflow</code> was <code>hidden</code>, <code>auto</code>, or <code>scroll</code>."
-                },
-                "ie_mobile": {
-                  "version_added": "7.1"
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "12.1"
-                },
-                "safari": {
-                  "version_added": "3.0",
-                  "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "<code>content-box</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "4.1"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "4.0",
+                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+              },
+              "firefox_android": {
+                "version_added": "14.0"
+              },
+              "ie": {
+                "version_added": "9.0",
+                "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>"
+              },
+              "ie_mobile": {
+                "version_added": "7.1"
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": "12.1"
+              },
+              "safari": {
+                "version_added": "3.0"
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "content-box": {
-              "desc": "<code>content-box</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": "4.1"
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0",
-                  "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
-                },
-                "firefox_android": {
-                  "version_added": "14.0"
-                },
-                "ie": {
-                  "version_added": "9.0",
-                  "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>"
-                },
-                "ie_mobile": {
-                  "version_added": "7.1"
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "12.1"
-                },
-                "safari": {
-                  "version_added": "3.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "text": {
+          "__compat": {
+            "description": "<code>text</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true,
+                "prefix": "-webkit-",
+                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": [
+                {
+                  "version_added": "12",
+                  "prefix": "-webkit-",
+                  "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                },
+                {
+                  "version_added": "15"
+                }
+              ],
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49.0",
+                "notes": "In Firefox 48, it was not activated by default and its support could be activated by setting <code>layout.css.background-clip-text.enabled</code> pref to <code>true</code>."
+              },
+              "firefox_android": {
+                "version_added": "49.0",
+                "notes": "In Firefox 48, it was not activated by default and its support could be activated by setting <code>layout.css.background-clip-text.enabled</code> pref to <code>true</code>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true,
+                "prefix": "-webkit-",
+                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+              },
+              "opera_android": {
+                "version_added": true,
+                "prefix": "-webkit-",
+                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+              },
+              "safari": {
+                "version_added": true,
+                "prefix": "-webkit-",
+                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+              },
+              "safari_ios": {
+                "version_added": true,
+                "prefix": "-webkit-",
+                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               }
             },
-            "text": {
-              "desc": "<code>text</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": true,
-                  "prefix": "-webkit-",
-                  "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": [
-                  {
-                    "version_added": "12",
-                    "prefix": "-webkit-",
-                    "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
-                  },
-                  {
-                    "version_added": "15"
-                  }
-                ],
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49.0",
-                  "notes": "In Firefox 48, it was not activated by default and its support could be activated by setting <code>layout.css.background-clip-text.enabled</code> pref to <code>true</code>."
-                },
-                "firefox_android": {
-                  "version_added": "49.0",
-                  "notes": "In Firefox 48, it was not activated by default and its support could be activated by setting <code>layout.css.background-clip-text.enabled</code> pref to <code>true</code>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true,
-                  "prefix": "-webkit-",
-                  "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
-                },
-                "opera_android": {
-                  "version_added": true,
-                  "prefix": "-webkit-",
-                  "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
-                },
-                "safari": {
-                  "version_added": true,
-                  "prefix": "-webkit-",
-                  "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
-                },
-                "safari_ios": {
-                  "version_added": true,
-                  "prefix": "-webkit-",
-                  "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -1,107 +1,104 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-color": {
+  "css": {
+    "properties": {
+      "background-color": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "4.0",
+              "notes": "In Internet Explorer 8 and 9, there is a bug where a computed <code>background-color</code> of <code>transparent</code> causes <code>click</code> events to not get fired on overlaid elements."
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "alpha_ch_for_hex": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "4.0",
-                  "notes": "In Internet Explorer 8 and 9, there is a bug where a computed <code>background-color</code> of <code>transparent</code> causes <code>click</code> events to not get fired on overlaid elements."
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "3.5"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "Alpha channel for hex values",
+            "support": {
+              "webview_android": {
+                "version_added": "52.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "52.0"
+              },
+              "chrome_android": {
+                "version_added": "52.0"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "alpha_ch_for_hex": {
-              "desc": "Alpha channel for hex values",
-              "support": {
-                "webview_android": {
-                  "version_added": "52.0"
-                },
-                "chrome": {
-                  "version_added": "52.0"
-                },
-                "chrome_android": {
-                  "version_added": "52.0"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -1,370 +1,377 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-image": {
+  "css": {
+    "properties": {
+      "background-image": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0",
+              "notes": [
+                "If the <code>browser.display.use_document_colors</code> user preference in <code>about:config</code> is set to <code>false</code>, background images will not be displayed."
+              ]
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multiple_backgrounds": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0",
-                  "notes": [
-                    "If the <code>browser.display.use_document_colors</code> user preference in <code>about:config</code> is set to <code>false</code>, background images will not be displayed."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "4"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "3.5"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "Multiple backgrounds",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "multiple_backgrounds": {
-              "desc": "Multiple backgrounds",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "1.3"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "gradients": {
+          "__compat": {
+            "description": "Gradients",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0",
+                "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
+              },
+              "chrome_android": {
+                "version_added": true,
+                "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6",
+                "notes": "Some versions support only experimental gradients prefixed with <code>-moz</code>."
+              },
+              "firefox_android": {
+                "version_added": true,
+                "notes": "Some versions support only experimental gradients prefixed with <code>-moz</code>."
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "11",
+                "notes": "Some versions support only experimental gradients prefixed with <code>-o</code>."
+              },
+              "opera_android": {
+                "version_added": true,
+                "notes": "Some versions support only experimental gradients prefixed with <code>-o</code>."
+              },
+              "safari": {
+                "version_added": "4.0",
+                "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
+              },
+              "safari_ios": {
+                "version_added": true,
+                "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               }
             },
-            "gradients": {
-              "desc": "Gradients",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0",
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6",
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-moz</code>."
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-moz</code>."
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "11",
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-o</code>."
-                },
-                "opera_android": {
-                  "version_added": true,
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-o</code>."
-                },
-                "safari": {
-                  "version_added": "4.0",
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
-                },
-                "safari_ios": {
-                  "version_added": true,
-                  "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "svg_images": {
+          "__compat": {
+            "description": "SVG images",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "8.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "4.0"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "5.0",
+                "notes": "Support of SVG in CSS background is incomplete."
+              },
+              "safari_ios": {
+                "version_added": "5.0",
+                "notes": "Support of SVG in CSS background is incomplete."
               }
             },
-            "svg_images": {
-              "desc": "SVG images",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": "8.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "9.5"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "5.0",
-                  "notes": "Support of SVG in CSS background is incomplete."
-                },
-                "safari_ios": {
-                  "version_added": "5.0",
-                  "notes": "Support of SVG in CSS background is incomplete."
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "element": {
+          "__compat": {
+            "description": "<code>element()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "notes": "<code>element()</code> is supported only in its <code>-moz-element()</code> prefixed version"
+              },
+              "firefox_android": {
+                "version_added": true,
+                "notes": "<code>element()</code> is supported only in its <code>-moz-element()</code> prefixed version"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "element": {
-              "desc": "<code>element()</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": true,
-                  "notes": "<code>element()</code> is supported only in its <code>-moz-element()</code> prefixed version"
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "notes": "<code>element()</code> is supported only in its <code>-moz-element()</code> prefixed version"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "image-rect": {
+          "__compat": {
+            "description": "<code>image-rect()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": true,
+                "notes": "<code>image-rect()</code> is supported only in its <code>-moz-image-rect()</code> prefixed version."
+              },
+              "firefox_android": {
+                "prefix": "-moz-",
+                "version_added": true,
+                "notes": "<code>image-rect()</code> is supported only in its <code>-moz-image-rect()</code> prefixed version."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "image-rect": {
-              "desc": "<code>image-rect()</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "prefix": "-moz-",
-                  "version_added": true,
-                  "notes": "<code>image-rect()</code> is supported only in its <code>-moz-image-rect()</code> prefixed version."
-                },
-                "firefox_android": {
-                  "prefix": "-moz-",
-                  "version_added": true,
-                  "notes": "<code>image-rect()</code> is supported only in its <code>-moz-image-rect()</code> prefixed version."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "any_image": {
+          "__compat": {
+            "description": "Any <code>&lt;image&gt;</code> value",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "any_image": {
-              "desc": "Any <code>&lt;image&gt;</code> value",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -1,116 +1,113 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-origin": {
+  "css": {
+    "properties": {
+      "background-origin": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "4.1"
+            },
+            "chrome": {
+              "version_added": "1.0",
+              "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0",
+              "notes": [
+                "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>.",
+                "Since Firefox 49, also supports the <code>-webkit</code> prefixed version of the property."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "14.0"
+            },
+            "ie": {
+              "version_added": "9.0",
+              "notes": "In IE 7 and before, Internet explorer was behaving as if <code>background-origin: border-box</code> was set. In Internet Explorer 8, as if <code>background-origin: padding-box</code>, the regular default value, was set."
+            },
+            "ie_mobile": {
+              "version_added": "7.1"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "3.0",
+              "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "content-box": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "4.1"
-                },
-                "chrome": {
-                  "version_added": "1.0",
-                  "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0",
-                  "notes": [
-                    "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>.",
-                    "Since Firefox 49, also supports the <code>-webkit</code> prefixed version of the property."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "14.0"
-                },
-                "ie": {
-                  "version_added": "9.0",
-                  "notes": "In IE 7 and before, Internet explorer was behaving as if <code>background-origin: border-box</code> was set. In Internet Explorer 8, as if <code>background-origin: padding-box</code>, the regular default value, was set."
-                },
-                "ie_mobile": {
-                  "version_added": "7.1"
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "12.1"
-                },
-                "safari": {
-                  "version_added": "3.0",
-                  "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "<code>content-box</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "4.1"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "4.0",
+                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+              },
+              "firefox_android": {
+                "version_added": "14.0"
+              },
+              "ie": {
+                "version_added": "9.0",
+                "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>."
+              },
+              "ie_mobile": {
+                "version_added": "7.1"
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": "12.1"
+              },
+              "safari": {
+                "version_added": "3.0",
+                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "content-box": {
-              "desc": "<code>content-box</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": "4.1"
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0",
-                  "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
-                },
-                "firefox_android": {
-                  "version_added": "14.0"
-                },
-                "ie": {
-                  "version_added": "9.0",
-                  "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>."
-                },
-                "ie_mobile": {
-                  "version_added": "7.1"
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "12.1"
-                },
-                "safari": {
-                  "version_added": "3.0",
-                  "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -1,106 +1,103 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-position-x": {
+  "css": {
+    "properties": {
+      "background-position-x": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49.0"
+            },
+            "firefox_android": {
+              "version_added": "49.0"
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "two_value_syntax": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49.0"
-                },
-                "firefox_android": {
-                  "version_added": "49.0"
-                },
-                "ie": {
-                  "version_added": "6"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+            "description": "Two-value syntax (support for offsets from any edge)",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49.0"
+              },
+              "firefox_android": {
+                "version_added": "49.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "two_value_syntax": {
-              "desc": "Two-value syntax (support for offsets from any edge)",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49.0"
-                },
-                "firefox_android": {
-                  "version_added": "49.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -1,106 +1,103 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-position-y": {
+  "css": {
+    "properties": {
+      "background-position-y": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49.0"
+            },
+            "firefox_android": {
+              "version_added": "49.0"
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "2_value_syntax": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49.0"
-                },
-                "firefox_android": {
-                  "version_added": "49.0"
-                },
-                "ie": {
-                  "version_added": "6"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+            "description": "Two-value syntax (support for offsets from any edge)",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49.0"
+              },
+              "firefox_android": {
+                "version_added": "49.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "2_value_syntax": {
-              "desc": "Two-value syntax (support for offsets from any edge)",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49.0"
-                },
-                "firefox_android": {
-                  "version_added": "49.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -1,155 +1,154 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-position": {
+  "css": {
+    "properties": {
+      "background-position": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multiple_backgrounds": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "4"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "3.5"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "Multiple backgrounds",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "multiple_backgrounds": {
-              "desc": "Multiple backgrounds",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "1.3"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "4_value_syntax": {
+          "__compat": {
+            "description": "Four-value syntax (support for offsets from any edge)",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "25.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "13.0"
+              },
+              "firefox_android": {
+                "version_added": "13.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.0"
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "4_value_syntax": {
-              "desc": "Four-value syntax (support for offsets from any edge)",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "25.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "13.0"
-                },
-                "firefox_android": {
-                  "version_added": "13.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "7.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -1,204 +1,205 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-repeat": {
+  "css": {
+    "properties": {
+      "background-repeat": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multiple_backgrounds": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "4"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "3.5"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+            "description": "Multiple backgrounds",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "multiple_backgrounds": {
-              "desc": "Multiple backgrounds",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "9"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "1.3"
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "2-value": {
+          "__compat": {
+            "description": "Two-value syntax (different values for x & y directions)",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "13.0"
+              },
+              "firefox_android": {
+                "version_added": "13.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "2-value": {
-              "desc": "Two-value syntax (different values for x & y directions)",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "13.0"
-                },
-                "firefox_android": {
-                  "version_added": "13.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "round_space": {
+          "__compat": {
+            "description": "<code>round</code> and <code>space</code> keywords",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49.0"
+              },
+              "firefox_android": {
+                "version_added": "49.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "round_space": {
-              "desc": "<code>round</code> and <code>space</code> keywords",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "49.0"
-                },
-                "firefox_android": {
-                  "version_added": "49.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -1,197 +1,196 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background-size": {
+  "css": {
+    "properties": {
+      "background-size": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.3"
+            },
+            "chrome": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0",
+                "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
+              },
+              {
+                "version_added": "3.0",
+                "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": "3.6"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "version_added": "4.0"
+              }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": "1.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "version_added": "4.0"
+              }
+            ],
+            "ie": {
+              "version_added": "9.0"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": [
+              {
+                "prefix": "-o-",
+                "version_added": "9.5",
+                "notes": "Opera 9.5's computation of the background positioning area is incorrect for fixed backgrounds. Opera 9.5 also interprets the two-value form as a horizontal scaling factor and, from appearances, a vertical clipping dimension. This has been fixed in Opera 10."
+              },
+              {
+                "version_added": "10"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.0",
+                "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
+              },
+              {
+                "version_added": "4.1"
+              }
+            ],
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "contain_and_cover": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.3"
-                },
-                "chrome": [
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "1.0",
-                    "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
-                  },
-                  {
-                    "version_added": "3.0",
-                    "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
-                  }
-                ],
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "3.6"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "49"
-                  },
-                  {
-                    "version_added": "4.0"
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "1.0"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "49"
-                  },
-                  {
-                    "version_added": "4.0"
-                  }
-                ],
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": [
-                  {
-                    "prefix": "-o-",
-                    "version_added": "9.5",
-                    "notes": "Opera 9.5's computation of the background positioning area is incorrect for fixed backgrounds. Opera 9.5 also interprets the two-value form as a horizontal scaling factor and, from appearances, a vertical clipping dimension. This has been fixed in Opera 10."
-                  },
-                  {
-                    "version_added": "10"
-                  }
-                ],
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": [
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "3.0",
-                    "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
-                  },
-                  {
-                    "version_added": "4.1"
-                  }
-                ],
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "<contain> and <cover>",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "3.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": "10.0"
+              },
+              "opera": {
+                "version_added": "10.0"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "contain_and_cover": {
-              "desc": "<contain> and <cover>",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "3.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "9"
-                },
-                "ie_mobile": {
-                  "version_added": "10.0"
-                },
-                "opera": {
-                  "version_added": "10.0"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "4.1"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "SVG_image_as_background": {
+          "__compat": {
+            "description": "SVG image as background",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "44.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "8.0"
+              },
+              "firefox_android": {
+                "version_added": "8.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "31.0"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "SVG_image_as_background": {
-              "desc": "SVG image as background",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "44.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "8.0"
-                },
-                "firefox_android": {
-                  "version_added": "8.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "31.0"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -1,302 +1,307 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "background": {
+  "css": {
+    "properties": {
+      "background": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "10.0"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "5.0"
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multiple_backgrounds": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "4"
-                },
-                "ie_mobile": {
-                  "version_added": "10.0"
-                },
-                "opera": {
-                  "version_added": "3.5"
-                },
-                "opera_android": {
-                  "version_added": "5.0"
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
+            "description": "Multiple backgrounds",
+            "support": {
+              "webview_android": {
+                "version_added": "2.1"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": "10.0"
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
               }
             },
-            "multiple_backgrounds": {
-              "desc": "Multiple backgrounds",
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "9"
-                },
-                "ie_mobile": {
-                  "version_added": "10.0"
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "1.3"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "SVG_image_as_background": {
+          "__compat": {
+            "description": "SVG image as background",
+            "support": {
+              "webview_android": {
+                "version_added": "3.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "31.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "9.0"
+              },
+              "firefox_android": {
+                "version_added": "4.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": "10.0"
+              },
+              "opera": {
+                "version_added": "21.0"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
               }
             },
-            "SVG_image_as_background": {
-              "desc": "SVG image as background",
-              "support": {
-                "webview_android": {
-                  "version_added": "3.0"
-                },
-                "chrome": {
-                  "version_added": "31.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "9.0"
-                },
-                "firefox_android": {
-                  "version_added": "4.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": "10.0"
-                },
-                "opera": {
-                  "version_added": "21.0"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "4.2"
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "background-size": {
+          "__compat": {
+            "description": "Values of <code>background-size</code> longhand",
+            "support": {
+              "webview_android": {
+                "version_added": "3.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "21.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "9.0"
+              },
+              "firefox_android": {
+                "version_added": "18.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": "10.0"
+              },
+              "opera": {
+                "version_added": "21.0"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.0"
               }
             },
-            "background-size": {
-              "desc": "Values of <code>background-size</code> longhand",
-              "support": {
-                "webview_android": {
-                  "version_added": "3.0"
-                },
-                "chrome": {
-                  "version_added": "21.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "9.0"
-                },
-                "firefox_android": {
-                  "version_added": "18.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": "10.0"
-                },
-                "opera": {
-                  "version_added": "21.0"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "4.0"
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "background-origin": {
+          "__compat": {
+            "description": "Values of <code>background-origin</code> longhand",
+            "support": {
+              "webview_android": {
+                "version_added": "3.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "21.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "22.0"
+              },
+              "firefox_android": {
+                "version_added": "22.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": "10.0"
+              },
+              "opera": {
+                "version_added": "21.0"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.0"
               }
             },
-            "background-origin": {
-              "desc": "Values of <code>background-origin</code> longhand",
-              "support": {
-                "webview_android": {
-                  "version_added": "3.0"
-                },
-                "chrome": {
-                  "version_added": "21.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "22.0"
-                },
-                "firefox_android": {
-                  "version_added": "22.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": "10.0"
-                },
-                "opera": {
-                  "version_added": "21.0"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "4.0"
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "background-clip": {
+          "__compat": {
+            "description": "Values of <code>background-clip</code> longhand",
+            "support": {
+              "webview_android": {
+                "version_added": "3.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "21.0"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "22.0"
+              },
+              "firefox_android": {
+                "version_added": "22.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": "10.0"
+              },
+              "opera": {
+                "version_added": "21.0"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.0"
               }
             },
-            "background-clip": {
-              "desc": "Values of <code>background-clip</code> longhand",
-              "support": {
-                "webview_android": {
-                  "version_added": "3.0"
-                },
-                "chrome": {
-                  "version_added": "21.0"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "22.0"
-                },
-                "firefox_android": {
-                  "version_added": "22.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": "10.0"
-                },
-                "opera": {
-                  "version_added": "21.0"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": {
-                  "version_added": "4.0"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -1,96 +1,91 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "properties": {
-        "text-align-last": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": [
-                  {
-                    "version_added": "35.0",
-                    "version_removed": "47.0",
-                    "flag": {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "47.0"
-                  }
-                ],
-                "chrome_android": [
-                  {
-                    "version_added": "35.0",
-                    "version_removed": "47.0",
-                    "flag": {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "47.0"
-                  }
-                ],
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "12.0",
-                    "version_removed": "53.0"
-                  },
-                  {
-                    "version_added": "49.0"
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "12.0",
-                    "version_removed": "53.0"
-                  },
-                  {
-                    "version_added": "49.0"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": false,
-                  "notes": "See Webkit bug 76173."
-                },
-                "safari_ios": {
-                  "version_added": false,
-                  "notes": "See Webkit bug 76173."
+  "css": {
+    "properties": {
+      "text-align-last": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "35.0",
+                "version_removed": "47.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              {
+                "version_added": "47.0"
               }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "35.0",
+                "version_removed": "47.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "47.0"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": "12.0",
+                "version_removed": "53.0"
+              },
+              {
+                "version_added": "49.0"
+              }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": "12.0",
+                "version_removed": "53.0"
+              },
+              {
+                "version_added": "49.0"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "See Webkit bug 76173."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "See Webkit bug 76173."
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -1,77 +1,72 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "selectors": {
-        "any-link": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                },
-                "chrome": {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": true
-                  },
-                  {
-                    "version_added": "50.0"
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": true
-                  },
-                  {
-                    "version_added": "50.0"
-                  }
-                ],
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                },
-                "opera_android": {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                },
-                "safari": {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
+  "css": {
+    "selectors": {
+      "any-link": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              {
+                "version_added": "50.0"
               }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "version_added": "50.0"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -1,55 +1,50 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "css": {
-      "selectors": {
-        "cue": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": [
-                    "Firefox currently does not support a parameter on <code>::cue</code>."
-                  ]
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              }
+  "css": {
+    "selectors": {
+      "cue": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": [
+                "Firefox currently does not support a parameter on <code>::cue</code>."
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
           }
         }

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -1,11 +1,108 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "base": {
+  "html": {
+    "elements": {
+      "base": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": true,
+              "notes": "Before Internet Explorer 7, <code>&lt;base&gt;</code> can be positioned anywhere in the document and the nearest value of <code>&lt;>base&gt;</code> is used."
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "href": {
           "__compat": {
-            "basic_support": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "relative_url": {
+            "__compat": {
+              "description": "Relative URIs.",
               "support": {
                 "webview_android": {
                   "version_added": true
@@ -23,14 +120,13 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "4.0"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "4.0"
                 },
                 "ie": {
-                  "version_added": true,
-                  "notes": "Before Internet Explorer 7, <code>&lt;base&gt;</code> can be positioned anywhere in the document and the nearest value of <code>&lt;>base&gt;</code> is used."
+                  "version_added": true
                 },
                 "ie_mobile": {
                   "version_added": true
@@ -54,158 +150,55 @@
                 "deprecated": false
               }
             }
-          },
-          "href": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "target": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "relative_url": {
-                "desc": "Relative URIs.",
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "4.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "4.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
-            }
-          },
-          "target": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -1,246 +1,235 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "canvas": {
+  "html": {
+    "elements": {
+      "canvas": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.5",
+              "notes": [
+                "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
+                "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
+                "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "1.5",
+              "notes": [
+                "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
+                "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
+                "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
+              ]
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "2",
+              "notes": "Although early versions of Apple's Safari browser don't require the closing tag, the specification indicates that it is required, so you should be sure to include it for broadest compatibility. Versions of Safari prior to version 2 will render the content of the fallback in addition to the canvas itself unless you use CSS tricks to mask it."
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "height": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "1"
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.5",
-                  "notes": [
-                    "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
-                    "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
-                    "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "1.5",
-                  "notes": [
-                    "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
-                    "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
-                    "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
-                  ]
-                },
-                "ie": {
-                  "version_added": "9"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "9"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": "2",
-                  "notes": "Although early versions of Apple's Safari browser don't require the closing tag, the specification indicates that it is required, so you should be sure to include it for broadest compatibility. Versions of Safari prior to version 2 will render the content of the fallback in addition to the canvas itself unless you use CSS tricks to mask it."
-                },
-                "safari_ios": {
-                  "version_added": "1"
-                }
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.5",
+                "notes": [
+                  "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
+                  "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
+                  "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "1.5",
+                "notes": [
+                  "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
+                  "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
+                  "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
+                ]
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "9"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "2",
+                "notes": "Although early versions of Apple's Safari browser don't require the closing tag, the specification indicates that it is required, so you should be sure to include it for broadest compatibility. Versions of Safari prior to version 2 will render the content of the fallback in addition to the canvas itself unless you use CSS tricks to mask it."
+              },
+              "safari_ios": {
+                "version_added": "1"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "height": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "1"
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.5",
-                    "notes": [
-                      "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
-                      "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
-                      "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "1.5",
-                    "notes": [
-                      "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
-                      "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
-                      "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
-                    ]
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "9"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "2",
-                    "notes": "Although early versions of Apple's Safari browser don't require the closing tag, the specification indicates that it is required, so you should be sure to include it for broadest compatibility. Versions of Safari prior to version 2 will render the content of the fallback in addition to the canvas itself unless you use CSS tricks to mask it."
-                  },
-                  "safari_ios": {
-                    "version_added": "1"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "moz-opaque": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
-          },
-          "moz-opaque": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "3.5"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": false
-                }
+          }
+        },
+        "width": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.5",
+                "notes": [
+                  "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
+                  "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
+                  "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "1.5",
+                "notes": [
+                  "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
+                  "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
+                  "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
+                ]
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "9"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "2",
+                "notes": "Although early versions of Apple's Safari browser don't require the closing tag, the specification indicates that it is required, so you should be sure to include it for broadest compatibility. Versions of Safari prior to version 2 will render the content of the fallback in addition to the canvas itself unless you use CSS tricks to mask it."
+              },
+              "safari_ios": {
+                "version_added": "1"
               }
-            }
-          },
-          "width": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "1"
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.5",
-                    "notes": [
-                      "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
-                      "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
-                      "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "1.5",
-                    "notes": [
-                      "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
-                      "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
-                      "Before Firefox 12, if JavaScript is disabled, the &lt;canvas&gt; element was being rendered instead of showing the fallback content as per the specification. Since then, the fallback content is rendered instead."
-                    ]
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "9"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "2",
-                    "notes": "Although early versions of Apple's Safari browser don't require the closing tag, the specification indicates that it is required, so you should be sure to include it for broadest compatibility. Versions of Safari prior to version 2 will render the content of the fallback in addition to the canvas itself unless you use CSS tricks to mask it."
-                  },
-                  "safari_ios": {
-                    "version_added": "1"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/html/elements/del.json
+++ b/html/elements/del.json
@@ -1,161 +1,152 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "del": {
+  "html": {
+    "elements": {
+      "del": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "cite": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1"
-                },
-                "firefox_android": {
-                  "version_added": "1"
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "cite": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "datetime": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
-            }
-          },
-          "datetime": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -1,109 +1,102 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "head": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "html": {
+    "elements": {
+      "head": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
           },
-          "profile": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "profile": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -1,213 +1,202 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "html": {
+  "html": {
+    "elements": {
+      "html": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "manifest": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
-          },
-          "manifest": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "3.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
+          }
+        },
+        "version": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
             }
-          },
-          "version": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
+          }
+        },
+        "xmlns": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
-            }
-          },
-          "xmlns": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/html/elements/ins.json
+++ b/html/elements/ins.json
@@ -1,161 +1,152 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "ins": {
+  "html": {
+    "elements": {
+      "ins": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "cite": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1"
-                },
-                "firefox_android": {
-                  "version_added": "1"
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "cite": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "datetime": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
-            }
-          },
-          "datetime": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1,50 +1,646 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "link": {
+  "html": {
+    "elements": {
+      "link": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "charset": {
           "__compat": {
-            "basic_support": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "crossorigin": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "25.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "18.0"
+              },
+              "firefox_android": {
+                "version_added": "18.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15.0"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "disabled": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "href": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hreflang": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "integrity": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "45.0"
+              },
+              "chrome": {
+                "version_added": "45.0"
+              },
+              "chrome_android": {
+                "version_added": "45.0"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "media": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "methods": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "4.0"
+              },
+              "ie_mobile": {
+                "version_added": "4.0"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "prefetch": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "56.0"
+              },
+              "chrome": {
+                "version_added": "56.0"
+              },
+              "chrome_android": {
+                "version_added": "56.0"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43.0"
+              },
+              "opera_android": {
+                "version_added": "43.0"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "referrerpolicy": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "58.0"
+              },
+              "chrome": {
+                "version_added": "58.0"
+              },
+              "chrome_android": {
+                "version_added": "58.0"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "50.0"
+              },
+              "firefox_android": {
+                "version_added": "50.0"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "rel": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "alternate_stylesheet": {
+            "__compat": {
+              "description": "Alternative stylesheets.",
               "support": {
                 "webview_android": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "chrome": {
-                  "version_added": "1.0"
+                  "version_added": null
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "3.0"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "4.0"
                 },
                 "ie": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "ie_mobile": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "opera": {
                   "version_added": true
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": null
                 }
               },
               "status": {
@@ -54,1225 +650,608 @@
               }
             }
           },
-          "charset": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "crossorigin": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "25.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "18.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "18.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15.0"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "disabled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "href": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "hreflang": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "integrity": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "45.0"
-                  },
-                  "chrome": {
-                    "version_added": "45.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "45.0"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "media": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "methods": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "4.0"
-                  },
-                  "ie_mobile": {
-                    "version_added": "4.0"
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
           "prefetch": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "56.0"
-                  },
-                  "chrome": {
-                    "version_added": "56.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "56.0"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "43.0"
-                  },
-                  "opera_android": {
-                    "version_added": "43.0"
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "referrerpolicy": {
+          "prerender": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "58.0"
-                  },
-                  "chrome": {
-                    "version_added": "58.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "58.0"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "50.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "50.0"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "rel": {
+          "preconnect": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": "46.0"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "46.0"
+                },
+                "chrome_android": {
+                  "version_added": "42.0"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "39",
+                  "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
+                },
+                "firefox_android": {
+                  "version_added": "39.0",
+                  "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               },
-              "alternate_stylesheet": {
-                "desc": "Alternative stylesheets.",
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "3.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "4.0"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              },
-              "prefetch": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              },
-              "prerender": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              },
-              "preconnect": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "46.0"
-                  },
-                  "chrome": {
-                    "version_added": "46.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "42.0"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "39",
-                    "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
-                  },
-                  "firefox_android": {
-                    "version_added": "39.0",
-                    "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              },
-              "dns-prefetch": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "46.0"
-                  },
-                  "chrome": {
-                    "version_added": "46.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "3.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              },
-              "preload": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "50.0"
-                  },
-                  "chrome": {
-                    "version_added": "50.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "50.0"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": false,
-                  "deprecated": false
-                }
-              },
-              "noopener": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "49.0"
-                  },
-                  "chrome": {
-                    "version_added": "49.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "49.0"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "52.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "52.0"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "36.0"
-                  },
-                  "opera_android": {
-                    "version_added": "32.0"
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": false,
-                  "deprecated": false
-                }
-              },
-              "manifest": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "39.0"
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": "39.09"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": false,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "rev": {
+          "dns-prefetch": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": "46.0"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "46.0"
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "3.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "sizes": {
+          "preload": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/441770'>bug 441770</a>."
-                  },
-                  "firefox_android": {
-                    "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/441770'>bug 441770</a>."
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": "50.0"
                 },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "50.0"
+                },
+                "chrome_android": {
+                  "version_added": "50.0"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": false
               }
             }
           },
-          "target": {
+          "noopener": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": "49.0"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
+                "chrome": {
+                  "version_added": "49.0"
+                },
+                "chrome_android": {
+                  "version_added": "49.0"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "52.0"
+                },
+                "firefox_android": {
+                  "version_added": "52.0"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "36.0"
+                },
+                "opera_android": {
+                  "version_added": "32.0"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": false
               }
             }
           },
-          "title": {
+          "manifest": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": "39.0"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "39.09"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": false
               }
             }
-          },
-          "type": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "rev": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sizes": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/441770'>bug 441770</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/441770'>bug 441770</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "target": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "title": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "type": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -1,11 +1,256 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "meta": {
+  "html": {
+    "elements": {
+      "meta": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "charset": {
           "__compat": {
-            "basic_support": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "content": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "http-equiv": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "content-language": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          },
+          "content-security-policy": {
+            "__compat": {
               "support": {
                 "webview_android": {
                   "version_added": true
@@ -54,569 +299,301 @@
               }
             }
           },
-          "charset": {
+          "content-type": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "content": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "http-equiv": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "content-language": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "webview_android": {
-                      "version_added": true
-                    },
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "chrome_android": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "edge_mobile": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "1.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "1.0"
-                    },
-                    "ie": {
-                      "version_added": true
-                    },
-                    "ie_mobile": {
-                      "version_added": true
-                    },
-                    "opera": {
-                      "version_added": true
-                    },
-                    "opera_android": {
-                      "version_added": true
-                    },
-                    "safari": {
-                      "version_added": true
-                    },
-                    "safari_ios": {
-                      "version_added": true
-                    }
-                  },
-                  "status": {
-                    "experimental": false,
-                    "standard_track": true,
-                    "deprecated": true
-                  }
-                }
-              }
-            },
-            "content-security-policy": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "webview_android": {
-                      "version_added": true
-                    },
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "chrome_android": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "edge_mobile": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "1.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "1.0"
-                    },
-                    "ie": {
-                      "version_added": true
-                    },
-                    "ie_mobile": {
-                      "version_added": true
-                    },
-                    "opera": {
-                      "version_added": true
-                    },
-                    "opera_android": {
-                      "version_added": true
-                    },
-                    "safari": {
-                      "version_added": true
-                    },
-                    "safari_ios": {
-                      "version_added": true
-                    }
-                  },
-                  "status": {
-                    "experimental": false,
-                    "standard_track": true,
-                    "deprecated": false
-                  }
-                }
-              }
-            },
-            "content-type": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "webview_android": {
-                      "version_added": true
-                    },
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "chrome_android": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "edge_mobile": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "1.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "1.0"
-                    },
-                    "ie": {
-                      "version_added": true
-                    },
-                    "ie_mobile": {
-                      "version_added": true
-                    },
-                    "opera": {
-                      "version_added": true
-                    },
-                    "opera_android": {
-                      "version_added": true
-                    },
-                    "safari": {
-                      "version_added": true
-                    },
-                    "safari_ios": {
-                      "version_added": true
-                    }
-                  },
-                  "status": {
-                    "experimental": false,
-                    "standard_track": true,
-                    "deprecated": false
-                  }
-                }
-              }
-            },
-            "refresh": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "webview_android": {
-                      "version_added": true
-                    },
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "chrome_android": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "edge_mobile": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "1.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "1.0"
-                    },
-                    "ie": {
-                      "version_added": true
-                    },
-                    "ie_mobile": {
-                      "version_added": true
-                    },
-                    "opera": {
-                      "version_added": true
-                    },
-                    "opera_android": {
-                      "version_added": true
-                    },
-                    "safari": {
-                      "version_added": true
-                    },
-                    "safari_ios": {
-                      "version_added": true
-                    }
-                  },
-                  "status": {
-                    "experimental": false,
-                    "standard_track": true,
-                    "deprecated": false
-                  }
-                }
-              }
-            },
-            "set-cookie": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "webview_android": {
-                      "version_added": true
-                    },
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "chrome_android": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "edge_mobile": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "1.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "1.0"
-                    },
-                    "ie": {
-                      "version_added": true
-                    },
-                    "ie_mobile": {
-                      "version_added": true
-                    },
-                    "opera": {
-                      "version_added": true
-                    },
-                    "opera_android": {
-                      "version_added": true
-                    },
-                    "safari": {
-                      "version_added": true
-                    },
-                    "safari_ios": {
-                      "version_added": true
-                    }
-                  },
-                  "status": {
-                    "experimental": false,
-                    "standard_track": true,
-                    "deprecated": true
-                  }
-                }
-              }
-            }
-          },
-          "name": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
                 }
               },
-              "referer": {
-                "desc": "referrer value",
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "17.0",
-                    "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "36.0",
-                    "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
-                  },
-                  "firefox_android": {
-                    "version_added": "36.0",
-                    "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "refresh": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "set-cookie": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          }
+        },
+        "name": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "scheme": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "webview_android": {
-                      "version_added": true
-                    },
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "chrome_android": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "edge_mobile": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "1.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "1.0"
-                    },
-                    "ie": {
-                      "version_added": true
-                    },
-                    "ie_mobile": {
-                      "version_added": true
-                    },
-                    "opera": {
-                      "version_added": true
-                    },
-                    "opera_android": {
-                      "version_added": true
-                    },
-                    "safari": {
-                      "version_added": true
-                    },
-                    "safari_ios": {
-                      "version_added": true
-                    }
-                  },
-                  "status": {
-                    "experimental": false,
-                    "standard_track": true,
-                    "deprecated": true
-                  }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "scheme": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": true
+                },
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "1.0"
+                },
+                "firefox_android": {
+                  "version_added": "1.0"
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "ie_mobile": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          },
+          "referer": {
+            "__compat": {
+              "description": "referrer value",
+              "support": {
+                "webview_android": {
+                  "version_added": null
+                },
+                "chrome": {
+                  "version_added": "17.0",
+                  "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "36.0",
+                  "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
+                },
+                "firefox_android": {
+                  "version_added": "36.0",
+                  "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               }
             }

--- a/html/elements/noscript.json
+++ b/html/elements/noscript.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "noscript": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1"
-                },
-                "firefox_android": {
-                  "version_added": "1"
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "html": {
+    "elements": {
+      "noscript": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -1,593 +1,568 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "script": {
+  "html": {
+    "elements": {
+      "script": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
+            },
+            "firefox_android": {
+              "version_added": "1",
+              "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "async": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1",
-                  "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
-                },
-                "firefox_android": {
-                  "version_added": "1",
-                  "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "crossorigin": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "13"
+              },
+              "firefox_android": {
+                "version_added": "13"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "12.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true,
+                "notes": "The <code>crossorigin</code> attribute was implemented in WebKit in WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=81438'>bug 81438</a>."
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "defer": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.5",
+                "notes": "Since Firefox 3.6, the <code>defer</code> attribute is ignored on scripts that don't have the <code>src</code> attribute. However, in Firefox 3.5 even inline scripts are deferred if the <code>defer</code> attribute is set."
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": "10",
+                "notes": "In versions prior to Internet Explorer 10, it implemented &gt;script&lt; by a proprietary specification. Since version 10 it conforms to the W3C specification."
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "integrity": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "45"
+              },
+              "chrome": {
+                "version_added": "45"
+              },
+              "chrome_android": {
+                "version_added": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "43"
+              },
+              "firefox_android": {
+                "version_added": "43"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=148363'>bug 148363</a> tracks WebKit implementation of Subresource Integrity (which includes the <code>integrity</code> attribute)."
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "module": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "nomodule": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.moduleScripts.enabled",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "async": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+              "firefox_android": {
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "dom.moduleScripts.enabled",
+                  "value_to_set": "true"
                 }
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "crossorigin": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "30"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "13"
-                  },
-                  "firefox_android": {
-                    "version_added": "13"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "12.5"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": true,
-                    "notes": "The <code>crossorigin</code> attribute was implemented in WebKit in WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=81438'>bug 81438</a>."
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "defer": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "3.5",
-                    "notes": "Since Firefox 3.6, the <code>defer</code> attribute is ignored on scripts that don't have the <code>src</code> attribute. However, in Firefox 3.5 even inline scripts are deferred if the <code>defer</code> attribute is set."
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": "10",
-                    "notes": "In versions prior to Internet Explorer 10, it implemented &gt;script&lt; by a proprietary specification. Since version 10 it conforms to the W3C specification."
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "text": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "integrity": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "45"
-                  },
-                  "chrome": {
-                    "version_added": "45"
-                  },
-                  "chrome_android": {
-                    "version_added": "45"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "43"
-                  },
-                  "firefox_android": {
-                    "version_added": "43"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": false,
-                    "notes": "WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=148363'>bug 148363</a> tracks WebKit implementation of Subresource Integrity (which includes the <code>integrity</code> attribute)."
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "type": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "1"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
-            }
-          },
-          "language": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "module": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "nomodule": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true,
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.moduleScripts.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  "firefox_android": {
-                    "version_added": true,
-                    "flag": {
-                      "type": "preference",
-                      "name": "dom.moduleScripts.enabled",
-                      "value_to_set": "true"
-                    }
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "text": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "type": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "1"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1"
-                  },
-                  "firefox_android": {
-                    "version_added": "1"
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -1,275 +1,262 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "style": {
+  "html": {
+    "elements": {
+      "style": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "1.0"
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "3.0"
+            },
+            "ie_mobile": {
+              "version_added": "9.0",
+              "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6.0"
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": "1.0"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "type": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "1.0"
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "3.0"
-                },
-                "ie_mobile": {
-                  "version_added": "9.0",
-                  "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
-                },
-                "opera": {
-                  "version_added": "3.5"
-                },
-                "opera_android": {
-                  "version_added": "6.0"
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": "1.0"
+            "support": {
+              "webview_android": {
+                "version_added": "1.0"
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": "3.0"
+              },
+              "ie_mobile": {
+                "version_added": "9.0",
+                "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "6.0"
+              },
+              "safari": {
+                "version_added": "1.0"
+              },
+              "safari_ios": {
+                "version_added": "1.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "media": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "1.0"
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": "3.0"
+              },
+              "ie_mobile": {
+                "version_added": "9.0",
+                "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "6.0"
+              },
+              "safari": {
+                "version_added": "1.0"
+              },
+              "safari_ios": {
+                "version_added": "1.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "title": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "1.0"
+              },
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": "3.0"
+              },
+              "ie_mobile": {
+                "version_added": "9.0",
+                "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "6.0"
+              },
+              "safari": {
+                "version_added": "1.0"
+              },
+              "safari_ios": {
+                "version_added": "1.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scoped": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "19.0",
+                "version_removed": "35.0",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable &lt;style scoped&gt;",
+                  "value_to_set": "true"
                 }
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "21.0"
+              },
+              "firefox_android": {
+                "version_added": "21.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
-            }
-          },
-          "type": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "1.0"
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "1.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": "3.0"
-                  },
-                  "ie_mobile": {
-                    "version_added": "9.0",
-                    "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
-                  },
-                  "opera": {
-                    "version_added": "3.5"
-                  },
-                  "opera_android": {
-                    "version_added": "6.0"
-                  },
-                  "safari": {
-                    "version_added": "1.0"
-                  },
-                  "safari_ios": {
-                    "version_added": "1.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "media": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "1.0"
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "1.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": "3.0"
-                  },
-                  "ie_mobile": {
-                    "version_added": "9.0",
-                    "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
-                  },
-                  "opera": {
-                    "version_added": "3.5"
-                  },
-                  "opera_android": {
-                    "version_added": "6.0"
-                  },
-                  "safari": {
-                    "version_added": "1.0"
-                  },
-                  "safari_ios": {
-                    "version_added": "1.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "title": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "1.0"
-                  },
-                  "chrome": {
-                    "version_added": "1.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "1.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "1.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "1.0"
-                  },
-                  "ie": {
-                    "version_added": "3.0"
-                  },
-                  "ie_mobile": {
-                    "version_added": "9.0",
-                    "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
-                  },
-                  "opera": {
-                    "version_added": "3.5"
-                  },
-                  "opera_android": {
-                    "version_added": "6.0"
-                  },
-                  "safari": {
-                    "version_added": "1.0"
-                  },
-                  "safari_ios": {
-                    "version_added": "1.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "scoped": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "19.0",
-                    "version_removed": "35.0",
-                    "flag": {
-                      "type": "preference",
-                      "name": "Enable &lt;style scoped&gt;",
-                      "value_to_set": "true"
-                    }
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "21.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "21.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }

--- a/html/elements/title.json
+++ b/html/elements/title.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "html": {
-      "elements": {
-        "title": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "1.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "1.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "1.0"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "1.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "html": {
+    "elements": {
+      "title": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "1.0"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "1.0"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1.0"
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -1,222 +1,223 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "data-url": {
+  "http": {
+    "data-url": {
+      "__compat": {
+        "description": "data URL scheme",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": "12",
+            "notes": "The maximum size supported is 4GB"
+          },
+          "edge_mobile": {
+            "version_added": true,
+            "notes": "The maximum size supported is 4GB"
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": "8",
+            "notes": "The maximum size supported is 32kB"
+          },
+          "ie_mobile": {
+            "version_added": true,
+            "notes": "The maximum size supported is 4GB"
+          },
+          "opera": {
+            "version_added": "7.20"
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "css_files": {
         "__compat": {
-          "basic_support": {
-            "desc": "data URL scheme",
-            "support": {
-              "webview_android": {
-                "version_added": true
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": "The maximum size supported is 4GB"
-              },
-              "edge_mobile": {
-                "version_added": true,
-                "notes": "The maximum size supported is 4GB"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
+          "description": "CSS files",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12",
+              "notes": "The maximum size supported is 4GB"
+            },
+            "edge_mobile": {
+              "version_added": true,
+              "notes": "The maximum size supported is 4GB"
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": [
+              {
                 "version_added": "8",
                 "notes": "The maximum size supported is 32kB"
               },
-              "ie_mobile": {
-                "version_added": true,
-                "notes": "The maximum size supported is 4GB"
-              },
-              "opera": {
-                "version_added": "7.20"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "css_files": {
-            "desc": "CSS files",
-            "support": {
-              "webview_android": {
-                "version_added": true
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": "The maximum size supported is 4GB"
-              },
-              "edge_mobile": {
-                "version_added": true,
-                "notes": "The maximum size supported is 4GB"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": [
-                {
-                  "version_added": "8",
-                  "notes": "The maximum size supported is 32kB"
-                },
-                {
-                  "version_added": "9",
-                  "notes": "The maximum size supported is 4GB"
-                }
-              ],
-              "ie_mobile": {
-                "version_added": true,
-                "notes": "The maximum size supported is 4GB"
-              },
-              "opera": {
-                "version_added": "7.20"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "html_files": {
-            "desc": "HTML files",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "js_files": {
-            "desc": "JavaScript files",
-            "support": {
-              "webview_android": {
-                "version_added": true
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": "The maximum size supported is 4GB"
-              },
-              "edge_mobile": {
-                "version_added": true,
-                "notes": "The maximum size supported is 4GB"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
+              {
                 "version_added": "9",
                 "notes": "The maximum size supported is 4GB"
-              },
-              "ie_mobile": {
-                "version_added": true,
-                "notes": "The maximum size supported is 4GB"
-              },
-              "opera": {
-                "version_added": "7.20"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
               }
+            ],
+            "ie_mobile": {
+              "version_added": true,
+              "notes": "The maximum size supported is 4GB"
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            "opera": {
+              "version_added": "7.20"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "html_files": {
+        "__compat": {
+          "description": "HTML files",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "js_files": {
+        "__compat": {
+          "description": "JavaScript files",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12",
+              "notes": "The maximum size supported is 4GB"
+            },
+            "edge_mobile": {
+              "version_added": true,
+              "notes": "The maximum size supported is 4GB"
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9",
+              "notes": "The maximum size supported is 4GB"
+            },
+            "ie_mobile": {
+              "version_added": true,
+              "notes": "The maximum size supported is 4GB"
+            },
+            "opera": {
+              "version_added": "7.20"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/accept-charset.json
+++ b/http/headers/accept-charset.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Accept-Charset": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Accept-Charset": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/accept-encoding.json
+++ b/http/headers/accept-encoding.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Accept-Encoding": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Accept-Encoding": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/accept-language.json
+++ b/http/headers/accept-language.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Accept-Language": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Accept-Language": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/accept-ranges.json
+++ b/http/headers/accept-ranges.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Accept-Ranges": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Accept-Ranges": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/accept.json
+++ b/http/headers/accept.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Accept": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Accept": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-allow-credentials.json
+++ b/http/headers/access-control-allow-credentials.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Allow-Credentials": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Allow-Credentials": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Allow-Headers": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Allow-Headers": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Allow-Methods": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Allow-Methods": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-allow-origin.json
+++ b/http/headers/access-control-allow-origin.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Allow-Origin": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Allow-Origin": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Expose-Headers": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Expose-Headers": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-max-age.json
+++ b/http/headers/access-control-max-age.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Max-Age": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Max-Age": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-request-headers.json
+++ b/http/headers/access-control-request-headers.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Request-Headers": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Request-Headers": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/access-control-request-method.json
+++ b/http/headers/access-control-request-method.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Access-Control-Request-Method": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "2.1"
-                },
-                "chrome": {
-                  "version_added": "4"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.5"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": "12"
-                },
-                "safari": {
-                  "version_added": "4"
-                },
-                "safari_ios": {
-                  "version_added": "3.2"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Access-Control-Request-Method": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "1.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/age.json
+++ b/http/headers/age.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Age": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Age": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -1,209 +1,210 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Cache-Control": {
+  "http": {
+    "headers": {
+      "Cache-Control": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "immutable": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "<code>immutable</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49.0"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=167497'>bug 167497</a>."
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "immutable": {
-              "desc": "<code>immutable</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "49.0"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false,
-                  "notes": "See WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=167497'>bug 167497</a>."
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "stale-while-revalidate": {
+          "__compat": {
+            "description": "<code>stale-while-revalidate</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
+              "chrome": {
+                "version_added": false,
+                "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=348877'>bug 348877</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a>."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "stale-while-revalidate": {
-              "desc": "<code>stale-while-revalidate</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false,
-                  "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=348877'>bug 348877</a>."
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a>."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "stale-if-error": {
+          "__compat": {
+            "description": "stale-if-error",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
+              "chrome": {
+                "version_added": false,
+                "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=348877'>bug 348877</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a>."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "stale-if-error": {
-              "desc": "stale-if-error",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false,
-                  "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=348877'>bug 348877</a>."
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a>."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         }

--- a/http/headers/connection.json
+++ b/http/headers/connection.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Connection": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Connection": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Disposition": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Content-Disposition": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -1,106 +1,103 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Encoding": {
+  "http": {
+    "headers": {
+      "Content-Encoding": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "br": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "<code>br</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "51"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "44.0"
+              },
+              "firefox_android": {
+                "version_added": "44.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "36.0"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "br": {
-              "desc": "<code>br</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "chrome": {
-                  "version_added": "50"
-                },
-                "chrome_android": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "44.0"
-                },
-                "firefox_android": {
-                  "version_added": "44.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "36.0"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         }

--- a/http/headers/content-language.json
+++ b/http/headers/content-language.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Language": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Content-Language": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Length": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Content-Length": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/content-location.json
+++ b/http/headers/content-location.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Location": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Content-Location": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/content-range.json
+++ b/http/headers/content-range.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Range": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Content-Range": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Security-Policy-Report-Only": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "4.4"
-                },
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "23.0"
-                },
-                "firefox_android": {
-                  "version_added": "23.0"
-                },
-                "ie": {
-                  "version_added": "10"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "15"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7.1"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Content-Security-Policy-Report-Only": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "23.0"
+            },
+            "firefox_android": {
+              "version_added": "23.0"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1,1621 +1,1568 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "csp": {
-          "Content-Security-Policy": {
+  "http": {
+    "headers": {
+      "csp": {
+        "Content-Security-Policy": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25",
+                "notes": "Implemented as X-Webkit-CSP header in Chrome 14."
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "23.0",
+                "notes": "Implemented as X-Content-Security-Policy header in Firefox 4."
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": "10",
+                "notes": "Implemented as X-Content-Security-Policy header, only supporting 'sandbox' directive."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7",
+                "notes": "Implemented as X-Webkit-CSP header in Safari 6."
+              },
+              "safari_ios": {
+                "version_added": "7.1",
+                "notes": "Implemented as X-Webkit-CSP header in iOS 5.1."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "meta-element-support": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25",
-                    "notes": "Implemented as X-Webkit-CSP header in Chrome 14."
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "23.0",
-                    "notes": "Implemented as X-Content-Security-Policy header in Firefox 4."
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": "10",
-                    "notes": "Implemented as X-Content-Security-Policy header, only supporting 'sandbox' directive."
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7",
-                    "notes": "Implemented as X-Webkit-CSP header in Safari 6."
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1",
-                    "notes": "Implemented as X-Webkit-CSP header in iOS 5.1."
-                  }
+              "description": "<code>&lt;meta&gt;</code> element support",
+              "support": {
+                "webview_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45.0"
+                },
+                "firefox_android": {
+                  "version_added": "45.0"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
                 }
               },
-              "meta-element-support": {
-                "desc": "<code>&lt;meta&gt;</code> element support",
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "45.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "worker_support": {
+            "__compat": {
+              "description": "Worker support",
+              "support": {
+                "webview_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "50.0"
+                },
+                "firefox_android": {
+                  "version_added": "50.0"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               },
-              "worker_support": {
-                "desc": "Worker support",
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "50.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "50.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "base-uri": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "35.0"
+              },
+              "firefox_android": {
+                "version_added": "35.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "27"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "block-all-mixed-content": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "48.0"
+              },
+              "firefox_android": {
+                "version_added": "48.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "child-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45.0"
+              },
+              "firefox_android": {
+                "version_added": "45.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "27"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "connect-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0",
+                "notes": "Prior to Firefox 50, ping attributes of &lt;a&gt; elements weren't covered by connect-src."
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "default-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "disown-opener": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "font-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "form-action": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "36.0"
+              },
+              "firefox_android": {
+                "version_added": "36.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "27"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "frame-ancestors": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "33.0"
+              },
+              "firefox_android": {
+                "version_added": "33.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "26"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "frame-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "img-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "manifest-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "41.0"
+              },
+              "firefox_android": {
+                "version_added": "41.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "media-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "navigation-to": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "object-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "plugin-types": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1045899'>Bugzilla bug 1045899</a>."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "27"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "referrer": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "33",
+                "version_removed": "56"
+              },
+              "chrome": {
+                "version_added": "33",
+                "version_removed": "56"
+              },
+              "chrome_android": {
+                "version_added": "33",
+                "version_removed": "56"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "37.0",
+                "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
+              },
+              "firefox_android": {
+                "version_added": "37.0",
+                "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true,
+                "version_removed": "43"
+              },
+              "opera_android": {
+                "version_added": true,
+                "version_removed": "43"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "report-sample": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "59"
+              },
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": {
+                "version_added": "59"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "46"
+              },
+              "opera_android": {
+                "version_added": "46"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "report-to": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "report-uri": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "require-sri-for": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "54"
+              },
+              "chrome": {
+                "version_added": "54"
+              },
+              "chrome_android": {
+                "version_added": "54"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49.0"
+              },
+              "firefox_android": {
+                "version_added": "49.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "41"
+              },
+              "opera_android": {
+                "version_added": "41"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sandbox": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "50.0"
+              },
+              "firefox_android": {
+                "version_added": "50.0"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "script-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
               }
             }
           },
-          "base-uri": {
+          "external_scripts": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "40"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "35.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "35.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "27"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "9.3"
-                  }
+              "description": "With external excripts",
+              "support": {
+                "webview_android": {
+                  "version_added": "59"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "block-all-mixed-content": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "48.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "48.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
+                "chrome": {
+                  "version_added": "59"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "child-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "40"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "45.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "27"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "9.3"
-                  }
+                "chrome_android": {
+                  "version_added": "59"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "connect-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0",
-                    "notes": "Prior to Firefox 50, ping attributes of &lt;a&gt; elements weren't covered by connect-src."
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
+                "edge": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "default-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
+                "edge_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "disown-opener": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
+                "firefox": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "font-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
+                "firefox_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "form-action": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "40"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "36.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "36.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "27"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "9.3"
-                  }
+                "ie": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "frame-ancestors": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "40"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "33.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "33.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "26"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "9.3"
-                  }
+                "ie_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "frame-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
+                "opera": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "img-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
+                "opera_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "manifest-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "41.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "41.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
+                "safari": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "media-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "navigation-to": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "object-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "plugin-types": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "40"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1045899'>Bugzilla bug 1045899</a>."
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "27"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "9.3"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "referrer": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "33",
-                    "version_removed": "56"
-                  },
-                  "chrome": {
-                    "version_added": "33",
-                    "version_removed": "56"
-                  },
-                  "chrome_android": {
-                    "version_added": "33",
-                    "version_removed": "56"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "37.0",
-                    "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
-                  },
-                  "firefox_android": {
-                    "version_added": "37.0",
-                    "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true,
-                    "version_removed": "43"
-                  },
-                  "opera_android": {
-                    "version_added": true,
-                    "version_removed": "43"
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "report-sample": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "59"
-                  },
-                  "chrome": {
-                    "version_added": "59"
-                  },
-                  "chrome_android": {
-                    "version_added": "59"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "46"
-                  },
-                  "opera_android": {
-                    "version_added": "46"
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "report-to": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "report-uri": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "require-sri-for": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "54"
-                  },
-                  "chrome": {
-                    "version_added": "54"
-                  },
-                  "chrome_android": {
-                    "version_added": "54"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "49.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "41"
-                  },
-                  "opera_android": {
-                    "version_added": "41"
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "sandbox": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "50.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "50.0"
-                  },
-                  "ie": {
-                    "version_added": "10"
-                  },
-                  "ie_mobile": {
-                    "version_added": "10"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "script-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
+                "safari_ios": {
+                  "version_added": null
                 }
               },
-              "external_scripts": {
-                "desc": "With external excripts",
-                "support": {
-                  "webview_android": {
-                    "version_added": "59"
-                  },
-                  "chrome": {
-                    "version_added": "59"
-                  },
-                  "chrome_android": {
-                    "version_added": "59"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": {
-                    "version_added": null
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
-          },
-          "strict-dynamic": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "52"
-                  },
-                  "chrome": {
-                    "version_added": "52"
-                  },
-                  "chrome_android": {
-                    "version_added": "52"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52.0"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "39"
-                  },
-                  "opera_android": {
-                    "version_added": "39"
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "strict-dynamic": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "52"
+              },
+              "chrome": {
+                "version_added": "52"
+              },
+              "chrome_android": {
+                "version_added": "52"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52.0"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "39"
+              },
+              "opera_android": {
+                "version_added": "39"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "style-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "23.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "23.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7.1"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "style-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "23.0"
+              },
+              "firefox_android": {
+                "version_added": "23.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "upgrade-insecure-requests": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "43"
-                  },
-                  "chrome": {
-                    "version_added": "43"
-                  },
-                  "chrome_android": {
-                    "version_added": "43"
-                  },
-                  "edge": {
-                    "version_added": false,
-                    "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "42.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "42.0"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "30"
-                  },
-                  "opera_android": {
-                    "version_added": "30"
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "upgrade-insecure-requests": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "43"
+              },
+              "chrome": {
+                "version_added": "43"
+              },
+              "chrome_android": {
+                "version_added": "43"
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "42.0"
+              },
+              "firefox_android": {
+                "version_added": "42.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
+              },
+              "opera_android": {
+                "version_added": "30"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "worker-src": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "59"
-                  },
-                  "chrome": {
-                    "version_added": "59"
-                  },
-                  "chrome_android": {
-                    "version_added": "59"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1302667'>Bugzilla bug 1302667</a>."
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "48"
-                  },
-                  "opera_android": {
-                    "version_added": "48"
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "worker-src": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "59"
+              },
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": {
+                "version_added": "59"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1302667'>Bugzilla bug 1302667</a>."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": "48"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/http/headers/content-type.json
+++ b/http/headers/content-type.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Content-Type": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Content-Type": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/cookie.json
+++ b/http/headers/cookie.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Cookie": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Cookie": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/cookie2.json
+++ b/http/headers/cookie2.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Cookie2": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "Cookie2": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/date.json
+++ b/http/headers/date.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Date": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Date": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "DNT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "23"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "9"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "6"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "DNT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/etag.json
+++ b/http/headers/etag.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "ETag": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "ETag": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/expires.json
+++ b/http/headers/expires.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Expires": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Expires": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/from.json
+++ b/http/headers/from.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "From": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "From": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/host.json
+++ b/http/headers/host.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Host": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Host": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "If-Match": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "If-Match": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/if-modified-since.json
+++ b/http/headers/if-modified-since.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "If-Modified-Since": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "If-Modified-Since": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/if-none-match.json
+++ b/http/headers/if-none-match.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "If-None-Match": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "If-None-Match": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/if-range.json
+++ b/http/headers/if-range.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "If-Range": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "If-Range": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/if-unmodified-since.json
+++ b/http/headers/if-unmodified-since.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "If-Unmodified-Since": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "If-Unmodified-Since": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Keep-Alive": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "Keep-Alive": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/large-allocation.json
+++ b/http/headers/large-allocation.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Large-Allocation": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Large-Allocation": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/last-modified.json
+++ b/http/headers/last-modified.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Last-Modified": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "Last-Modified": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/location.json
+++ b/http/headers/location.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Location": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "Location": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Origin": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Origin": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/pragma.json
+++ b/http/headers/pragma.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Pragma": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Pragma": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -1,60 +1,55 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Public-Key-Pins-Report-Only": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "46"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false,
-                  "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1091177'>Bugzilla bug 1091177</a>."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "33"
-                },
-                "opera_android": {
-                  "version_added": "33"
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Public-Key-Pins-Report-Only": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "46"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1091177'>Bugzilla bug 1091177</a>."
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "33"
+            },
+            "opera_android": {
+              "version_added": "33"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -1,108 +1,105 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Public-Key-Pins": {
+  "http": {
+    "headers": {
+      "Public-Key-Pins": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "35.0"
+            },
+            "firefox_android": {
+              "version_added": "35.0"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "report-uri": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false,
-                  "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "35.0"
-                },
-                "firefox_android": {
-                  "version_added": "35.0"
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
+            "description": "report-uri",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "46"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1091176'>Bugzilla bug 1091176</a>."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "33"
+              },
+              "opera_android": {
+                "version_added": "33"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "report-uri": {
-              "desc": "report-uri",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "46"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1091176'>Bugzilla bug 1091176</a>."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "33"
-                },
-                "opera_android": {
-                  "version_added": "33"
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/http/headers/range.json
+++ b/http/headers/range.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Range": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Range": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Referer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Referer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -1,207 +1,208 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Referrer-Policy": {
+  "http": {
+    "headers": {
+      "Referrer-Policy": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "56.0"
+            },
+            "chrome": {
+              "version_added": "56.0"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "50.0"
+            },
+            "firefox_android": {
+              "version_added": "50.0"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "same-origin": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "56.0"
-                },
-                "chrome": {
-                  "version_added": "56.0"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "50.0"
-                },
-                "firefox_android": {
-                  "version_added": "50.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+            "description": "same-origin",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52.0"
+              },
+              "firefox_android": {
+                "version_added": "52.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "same-origin": {
-              "desc": "same-origin",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false,
-                  "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52.0"
-                },
-                "firefox_android": {
-                  "version_added": "52.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "strict-origin": {
+          "__compat": {
+            "description": "strict-origin",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52.0"
+              },
+              "firefox_android": {
+                "version_added": "52.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "strict-origin": {
-              "desc": "strict-origin",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false,
-                  "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52.0"
-                },
-                "firefox_android": {
-                  "version_added": "52.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "strict-origin-when-cross-origin": {
+          "__compat": {
+            "description": "strict-origin-when-cross-origin",
+            "support": {
+              "webview_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52.0"
+              },
+              "firefox_android": {
+                "version_added": "52.0"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "strict-origin-when-cross-origin": {
-              "desc": "strict-origin-when-cross-origin",
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false,
-                  "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52.0"
-                },
-                "firefox_android": {
-                  "version_added": "52.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         }

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -1,59 +1,54 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Retry-After": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/230260'>Bug 230260</a>."
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Retry-After": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/230260'>Bug 230260</a>."
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/server.json
+++ b/http/headers/server.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Server": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Server": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -1,255 +1,258 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Set-Cookie": {
+  "http": {
+    "headers": {
+      "Set-Cookie": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "Max-Age": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "<code>Max-Age</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "8.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "Max-Age": {
-              "desc": "<code>Max-Age</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "8.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "HttpOnly": {
+          "__compat": {
+            "description": "<code>HttpOnly</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "1.0"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.0"
+              },
+              "firefox_android": {
+                "version_added": "1.0"
+              },
+              "ie": {
+                "version_added": "9.0"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "11"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "5.0"
+              },
+              "safari_ios": {
+                "version_added": "iOS 4"
               }
             },
-            "HttpOnly": {
-              "desc": "<code>HttpOnly</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.0"
-                },
-                "firefox_android": {
-                  "version_added": "1.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "11"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "5.0"
-                },
-                "safari_ios": {
-                  "version_added": "iOS 4"
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "cookie_prefixes": {
+          "__compat": {
+            "description": "Cookie prefixes",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "49"
+              },
+              "chrome_android": {
+                "version_added": "49"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": "50"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "36"
+              },
+              "opera_android": {
+                "version_added": "36"
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
             },
-            "cookie_prefixes": {
-              "desc": "Cookie prefixes",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "49"
-                },
-                "chrome_android": {
-                  "version_added": "49"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "50"
-                },
-                "firefox_android": {
-                  "version_added": "50"
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "36"
-                },
-                "opera_android": {
-                  "version_added": "36"
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "SameSite": {
+          "__compat": {
+            "description": "<code>SameSite</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "51"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/795346'>bug 795346</a> on Bugzilla."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/795346'>bug 795346</a> on Bugzilla."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "39"
+              },
+              "opera_android": {
+                "version_added": "39"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
-            "SameSite": {
-              "desc": "<code>SameSite</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": "51"
-                },
-                "chrome": {
-                  "version_added": "51"
-                },
-                "chrome_android": {
-                  "version_added": "51"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/795346'>bug 795346</a> on Bugzilla."
-                },
-                "firefox_android": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/795346'>bug 795346</a> on Bugzilla."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "39"
-                },
-                "opera_android": {
-                  "version_added": "39"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/http/headers/set-cookie2.json
+++ b/http/headers/set-cookie2.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Set-Cookie2": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": false
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "Set-Cookie2": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -1,82 +1,77 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "SourceMap": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": [
-                  {
-                    "prefix": "X-",
-                    "version_added": true
-                  },
-                  {
-                    "version_added": true
-                  }
-                ],
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": [
-                  {
-                    "prefix": "X-",
-                    "version_added": "27.0"
-                  },
-                  {
-                    "version_added": "55.0"
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "prefix": "X-",
-                    "version_added": "27.0"
-                  },
-                  {
-                    "version_added": "55.0"
-                  }
-                ],
-                "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": [
-                  {
-                    "prefix": "X-",
-                    "version_added": true
-                  },
-                  {
-                    "version_added": true
-                  }
-                ],
-                "safari_ios": {
-                  "version_added": null
-                }
+  "http": {
+    "headers": {
+      "SourceMap": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "prefix": "X-",
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
+              {
+                "version_added": true
               }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "prefix": "X-",
+                "version_added": "27.0"
+              },
+              {
+                "version_added": "55.0"
+              }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "X-",
+                "version_added": "27.0"
+              },
+              {
+                "version_added": "55.0"
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "prefix": "X-",
+                "version_added": true
+              },
+              {
+                "version_added": true
+              }
+            ],
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Strict-Transport-Security": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "4.4"
-                },
-                "chrome": {
-                  "version_added": "4.0"
-                },
-                "chrome_android": {
-                  "version_added": "18"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "12"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "8.4"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": true
-              }
+  "http": {
+    "headers": {
+      "Strict-Transport-Security": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "version_added": "4.0"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8.4"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/te.json
+++ b/http/headers/te.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "TE": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "TE": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/trailer.json
+++ b/http/headers/trailer.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Trailer": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Trailer": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/transfer-encoding.json
+++ b/http/headers/transfer-encoding.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Transfer-Encoding": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Transfer-Encoding": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -1,59 +1,54 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Upgrade-Insecure-Requests": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": "44"
-                },
-                "chrome_android": {
-                  "version_added": "44"
-                },
-                "edge": {
-                  "version_added": false,
-                  "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48.0"
-                },
-                "firefox_android": {
-                  "version_added": "48.0"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "31"
-                },
-                "opera_android": {
-                  "version_added": "31"
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Upgrade-Insecure-Requests": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "44"
+            },
+            "chrome_android": {
+              "version_added": "44"
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "48.0"
+            },
+            "firefox_android": {
+              "version_added": "48.0"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "31"
+            },
+            "opera_android": {
+              "version_added": "31"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/user-agent.json
+++ b/http/headers/user-agent.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "User-Agent": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "User-Agent": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/vary.json
+++ b/http/headers/vary.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Vary": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Vary": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/via.json
+++ b/http/headers/via.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Via": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Via": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/warning.json
+++ b/http/headers/warning.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "Warning": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "Warning": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "X-Content-Type-Options": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "1.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "50"
-                },
-                "firefox_android": {
-                  "version_added": "50"
-                },
-                "ie": {
-                  "version_added": "8.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "13"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "X-Content-Type-Options": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "50"
+            },
+            "firefox_android": {
+              "version_added": "50"
+            },
+            "ie": {
+              "version_added": "8.0"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "13"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -1,106 +1,103 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "X-Frame-Options": {
+  "http": {
+    "headers": {
+      "X-Frame-Options": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "4.0"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.6.9"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "8.0"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "10.50"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "4.0"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "ALLOW-FROM": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": "4.0"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "3.6.9"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": "8.0"
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "10.50"
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": "4.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "ALLOW-FROM",
+            "support": {
+              "webview_android": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "18"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8.0"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
-            "ALLOW-FROM": {
-              "desc": "ALLOW-FROM",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "18"
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": "8.0"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -1,58 +1,53 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "headers": {
-        "X-XSS-Protection": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": "8.0"
-                },
-                "ie_mobile": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
-              }
+  "http": {
+    "headers": {
+      "X-XSS-Protection": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "8.0"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       }

--- a/http/methods.json
+++ b/http/methods.json
@@ -1,370 +1,353 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "methods": {
-        "CONNECT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "methods": {
+      "CONNECT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "DELETE": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "DELETE": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "GET": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "GET": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "HEAD": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "HEAD": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "OPTIONS": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "OPTIONS": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "POST": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "POST": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "PUT": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "PUT": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/status.json
+++ b/http/status.json
@@ -1,1306 +1,1253 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "http": {
-      "status": {
-        "100": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+  "http": {
+    "status": {
+      "100": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "200": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "200": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "201": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "201": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "204": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "204": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "206": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "206": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "301": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "301": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "302": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "302": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "303": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "303": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "304": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "304": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "307": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "307": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "308": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "308": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "401": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "401": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "403": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "403": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "404": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "404": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "406": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "406": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "407": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "407": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "410": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "410": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "412": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "412": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "416": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "416": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "451": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "451": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "500": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "500": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "501": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "501": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "502": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "502": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "503": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "503": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "504": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+        }
+      },
+      "504": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1,3544 +1,3455 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "javascript": {
-      "builtins": {
+  "javascript": {
+    "builtins": {
+      "Date": {
+        "@@toPrimitive": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "44"
+              },
+              "firefox_android": {
+                "version_added": "44"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "Date": {
-          "@@toPrimitive": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "44"
-                  },
-                  "firefox_android": {
-                    "version_added": "44"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true,
+                "notes": "The <a href='https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript'>ISO8601 Date Format</a> is not supported in Internet Explorer 8."
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "UTC": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getDate": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getDay": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getFullYear": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getHours": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getMilliseconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getMinutes": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getMonth": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getSeconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getTime": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getTimezoneOffset": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "5"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCDate": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCDay": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCFullYear": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCHours": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCMilliseconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCMinutes": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCMonth": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getUTCSeconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getYear": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "now": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "5"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "parse": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           },
-          "Date": {
+          "iso_8601": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true,
-                    "notes": "The <a href='https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript'>ISO8601 Date Format</a> is not supported in Internet Explorer 8."
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "description": "ISO 8601 format",
+              "support": {
+                "webview_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "UTC": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getDate": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getDay": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getFullYear": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getHours": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox": {
+                  "version_added": "4"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getMilliseconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getMinutes": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie": {
+                  "version_added": "9"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getMonth": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie_mobile": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getSeconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "nodejs": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getTime": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "opera": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getTimezoneOffset": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "5"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "opera_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCDate": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "safari": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCDay": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCFullYear": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCHours": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCMilliseconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCMinutes": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCMonth": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getUTCSeconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "getYear": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "now": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "5"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "3"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "10.5"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "4"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "parse": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "safari_ios": {
+                  "version_added": true
                 }
               },
-              "iso_8601": {
-                "desc": "ISO 8601 format",
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "4"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
+          }
+        },
+        "prototype": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           },
-          "prototype": {
+          "ordinary_object": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "description": "Ordinary object (ES2015)",
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "41"
+                },
+                "firefox_android": {
+                  "version_added": "41"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
-              "ordinary_object": {
-                "desc": "Ordinary object (ES2015)",
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "41"
-                  },
-                  "firefox_android": {
-                    "version_added": "41"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
-          },
-          "setDate": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "setDate": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setFullYear": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setHours": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setMilliseconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setMinutes": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setMonth": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setSeconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setTime": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setUTCDate": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setUTCFullYear": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setUTCHours": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setUTCMilliseconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setUTCMinutes": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setUTCMonth": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setUTCSeconds": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setYear": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "toDateString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toGMTString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "toISOString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toJSON": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toLocaleDateString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           },
-          "setFullYear": {
+          "locales": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setHours": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome": {
+                  "version_added": "24"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setMilliseconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome_android": {
+                  "version_added": "26"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setMinutes": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setMonth": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setSeconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox": {
+                  "version_added": "29"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setTime": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setUTCDate": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie": {
+                  "version_added": "11"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setUTCFullYear": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie_mobile": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setUTCHours": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "nodejs": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setUTCMilliseconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "opera": {
+                  "version_added": "15"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setUTCMinutes": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "opera_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setUTCMonth": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "safari": {
+                  "version_added": "10"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setUTCSeconds": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "setYear": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "toDateString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "toGMTString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "toISOString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "toJSON": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "8"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "toLocaleDateString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "locales": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              },
-              "options": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              },
-              "iana_time_zone_names": {
-                "desc": "IANA time zone names in <code>timeZone</code> option",
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "toLocaleFormat": {
+          "options": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "toLocaleString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome": {
+                  "version_added": "24"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "locales": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "iana_time_zone_names": {
+            "__compat": {
+              "description": "IANA time zone names in <code>timeZone</code> option",
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
-              "options": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "toLocaleFormat": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "toLocaleString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "locales": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "iana_time_zone_names": {
-                "desc": "IANA time zone names in <code>timeZone</code> option",
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "toLocaleTimeString": {
+          "options": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "locales": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "iana_time_zone_names": {
+            "__compat": {
+              "description": "IANA time zone names in <code>timeZone</code> option",
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
-              "options": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "toLocaleTimeString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "locales": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "iana_time_zone_names": {
-                "desc": "IANA time zone names in <code>timeZone</code> option",
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "toSource": {
+          "options": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
-          "toString": {
+          "iana_time_zone_names": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "description": "IANA time zone names in <code>timeZone</code> option",
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
-          },
-          "toTimeString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toSource": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
-          },
-          "toUTCString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "valueOf": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toTimeString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toUTCString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "valueOf": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1,2372 +1,2283 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "javascript": {
-      "builtins": {
-        "Math": {
-          "E": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+  "javascript": {
+    "builtins": {
+      "Math": {
+        "E": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "LN2": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "LN2": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "LN10": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "LN10": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "LOG2E": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "LOG2E": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "LOG10E": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "LOG10E": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "PI": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "PI": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "SQRT1_2": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "SQRT1_2": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "SQRT2": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "SQRT2": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "abs": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "abs": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "acos": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "acos": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "acosh": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "acosh": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "asin": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "asin": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "asinh": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "asinh": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "atan": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "atan": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "atan2": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "atan2": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "atanh": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "atanh": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "cbrt": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "cbrt": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "ceil": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "ceil": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "clz32": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "31"
-                  },
-                  "firefox_android": {
-                    "version_added": "31"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "clz32": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "cos": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "cos": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "cosh": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "cosh": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "exp": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "exp": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "expm1": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "expm1": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "floor": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "floor": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "fround": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "26"
-                  },
-                  "firefox_android": {
-                    "version_added": "26"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "fround": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "26"
+              },
+              "firefox_android": {
+                "version_added": "26"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "hypot": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "27"
-                  },
-                  "firefox_android": {
-                    "version_added": "27"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "hypot": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "27"
+              },
+              "firefox_android": {
+                "version_added": "27"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "imul": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "28"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "20"
-                  },
-                  "firefox_android": {
-                    "version_added": "20"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "16"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7"
-                  },
-                  "safari_ios": {
-                    "version_added": "7"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "imul": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "28"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "20"
+              },
+              "firefox_android": {
+                "version_added": "20"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "16"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "log": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "log": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "log1p": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "log1p": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "log2": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "log2": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "log10": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "log10": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "max": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "max": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "min": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "min": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "pow": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "pow": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "random": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "random": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "round": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "round": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "sign": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "sign": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "sin": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "sin": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "sinh": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "sinh": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "sqrt": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "sqrt": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "tan": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "tan": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "tanh": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "tanh": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "trunc": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "38"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "25"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "trunc": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -1,1431 +1,1384 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "javascript": {
-      "builtins": {
+  "javascript": {
+    "builtins": {
+      "Number": {
+        "EPSILON": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "MAX_SAFE_INTEGER": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "34"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "MAX_VALUE": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "MIN_SAFE_INTEGER": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "34"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "MIN_VALUE": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "NEGATIVE_INFINITY": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "NaN": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "Number": {
-          "EPSILON": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "POSITIVE_INFINITY": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "isFinite": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "19"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "16"
+              },
+              "firefox_android": {
+                "version_added": "16"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "isInteger": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "16"
+              },
+              "firefox_android": {
+                "version_added": "16"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "isNaN": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": {
+                "version_added": "15"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "isSafeInteger": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": {
+                "version_added": "32"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "parseFloat": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "parseInt": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "prototype": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toExponential": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toFixed": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toInteger": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "16",
+                "version_removed": "32"
+              },
+              "firefox_android": {
+                "version_added": "16",
+                "version_removed": "32"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "toLocaleString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           },
-          "MAX_SAFE_INTEGER": {
+          "locales": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "34"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "31"
-                  },
-                  "firefox_android": {
-                    "version_added": "31"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "MAX_VALUE": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome": {
+                  "version_added": "24"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "MIN_SAFE_INTEGER": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "34"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "31"
-                  },
-                  "firefox_android": {
-                    "version_added": "31"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
+                "chrome_android": {
+                  "version_added": "26"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "MIN_VALUE": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "NEGATIVE_INFINITY": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "NaN": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox": {
+                  "version_added": "29"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "Number": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "POSITIVE_INFINITY": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie": {
+                  "version_added": "11"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "isFinite": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "19"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "16"
-                  },
-                  "firefox_android": {
-                    "version_added": "16"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie_mobile": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "isInteger": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "16"
-                  },
-                  "firefox_android": {
-                    "version_added": "16"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "nodejs": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "isNaN": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "15"
-                  },
-                  "firefox_android": {
-                    "version_added": "15"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
+                "opera": {
+                  "version_added": "15"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "isSafeInteger": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "32"
-                  },
-                  "firefox_android": {
-                    "version_added": "32"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "opera_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "parseFloat": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
+                "safari": {
+                  "version_added": "10"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "parseInt": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "25"
-                  },
-                  "firefox_android": {
-                    "version_added": "25"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "toExponential": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "toFixed": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "toInteger": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "16",
-                    "version_removed": "32"
-                  },
-                  "firefox_android": {
-                    "version_added": "16",
-                    "version_removed": "32"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "toLocaleString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "locales": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "options": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "options": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
-          },
-          "toPrecision": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toPrecision": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "toSource": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": false
-                }
+          }
+        },
+        "toSource": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
-          },
-          "toString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "valueOf": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "valueOf": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -1,452 +1,433 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "javascript": {
-      "builtins": {
+  "javascript": {
+    "builtins": {
+      "Promise": {
         "Promise": {
-          "Promise": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0",
-                    "notes": "Constructor requires a new operator since version 37."
-                  },
-                  "firefox_android": {
-                    "version_added": "29",
-                    "notes": "Constructor requires a new operator since version 37."
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12",
-                    "notes": "Constructor requires a new operator since version 4."
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1",
-                    "notes": "Constructor requires a new operator since version 10."
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0",
-                    "notes": "Constructor requires a new operator since version 10."
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0",
+                "notes": "Constructor requires a new operator since version 37."
+              },
+              "firefox_android": {
+                "version_added": "29",
+                "notes": "Constructor requires a new operator since version 37."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12",
+                "notes": "Constructor requires a new operator since version 4."
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1",
+                "notes": "Constructor requires a new operator since version 10."
+              },
+              "safari_ios": {
+                "version_added": "8.0",
+                "notes": "Constructor requires a new operator since version 10."
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "all": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "all": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "prototype": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "prototype": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "catch": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "catch": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "then": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "then": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "race": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "race": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "reject": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "reject": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "resolve": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": "4.4.4"
-                  },
-                  "chrome": {
-                    "version_added": "32.0"
-                  },
-                  "chrome_android": {
-                    "version_added": "32.0"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29.0"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "0.12"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "7.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "8.0"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "resolve": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "4.4.4"
+              },
+              "chrome": {
+                "version_added": "32.0"
+              },
+              "chrome_android": {
+                "version_added": "32.0"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29.0"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "19"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "7.1"
+              },
+              "safari_ios": {
+                "version_added": "8.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1,3310 +1,3219 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "javascript": {
-      "builtins": {
+  "javascript": {
+    "builtins": {
+      "String": {
+        "@@iterator": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "alternative_name": "iterator",
+                  "version_added": "17",
+                  "version_removed": "27"
+                },
+                {
+                  "alternative_name": "@@iterator",
+                  "version_added": "27",
+                  "version_removed": "36",
+                  "notes": "A placeholder property named <code>@@iterator</code> is used."
+                },
+                {
+                  "version_added": "36",
+                  "notes": "The <code>@@iterator</code> symbol is implemented."
+                }
+              ],
+              "firefox_android": {
+                "version_added": "36"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "String": {
-          "@@iterator": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": [
-                    {
-                      "alternative_name": "iterator",
-                      "version_added": "17",
-                      "version_removed": "27"
-                    },
-                    {
-                      "alternative_name": "@@iterator",
-                      "version_added": "27",
-                      "version_removed": "36",
-                      "notes": "A placeholder property named <code>@@iterator</code> is used."
-                    },
-                    {
-                      "version_added": "36",
-                      "notes": "The <code>@@iterator</code> symbol is implemented."
-                    }
-                  ],
-                  "firefox_android": {
-                    "version_added": "36"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           },
-          "String": {
+          "unicode_code_point_escapes": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "description": "Unicode code point escapes \\u{xxxxxx}",
+              "support": {
+                "webview_android": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "40"
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "nodejs": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
                 }
               },
-              "unicode_code_point_escapes": {
-                "desc": "Unicode code point escapes \\u{xxxxxx}",
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "40"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
-          },
-          "anchor": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true,
-                    "notes": "Starting with version 17, the quotation mark (\") is replaced by its HTML reference character (<code>&quot;</code>) in strings supplied for the <code>name</code> parameter."
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
+          }
+        },
+        "anchor": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true,
+                "notes": "Starting with version 17, the quotation mark (\") is replaced by its HTML reference character (<code>&quot;</code>) in strings supplied for the <code>name</code> parameter."
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "big": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "blink": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "bold": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "charAt": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "charCodeAt": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "codePointAt": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "concat": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "endsWith": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "17"
+              },
+              "firefox_android": {
+                "version_added": "17"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fixed": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "fontcolor": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "fontsize": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "fromCharCode": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fromCodePoint": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "includes": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "alternative_name": "contains",
+                  "version_added": "18",
+                  "version_removed": "48"
+                },
+                {
+                  "version_added": "40"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "alternative_name": "contains",
+                  "version_added": "18",
+                  "version_removed": "48"
+                },
+                {
+                  "version_added": "40"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "indexOf": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "italics": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "lastIndexOf": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "ie_mobile": {
+                "version_added": "8.1"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "length": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "link": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "localeCompare": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           },
-          "big": {
+          "locales": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "blink": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome": {
+                  "version_added": "24"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "bold": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome_android": {
+                  "version_added": "26"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "charAt": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "charCodeAt": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "codePointAt": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": "29"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+                "firefox": {
+                  "version_added": "29"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "concat": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "endsWith": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "chrome_android": {
-                    "version_added": "36"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "17"
-                  },
-                  "firefox_android": {
-                    "version_added": "17"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
+                "ie": {
+                  "version_added": "11"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "fixed": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie_mobile": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "fontcolor": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "nodejs": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "fontsize": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "opera": {
+                  "version_added": "15"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "fromCharCode": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "opera_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "fromCodePoint": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+                "safari": {
+                  "version_added": "10"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "includes": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": [
-                    {
-                      "alternative_name": "contains",
-                      "version_added": "18",
-                      "version_removed": "48"
-                    },
-                    {
-                      "version_added": "40"
-                    }
-                  ],
-                  "firefox_android": [
-                    {
-                      "alternative_name": "contains",
-                      "version_added": "18",
-                      "version_removed": "48"
-                    },
-                    {
-                      "version_added": "40"
-                    }
-                  ],
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "indexOf": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "italics": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "lastIndexOf": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "6"
-                  },
-                  "ie_mobile": {
-                    "version_added": "8.1"
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "length": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "link": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "localeCompare": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "locales": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "options": {
+            "__compat": {
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
                 }
               },
-              "options": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "24"
-                  },
-                  "chrome_android": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "29"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": "11"
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
+          }
+        },
+        "match": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           },
-          "match": {
+          "flags": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true,
+                  "version_removed": "49"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               },
-              "flags": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true,
-                    "version_removed": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
               }
             }
-          },
-          "normalize": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "34"
-                  },
-                  "chrome_android": {
-                    "version_added": "34"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "31"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "normalize": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "34"
+              },
+              "chrome_android": {
+                "version_added": "34"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "padEnd": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "padStart": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "prototype": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "quote": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "version_removed": "37"
+              },
+              "firefox_android": {
+                "version_added": true,
+                "version_removed": "37"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "raw": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "41"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "repeat": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "24"
+              },
+              "firefox_android": {
+                "version_added": "24"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "replace": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           },
-          "padEnd": {
+          "flags": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "57"
-                  },
-                  "chrome_android": {
-                    "version_added": "57"
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "44"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "padStart": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": "57"
-                  },
-                  "chrome_android": {
-                    "version_added": "57"
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "44"
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+                "chrome": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "quote": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true,
-                    "version_removed": "37"
-                  },
-                  "firefox_android": {
-                    "version_added": true,
-                    "version_removed": "37"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
+                "edge": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "raw": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "chrome_android": {
-                    "version_added": "41"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "34"
-                  },
-                  "firefox_android": {
-                    "version_added": "34"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "10"
-                  },
-                  "safari_ios": {
-                    "version_added": "10"
-                  }
+                "edge_mobile": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "repeat": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "chrome_android": {
-                    "version_added": "36"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "24"
-                  },
-                  "firefox_android": {
-                    "version_added": "24"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
+                "firefox": {
+                  "version_added": true,
+                  "version_removed": "49"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "replace": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               },
-              "flags": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true,
-                    "version_removed": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
               }
             }
+          }
+        },
+        "search": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           },
-          "search": {
+          "flags": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true,
+                  "version_removed": "49"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               },
-              "flags": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true,
-                    "version_removed": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
               }
             }
-          },
-          "slice": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "slice": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "small": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "split": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "startsWith": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "17"
+              },
+              "firefox_android": {
+                "version_added": "17"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "strike": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "sub": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "substr": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "substring": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sup": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "toLocaleLowerCase": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           },
-          "small": {
+          "locale": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "split": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "chrome": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "startsWith": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "chrome_android": {
-                    "version_added": "36"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "17"
-                  },
-                  "firefox_android": {
-                    "version_added": "17"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "9"
-                  },
-                  "safari_ios": {
-                    "version_added": "9"
-                  }
+                "chrome_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "strike": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "sub": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "edge_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "substr": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox": {
+                  "version_added": "55"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "substring": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "firefox_android": {
+                  "version_added": "55"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "sup": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "toLocaleLowerCase": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+                "ie_mobile": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
-              "locale": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
+          }
+        },
+        "toLocaleUpperCase": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           },
-          "toLocaleUpperCase": {
+          "locale": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
+              "support": {
+                "webview_android": {
+                  "version_added": null
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
-              "locale": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": null
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": null
-                  },
-                  "edge_mobile": {
-                    "version_added": null
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "ie": {
-                    "version_added": null
-                  },
-                  "ie_mobile": {
-                    "version_added": null
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
-          },
-          "toLowerCase": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toLowerCase": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "toSource": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": false
-                  },
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": false
-                }
+          }
+        },
+        "toSource": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
-          },
-          "toString": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toString": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "toUpperCase": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "toUpperCase": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "trim": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "3.5"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": "9"
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": "10.5"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "5"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "trim": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "5"
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "trimLeft": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "3.5"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": false
-                }
+          }
+        },
+        "trimLeft": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
-          },
-          "trimRight": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": null
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": null
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "3.5"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": false
-                }
+          }
+        },
+        "trimRight": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
-          },
-          "valueOf": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "webview_android": {
-                    "version_added": true
-                  },
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": true
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "ie": {
-                    "version_added": true
-                  },
-                  "ie_mobile": {
-                    "version_added": true
-                  },
-                  "nodejs": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": true
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": true
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+          }
+        },
+        "valueOf": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "ajv": "^5.0.1"
   },
   "scripts": {
+    "convert": "node test/convert",
     "lint": "node test/lint",
+    "render": "node test/render",
     "test": "npm run lint"
   }
 }

--- a/test/convert.js
+++ b/test/convert.js
@@ -7,14 +7,14 @@ function convert(file, filePath) {
   delete file.version;
 
   function traverse(obj) {
-    for (i in obj) {
+    for (let i in obj) {
       if (!!obj[i] && typeof(obj[i])=="object") {
         // log structures that aren't nested properly and contain a dot.
         // Need to fix these manually or come up with a script here
         if (i.includes(".")) {
           console.log(i);
         }
-        // there is __compat, but sub features follow, "support" should always be the next key
+        //  Don't process objects that have been converted already
         if (obj[i].hasOwnProperty("__compat") && !obj[i].__compat.support) {
           let newObj = {};
           for (let feature of Object.keys(obj[i].__compat)) {

--- a/test/convert.js
+++ b/test/convert.js
@@ -1,0 +1,73 @@
+var fs = require('fs');
+var path = require('path');
+
+
+function convert(file, filePath) {
+  // remove version that is not being used or updated
+  delete file.version;
+
+  function traverse(obj) {
+    for (i in obj) {
+      if (!!obj[i] && typeof(obj[i])=="object") {
+        // log structures that aren't nested properly and contain a dot.
+        // Need to fix these manually or come up with a script here
+        if (i.includes(".")) {
+          console.log(i);
+        }
+        // there is __compat, but sub features follow, "support" should always be the next key
+        if (obj[i].hasOwnProperty("__compat") && !obj[i].__compat.support) {
+          let newObj = {};
+          for (let feature of Object.keys(obj[i].__compat)) {
+            // change "desc" to "description" and ensure it is added at the top (thus Object.assign)
+            if (obj[i].__compat[feature].desc) {
+              obj[i].__compat[feature] = Object.assign({description: obj[i].__compat[feature].desc}, obj[i].__compat[feature]);
+              delete obj[i].__compat[feature].desc;
+            }
+            // basic_support is now __compat on the main feature level
+            if (feature == 'basic_support') {
+              newObj = obj[i].__compat.basic_support;
+            } else {
+              // former sub features need to have __compat too
+              obj[i][feature] = {"__compat": obj[i].__compat[feature]};
+            }
+          }
+          obj[i].__compat = newObj;
+        }
+        traverse(obj[i]);
+      }
+    }
+  }
+  traverse(file.data);
+
+  fs.writeFile(filePath, JSON.stringify(file.data, null, 2), function(err) {
+    if(err) {
+      return console.log(err);
+    }
+  });
+
+}
+
+function load(...files) {
+  for (let file of files) {
+    if (file.indexOf(__dirname) !== 0) {
+      file = path.resolve(__dirname, '..', file);
+    }
+
+    if (fs.statSync(file).isFile()) {
+      if (path.extname(file) === '.json') {
+        console.log(file.replace(path.resolve(__dirname, '..') + path.sep, ''));
+        convert(require(file), file);
+      }
+
+      continue;
+    }
+
+    let subFiles = fs.readdirSync(file).map((subfile) => {
+      return path.join(file, subfile);
+    });
+
+    load(...subFiles);
+  }
+}
+
+load(process.argv[2])

--- a/test/render.js
+++ b/test/render.js
@@ -1,0 +1,374 @@
+/*
+
+See https://raw.githubusercontent.com/mozilla/kumascript/master/macros/Compat.ejs
+
+Run as `npm run render http.headers.Cache-Control`
+(same parameter as the {{compat("http.headers.Cache-Control")}} call)
+
+*/
+
+const bcd = require('..');
+
+var query = process.argv[2];
+var depth = process.argv[3] || 1;
+var output = '';
+
+var s_no_data_found = `No compatibility data found. Please contribute data for "${query}" (depth: ${depth}) to the <a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.`;
+var s_firefox_android = 'Firefox for Android';
+var s_chrome_android = 'Chrome for Android';
+
+const desktopBrowsers = {
+  chrome: 'Chrome',
+  edge: 'Edge',
+  firefox: 'Firefox',
+  ie: 'Internet Explorer',
+  opera: 'Opera',
+  safari: 'Safari'
+};
+
+const mobileBrowsers = {
+  webview_android: 'Android',
+  chrome_android: s_chrome_android,
+  edge_mobile: 'Edge mobile',
+  firefox_android: s_firefox_android,
+  ie_mobile: 'IE mobile',
+  opera_android: 'Opera Android',
+  safari_ios: 'iOS Safari',
+}
+
+var notesArray = [];
+
+/*
+Write the table header.
+
+`browserPlatformType` is either "mobile" or "desktop"
+`browserNames` is either the "mobileBrowsers" or "desktopBrowsers" object
+*/
+function writeTableHead(browserPlatformType, browserNames) {
+  let browserNameKeys = Object.keys(browserNames);
+  let output = `<div id="compat-${browserPlatformType}"><table class="compat-table"><thead><tr>`;
+  output +=  `<th>Feature</th>`
+  for (let browserNameKey of browserNameKeys) {
+    output += `<th>${browserNames[browserNameKey]}</th>`;
+  }
+  output += '</tr></thead>';
+  return output;
+}
+
+/*
+Given the value of `version_added` or `version_removed`, this returns
+a string to appear in the table cell, like "Yes", "No" or "?"
+
+`versionInfo` is either null, true, false or a string containing a version number
+*/
+function getVersionString(versionInfo) {
+  switch (versionInfo) {
+    case null:
+    return `<span title="supportsShort_unknown_title"
+    style="color: rgb(255, 153, 0);">?</span>`;
+    break;
+    case true:
+    return `<span style="color: #888">(Yes)</span>`;
+    break;
+    case false:
+    return `<span style="color: #f00">No</span>`;
+    break;
+    default:
+    return versionInfo;
+  }
+}
+
+/*
+Generate the note for a browser flag or preference
+First checks version_added and version_removed to create a string indicating when
+a preference setting is present. Then creates a (browser specific) string
+for either a preference flag or a compile flag.
+
+`supportData` is a support_statement
+`browserId` is a compat_block browser ID
+*/
+function writeFlagsNote(supportData, browserId) {
+  let output = '';
+
+  const firefoxPrefs = 'To change preferences in Firefox, visit about:config.';
+  const chromePrefs = 'To change preferences in Chrome, visit chrome://flags.';
+
+  if (typeof(supportData.version_added) === 'string') {
+    output = 'From version ' + supportData.version_added;
+  }
+
+  if (typeof(supportData.version_removed) === 'string') {
+    if (output) {
+      output += ' until version '+ supportData.version_removed + ' (exclusive): ';
+    } else {
+      output = 'Until version ' + supportData.version_removed + ' (exclusive): ';
+    }
+  } else {
+    output += ', ';
+  }
+
+  let flagText = `this feature is behind the <code>${supportData.flag.name}</code>`;
+
+  // value_to_set is optional
+  let valueToSet = '';
+  if (supportData.flag.value_to_set) {
+    valueToSet = ` (needs to be set to <code>${supportData.flag.value_to_set}</code>)`;
+  }
+
+  if (supportData.flag.type === 'preference') {
+    let prefSettings = '';
+    switch (browserId) {
+      case 'firefox':
+      case 'firefox_android':
+      prefSettings = firefoxPrefs;
+      break;
+      case 'chrome':
+      case 'chrome_android':
+      prefSettings = chromePrefs;
+      break;
+    }
+    output += `${flagText} preference${valueToSet}. ${prefSettings}`;
+  }
+
+  if (supportData.flag.type === 'compile_flag') {
+    output += `${flagText} compile flag${valueToSet}.`;
+  }
+
+  return output;
+}
+
+
+/*
+Main function responsible for the contents of a support cell in the table.
+
+`supportData` is a support_statement
+`browserId` is a compat_block browser ID
+`compatNotes` is collected Compatibility notes
+
+*/
+function writeSupportInfo(supportData, browserId, compatNotes) {
+  let output = '';
+
+  // browsers are optional in the data, display them as "?" in our table
+  if (!supportData) {
+    output = getVersionString(null);
+    // we have support data, lets go
+  } else {
+    output += getVersionString(supportData.version_added);
+
+    if (supportData.version_removed) {
+      // We don't know when
+      if (typeof(supportData.version_removed) === 'boolean' && supportData.version_removed) {
+        output += '&nbsp;—?'
+      } else { // We know when
+        output += '&nbsp;— ' + supportData.version_removed;
+      }
+    }
+
+    // Add prefix
+    if (supportData.prefix) {
+      output += `<span title="prefix" class="inlineIndicator prefixBox prefixBoxInline">
+      <a title="The name of this feature is prefixed with '${supportData.prefix}' as this
+      browser considers it experimental" href="/en-US/docs/Web/Guide/Prefixes">${supportData.prefix}
+      </a></span>`;
+    }
+
+    // Add alternative name
+    if (supportData.alternative_name) {
+      output += ` (as <code>${supportData.alternative_name}</code>)`;
+    }
+
+    // Add note anchors
+    // There are two types of notes (notes, and flag notes).
+    // Collect them and order them, before adding them to the cell
+    let noteAnchors = [];
+
+    // Generate notes, if any
+    if (compatNotes && supportData.notes) {
+      if (Array.isArray(supportData.notes)) {
+        for (let note of supportData.notes) {
+          let noteIndex = compatNotes.indexOf(note);
+          noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
+        }
+      } else {
+        let noteIndex = compatNotes.indexOf(supportData.notes);
+        noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
+      }
+    }
+
+    // there is a flag and it needs a note, too
+    if (compatNotes && supportData.flag) {
+      let flagNote = writeFlagsNote(supportData, browserId);
+      let noteIndex = compatNotes.indexOf(flagNote);
+      noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
+    }
+    noteAnchors = noteAnchors.sort();
+    output += noteAnchors.join(' ');
+
+  }
+  return output;
+}
+
+/*
+Iterate into all "support" objects, and all browsers under them,
+and collect all notes in an array, without duplicates.
+*/
+function collectCompatNotes() {
+
+  function pushNotes(supportEntry, browserName) {
+    // collect notes
+    if (supportEntry.hasOwnProperty('notes')) {
+      let notes = supportEntry['notes'];
+      if (Array.isArray(notes)) {
+        for (let note of notes) {
+          if (notesArray.indexOf(note) === -1) {
+            notesArray.push(note);
+          }
+        }
+      } else {
+        if (notesArray.indexOf(notes) === -1) {
+          notesArray.push(notes);
+        }
+      }
+    }
+    // collect flags
+    if (supportEntry.hasOwnProperty('flag')) {
+      let flagNote = writeFlagsNote(supportEntry, browserName);
+      if (notesArray.indexOf(flagNote) === -1) {
+        notesArray.push(flagNote);
+      }
+    }
+  }
+  for (let row of features) {
+    let support = Object.keys(row).map((k) => row[k])[0].support;
+    for (let browserName of Object.keys(support)) {
+      if (Array.isArray(support[browserName])) {
+        for (let entry of support[browserName]) {
+          pushNotes(entry, browserName);
+        }
+      } else {
+        pushNotes(support[browserName], browserName);
+      }
+    }
+  }
+  return notesArray;
+}
+
+/*
+For a single row, write all the cells that contain support data.
+(That is, every cell in the row except the first, which contains
+an identifier for the row,  like "Basic support".
+
+*/
+function writeSupportCells(supportData, compatNotes, browserNames) {
+  let output = '';
+
+  for (let browserNameKey of Object.keys(browserNames)) {
+    let support = supportData[browserNameKey];
+    let supportInfo = '';
+    // if supportData is an array, there are multiple support statements
+    if (Array.isArray(support)) {
+      for (let entry of support) {
+        supportInfo += `<p>${writeSupportInfo(entry, browserNameKey, compatNotes)}</p>`;
+      }
+    } else if (support) { // there is just one support statement
+      supportInfo = writeSupportInfo(support, browserNameKey, compatNotes);
+    } else { // this browser has no info, it's unknown
+    supportInfo = writeSupportInfo(null);
+  }
+  output += `<td>${supportInfo}</td>`;
+}
+return output;
+}
+
+/*
+
+*/
+function writeTable(browserPlatformType, browserNames) {
+  let compatNotes = collectCompatNotes();
+  let output = writeTableHead(browserPlatformType, browserNames);
+  output += '<tbody>';
+  for (let row of features) {
+    let feature = Object.keys(row).map((k) => row[k])[0];
+    var desc = feature.description || `<code>${Object.keys(row)[0]}</code>`;
+    output += `<tr><td>${desc}</td>`
+    output += `${writeSupportCells(feature.support, compatNotes, browserNames)}</tr>`;
+  }
+  output += '</tbody></table></div>';
+  return output;
+}
+
+/*
+Write each compat note, with an `id` so it will be linked from the table.
+*/
+function writeNotes() {
+  let output = '';
+  let compatNotes = collectCompatNotes();
+  for (let note of compatNotes) {
+    let noteIndex = compatNotes.indexOf(note);
+    output += `<p id=compatNote_${noteIndex+1}>${noteIndex+1}. ${note}</p>`;
+  }
+  return output;
+}
+
+/*
+Get compat data using a query string like "webextensions.api.alarms"
+*/
+function getData(queryString, obj) {
+  return queryString.split('.').reduce(function(prev, curr) {
+    return prev ? prev[curr] : undefined
+  }, obj);
+}
+
+/*
+Get features that should be displayed according to the query and the depth setting
+Flatten them into a features array
+*/
+function traverseFeatures(obj, depth, identifier) {
+  depth--;
+  if (depth >= 0) {
+    for (i in obj) {
+      if (!!obj[i] && typeof(obj[i])=="object" && i !== '__compat') {
+        if (obj[i].__compat) {
+          // [identifier + '.' + i]
+          features.push({[i]: obj[i].__compat});
+        }
+        traverseFeatures(obj[i], depth, identifier + '.' + i);
+      }
+    }
+  }
+}
+
+var compatData = getData(query, bcd);
+var features = [];
+var identifier = query.split(".").pop();
+
+if (!compatData) {
+  output = s_no_data_found;
+} else if (compatData.__compat) {
+  // get an optional main feature identifier and add it to the feature list
+  features.push({[identifier]: compatData.__compat});
+}
+
+traverseFeatures(compatData, depth, identifier);
+
+if (features.length > 0) {
+  output = `<div class="htab">
+  <a id="AutoCompatibilityTable" name="AutoCompatibilityTable"></a>
+  <ul>
+    <li class="selected">
+      <a href="javascript:;">Desktop</a>
+    </li>
+    <li>
+      <a href="javascript:;">Mobile</a>
+    </li>
+  </ul>
+  </div>`;
+  output += writeTable('desktop', desktopBrowsers);
+  output += writeTable('mobile', mobileBrowsers);
+  output += writeNotes();
+} else {
+  output = s_no_data_found;
+}
+
+console.log(output);

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -1,252 +1,249 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "sample": {
-      "api": {
-        "onlyBasicSupport": {
+  "sample": {
+    "api": {
+      "onlyBasicSupport": {
+        "__compat": {
+          "description": "Tests for various notes",
+          "support": {
+            "webview_android": {
+              "version_added": "4.1",
+              "notes": [
+                "First note",
+                "Second note"
+              ]
+            },
+            "chrome": {
+              "version_added": "1.0",
+              "notes": [
+                "A note"
+              ],
+              "version_removed": "3.0"
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "A note but no array"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": false
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0",
+              "version_removed": true
+            },
+            "firefox_android": {
+              "version_added": "14.0"
+            },
+            "ie": {
+              "version_added": "9.0",
+              "version_removed": null
+            },
+            "ie_mobile": {
+              "version_added": "7.1"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "3.0",
+              "notes": "The same note twice should only be displayed once and have one anchor number"
+            },
+            "safari_ios": {
+              "version_added": true,
+              "notes": "The same note twice should only be displayed once and have one anchor number"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "featureWithSubfeatures": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "4.1"
+            },
+            "chrome": {
+              "version_added": "1.0",
+              "notes": [
+                "A note"
+              ]
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "A note but no array"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4.0",
+              "notes": [
+                "First note",
+                "Second note"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "14.0"
+            },
+            "ie": {
+              "version_added": "9.0"
+            },
+            "ie_mobile": {
+              "version_added": "7.1"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "3.0"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "chocoCookie": {
           "__compat": {
-            "basic_support": {
-              "desc": "Tests for various notes",
-              "support": {
-                "webview_android": {
-                  "version_added": "4.1",
+            "description": "This is a sub feature with complex support statements",
+            "support": {
+              "webview_android": {
+                "version_added": "4.1"
+              },
+              "chrome": [
+                {
+                  "version_added": "35.0",
+                  "version_removed": "47.0",
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features",
+                    "value_to_set": "true"
+                  }
+                },
+                {
+                  "version_added": "47.0",
+                  "notes": "A note but no array"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "35.0",
+                  "version_removed": "47.0",
+                  "notes": [
+                    "First note for a flag",
+                    "Second note for a flag"
+                  ],
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features",
+                    "value_to_set": "true"
+                  }
+                },
+                {
+                  "version_added": "47.0"
+                }
+              ],
+              "edge": [
+                {
+                  "alternative_name": "chocolateCookie",
+                  "version_added": true,
+                  "version_removed": "12.0"
+                },
+                {
+                  "version_added": "12"
+                }
+              ],
+              "edge_mobile": {
+                "version_added": true,
+                "version_removed": true
+              },
+              "firefox": [
+                {
+                  "prefix": "-moz-",
+                  "version_added": "12.0",
+                  "version_removed": "53.0",
+                  "notes": "A note but no array for a support statement with -moz- prefix"
+                },
+                {
+                  "version_added": "49.0"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "prefix": "-moz-",
+                  "version_added": "12.0",
+                  "version_removed": "53.0",
                   "notes": [
                     "First note",
                     "Second note"
                   ]
                 },
-                "chrome": {
-                  "version_added": "1.0",
+                {
+                  "version_added": "49.0",
                   "notes": [
-                    "A note"
-                  ],
-                  "version_removed": "3.0"
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "A note but no array"
-                },
-                "edge": {
-                  "version_added": "12",
-                  "version_removed": false
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0",
-                  "version_removed": true
-                },
-                "firefox_android": {
-                  "version_added": "14.0"
-                },
-                "ie": {
-                  "version_added": "9.0",
-                  "version_removed": null
-                },
-                "ie_mobile": {
-                  "version_added": "7.1"
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "12.1"
-                },
-                "safari": {
-                  "version_added": "3.0",
-                  "notes": "The same note twice should only be displayed once and have one anchor number"
-                },
-                "safari_ios": {
-                  "version_added": true,
-                  "notes": "The same note twice should only be displayed once and have one anchor number"
+                    "A single note in an array"
+                  ]
                 }
+              ],
+              "ie": {
+                "version_added": "9.0",
+                "version_removed": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "ie_mobile": {
+                "version_added": "7.1",
+                "version_removed": null
+              },
+              "opera": {
+                "version_added": true,
+                "version_removed": "10.5"
+              },
+              "opera_android": {
+                "version_added": "12.1",
+                "version_removed": false
+              },
+              "safari": {
+                "version_added": "3.0"
+              },
+              "safari_ios": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
-        "featureWithSubfeatures": {
+        "subfeature-no-status-few-browsers": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "webview_android": {
-                  "version_added": "4.1"
-                },
-                "chrome": {
-                  "version_added": "1.0",
-                  "notes": [
-                    "A note"
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "notes": "A note but no array"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "4.0",
-                  "notes": [
-                    "First note",
-                    "Second note"
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "14.0"
-                },
-                "ie": {
-                  "version_added": "9.0"
-                },
-                "ie_mobile": {
-                  "version_added": "7.1"
-                },
-                "opera": {
-                  "version_added": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "12.1"
-                },
-                "safari": {
-                  "version_added": "3.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
+            "description": "No status block and only a few browsers",
+            "support": {
+              "firefox": {
+                "version_added": "49.0"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            },
-            "chocoCookie": {
-              "desc": "This is a sub feature with complex support statements",
-              "support": {
-                "webview_android": {
-                  "version_added": "4.1"
-                },
-                "chrome": [
-                  {
-                    "version_added": "35.0",
-                    "version_removed": "47.0",
-                    "flag": {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "47.0",
-                    "notes": "A note but no array"
-                  }
-                ],
-                "chrome_android": [
-                  {
-                    "version_added": "35.0",
-                    "version_removed": "47.0",
-                    "notes": [
-                      "First note for a flag",
-                      "Second note for a flag"
-                    ],
-                    "flag": {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features",
-                      "value_to_set": "true"
-                    }
-                  },
-                  {
-                    "version_added": "47.0"
-                  }
-                ],
-                "edge": [
-                  {
-                    "alternative_name": "chocolateCookie",
-                    "version_added": true,
-                    "version_removed": "12.0"
-                  },
-                  {
-                    "version_added": "12"
-                  }
-                ],
-                "edge_mobile": {
-                  "version_added": true,
-                  "version_removed": true
-                },
-                "firefox": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "12.0",
-                    "version_removed": "53.0",
-                    "notes": "A note but no array for a support statement with -moz- prefix"
-                  },
-                  {
-                    "version_added": "49.0"
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "12.0",
-                    "version_removed": "53.0",
-                    "notes": [
-                      "First note",
-                      "Second note"
-                    ]
-                  },
-                  {
-                    "version_added": "49.0",
-                    "notes": [
-                      "A single note in an array"
-                    ]
-                  }
-                ],
-                "ie": {
-                  "version_added": "9.0",
-                  "version_removed": true
-                },
-                "ie_mobile": {
-                  "version_added": "7.1",
-                  "version_removed": null
-                },
-                "opera": {
-                  "version_added": true,
-                  "version_removed": "10.5"
-                },
-                "opera_android": {
-                  "version_added": "12.1",
-                  "version_removed": false
-                },
-                "safari": {
-                  "version_added": "3.0"
-                },
-                "safari_ios": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            },
-            "subfeature-no-status-few-browsers": {
-              "desc": "No status block and only a few browsers",
-              "support": {
-                "firefox": {
-                  "version_added": "49.0"
-                },
-                "firefox_android": {
-                  "version_added": "49.0"
-                }
+              "firefox_android": {
+                "version_added": "49.0"
               }
             }
           }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -955,7 +955,7 @@
               }
             }
           },
-          "originTypes.extension": {
+          "originTypes": {
             "__compat": {
               "support": {
                 "chrome": {
@@ -974,25 +974,46 @@
                   "version_added": true
                 }
               }
-            }
-          },
-          "originTypes.protectedWeb": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
+            },
+            "extension": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "protectedWeb": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -5948,86 +5969,88 @@
               }
             }
           },
-          "details.id": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "22"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "15"
+          "details": {
+            "id": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "22"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
                 }
               }
-            }
-          },
-          "details.previousVersion": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "22"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": "15"
+            },
+            "previousVersion": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "22"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": "55"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
                 }
               }
-            }
-          },
-          "details.reason": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "22"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": "52"
-                },
-                "opera": {
-                  "version_added": "15"
+            },
+            "reason": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "22"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": "52"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
                 }
               }
-            }
-          },
-          "details.temporary": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": false
+            },
+            "temporary": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": "55"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
                 }
               }
             }
@@ -6266,44 +6289,46 @@
               }
             }
           },
-          "options.includeTlsChannelId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "32"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": "19"
+          "options": {
+            "includeTlsChannelId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "32"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": "19"
+                  }
                 }
               }
-            }
-          },
-          "options.toProxyScript": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": false
+            },
+            "toProxyScript": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": "55"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
                 }
               }
             }
@@ -7360,23 +7385,25 @@
               }
             }
           },
-          "connectInfo.frameId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "41"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "28"
+          "connectInfo": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "41"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "28"
+                  }
                 }
               }
             }
@@ -8185,23 +8212,25 @@
               }
             }
           },
-          "changeInfo.title": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": true
+          "changeInfo": {
+            "title": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -8620,23 +8649,25 @@
               }
             }
           },
-          "options.frameId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "41"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "28"
+          "options": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "41"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "28"
+                  }
                 }
               }
             }
@@ -11364,25 +11395,25 @@
                   "version_added": "15"
                 }
               }
-            }
-          },
-          "getInfo.windowTypes": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "46"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "33"
+            },
+            "windowTypes": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
                 }
               }
             }
@@ -11490,25 +11521,25 @@
                   "version_added": "15"
                 }
               }
-            }
-          },
-          "getInfo.windowTypes": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "46"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "33"
+            },
+            "windowTypes": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
                 }
               }
             }
@@ -11553,25 +11584,25 @@
                   "version_added": "15"
                 }
               }
-            }
-          },
-          "getInfo.windowTypes": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "46"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "33"
+            },
+            "windowTypes": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "46"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "33"
+                  }
                 }
               }
             }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1,12 +1,2032 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "webextensions": {
-      "api": {
-        "alarms": {
-          "Alarm": {
+  "webextensions": {
+    "api": {
+      "alarms": {
+        "Alarm": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "clear": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "clearAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onAlarm": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "bookmarks": {
+        "BookmarkTreeNode": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "BookmarkTreeNodeUnmodifiable": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "CreateDetails": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getChildren": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getRecent": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getSubTree": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getTree": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "move": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onChildrenReordered": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onCreated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onImportBegan": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onImportEnded": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onMoved": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onRemoved": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeTree": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "search": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "browserAction": {
+        "ColorArray": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ImageDataType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "disable": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "enable": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getBadgeBackgroundColor": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getBadgeText": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getPopup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getTitle": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onClicked": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setBadgeBackgroundColor": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setBadgeText": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setIcon": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "notes": [
+                  "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
+                ]
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          },
+          "imageData": {
             "__compat": {
-              "basic_support": {
+              "support": {
+                "chrome": {
+                  "version_added": "23"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          }
+        },
+        "setPopup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setTitle": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "browsingData": {
+        "DataTypeSet": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "RemovalOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "originTypes.extension": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "originTypes.protectedWeb": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.",
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeCache": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeCookies": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeDownloads": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeFormData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeHistory": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removePasswords": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removePluginData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                ],
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "settings": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "browserSettings": {
+        "cacheEnabled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "commands": {
+        "Command": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onCommand": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "contextMenus": {
+        "ACTION_MENU_TOP_LEVEL_LIMIT": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ContextType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "browser_action": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "notes": [
+                    "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                  ],
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "page_action": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "launcher": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "password": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "tab": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "ItemType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "OnClickData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "modifiers": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ],
+                "version_added": true
+              }
+            }
+          },
+          "command": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onClicked": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "contextualIdentities": {
+        "ContextualIdentity": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "query": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "cookies": {
+        "Cookie": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "CookieStore": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "OnChangedCause": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Provides access to cookies from private browsing mode and container tabs since version 52."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user's machine."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 52, the 'tabIds' list was empty and only cookies from the default cookie store were returned. From version 52 onwards, this has been fixed and the result includes cookies from private browsing mode and container tabs."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAllCookieStores": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Always returns the same default cookie store with ID 0. All cookies belong to this store."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 52, only the default cookie store was visible. From version 52 onwards, the cookie stores for private browsing mode and container tabs are also readable."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "set": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "devtools": {
+        "inspectedWindow": {
+          "eval": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "$0": {
+              "__compat": {
                 "support": {
                   "chrome": {
                     "version_added": true
@@ -15,12235 +2035,9816 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45"
+                    "version_added": "55"
                   },
                   "firefox_android": {
-                    "version_added": "48"
+                    "version_added": false
                   },
                   "opera": {
                     "version_added": true
                   }
                 }
+              }
+            },
+            "inspect()": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "options": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "reload": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "tabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "network": {
+          "onNavigated": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "panels": {
+          "ExtensionPanel": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            },
+            "onSearch": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
+          },
+          "create": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "onThemeChanged": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "themeName": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "41"
+                }
+              }
+            }
+          }
+        }
+      },
+      "downloads": {
+        "BooleanDelta": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "DangerType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "DoubleDelta": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "DownloadItem": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "DownloadQuery": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "DownloadTime": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "FilenameConflictAction": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "prompt": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "InterruptReason": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "State": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "StringDelta": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "acceptDanger": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "cancel": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "download": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "saveAs": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "POST": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "drag": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "erase": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getFileIcon": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onCreated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onErased": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "open": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "pause": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeFile": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "resume": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "search": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setShelfEnabled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "show": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "showDefaultFolder": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "events": {
+        "Event": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "Rule": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "UrlFilter": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": "50"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "extension": {
+        "ViewType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getBackgroundPage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getExtensionTabs": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "getURL": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "getViews": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "inIncognitoContext": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "isAllowedFileSchemeAccess": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "isAllowedIncognitoAccess": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "lastError": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onRequest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "onRequestExternal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "sendRequest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "setUpdateUrlData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "extensionTypes": {
+        "ImageDetails": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ImageFormat": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "RunAt": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "20"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        }
+      },
+      "history": {
+        "HistoryItem": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "typedCount": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "TransitionType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "VisitItem": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "addUrl": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "title": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "49"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "transition": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "49"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "visitTime": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "49"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "deleteAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "deleteRange": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "deleteUrl": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getVisits": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onTitleChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "onVisitRemoved": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onVisited": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "50",
+                "notes": [
+                  "Before version 56, the result object's 'title' was always an empty string. From version 56 onwards, it is set to the last known title, if that is available, or an empty string otherwise."
+                ]
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "search": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "i18n": {
+        "LanguageCode": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "47"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "34"
+              }
+            }
+          }
+        },
+        "detectLanguage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "47"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "34"
+              }
+            }
+          }
+        },
+        "getAcceptLanguages": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "47"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "34"
+              }
+            }
+          }
+        },
+        "getMessage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "17"
+              },
+              "edge": {
+                "version_added": true,
+                "notes": [
+                  "Throws an exception instead returning an empty string if the message does not exist.",
+                  "Expects substitutions to be strings, while other browsers allow any value which is then converted to a string."
+                ]
+              },
+              "firefox": {
+                "version_added": "45",
+                "notes": [
+                  "Firefox 47 and earlier returns \"??\" instead of \"\" if the message is not found in _locales, <a href='https://bugzil.la/1258199'>bug 1258199</a> changed this act to match Chrome, landed on Firefox 48."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "getUILanguage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "35"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "identity": {
+        "getRedirectURL": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "launchWebAuthFlow": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "idle": {
+        "IdleState": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onStateChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "locked": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "queryState": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "locked": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "setDetectionInterval": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "management": {
+        "ExtensionInfo": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "disabledReason": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "offlineEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "versionName": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55",
+                "notes": [
+                  "Before version 56, only extensions whose 'type' is 'theme' are returned."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "55",
+                "notes": [
+                  "Before version 56, only extensions whose 'type' is 'theme' are returned."
+                ]
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getPermissionWarningsById": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getPermissionWarningsByManifest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getSelf": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "onDisabled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onEnabled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onInstalled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onUninstalled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setEnabled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55",
+                "notes": [
+                  "Only extensions whose 'type' is 'theme' can be enabled and disabled."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "55",
+                "notes": [
+                  "Only extensions whose 'type' is 'theme' can be enabled and disabled."
+                ]
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "uninstall": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "uninstallSelf": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "dialogMessage": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "51"
+                },
+                "firefox_android": {
+                  "version_added": "51"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "notifications": {
+        "NotificationOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "TemplateType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "Only the 'basic' type is supported."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Only the 'basic' type is supported."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "Only the 'basic' type is supported."
+                ],
+                "version_added": true
+              }
+            }
+          }
+        },
+        "clear": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onButtonClicked": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onClicked": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onClosed": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "byUser": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "notes": [
+                  "Not supported on Macs."
+                ],
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "omnibox": {
+        "OnInputEnteredDisposition": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "SuggestResult": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'description' is interpreted as plain text, and XML markup is not recognised."
+                ],
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onInputCancelled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onInputChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onInputEntered": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onInputStarted": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setDefaultSuggestion": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'description' is interpreted as plain text, and XML markup is not recognised."
+                ],
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "pageAction": {
+        "ImageDataType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getPopup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
+                ],
+                "version_added": "50"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getTitle": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "hide": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored, and the page action is hidden for all tabs."
+                ],
+                "version_added": "50"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onClicked": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "50"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setIcon": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "notes": [
+                  "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
+                ]
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          },
+          "imageData": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "23"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          }
+        },
+        "setPopup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored, and the popup is set for all tabs."
+                ],
+                "version_added": "50"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setTitle": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "show": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "The 'tabId' parameter is ignored, and the page action is shown for all tabs."
+                ],
+                "version_added": "50"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "permissions": {
+        "contains": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onAdded": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onRemoved": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "Permissions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "request": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55",
+                "notes": [
+                  "The user will be prompted again for permissions that have been previously granted and then removed."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "55",
+                "notes": [
+                  "The user will be prompted again for permissions that have been previously granted and then removed."
+                ]
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "privacy": {
+        "network": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "peerConnectionEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "websites": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "hyperlinkAuditingEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "protectedContentEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "referrersEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "thirdPartyCookiesAllowed": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "proxy": {
+        "onProxyError": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "register": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 56, this function was called 'registerProxyScript'"
+                ],
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "unregister": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "runtime": {
+        "MessageSender": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          },
+          "url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "28"
+                },
+                "edge": {
+                  "version_added": true,
+                  "notes": [
+                    "The `url` is missing when the message was sent by an extension view."
+                  ]
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "tlsChannelId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "32"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "19"
+                }
+              }
+            }
+          },
+          "frameId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "41"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "28"
+                }
+              }
+            }
+          }
+        },
+        "OnInstalledReason": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "OnRestartRequiredReason": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "PlatformArch": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "PlatformInfo": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "nacl_arch": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        },
+        "PlatformNaclArch": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "PlatformOs": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "Port": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          },
+          "error": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "RequestUpdateCheckStatus": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "connect": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "connectNative": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "16"
+              }
+            }
+          }
+        },
+        "getBackgroundPage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "getBrowserInfo": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "getManifest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "getPackageDirectoryEntry": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "16"
+              }
+            }
+          }
+        },
+        "getPlatformInfo": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "16"
+              }
+            }
+          }
+        },
+        "getURL": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "id": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "lastError": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
+                ],
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onBrowserUpdateAvailable": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "27"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "onConnect": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "onConnectExternal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "onInstalled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Before version 55, this event is not triggered for temporarily installed add-ons."
+                ],
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Before version 55, this event is not triggered for temporarily installed add-ons."
+                ],
+                "version_added": "52"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          },
+          "details.id": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "22"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "details.previousVersion": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "22"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "details.reason": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "22"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "details.temporary": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onMessage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "onMessageExternal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "onRestartRequired": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "16"
+              }
+            }
+          }
+        },
+        "onStartup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "23"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "onSuspend": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "onSuspendCanceled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "onUpdateAvailable": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "openOptionsPage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "42"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              }
+            }
+          }
+        },
+        "reload": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "requestUpdateCheck": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "sendMessage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": true,
+                "notes": [
+                  "`runtime.onMessage` listeners in extension views receive the messages they sent."
+                ]
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          },
+          "options.includeTlsChannelId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "32"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "19"
+                }
+              }
+            }
+          },
+          "options.toProxyScript": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "sendNativeMessage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "16"
+              }
+            }
+          }
+        },
+        "setUninstallURL": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "41"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "28"
+              }
+            }
+          }
+        }
+      },
+      "sessions": {
+        "Filter": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "MAX_SESSION_RESULTS": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "Session": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
+                ],
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getRecentlyClosed": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "restore": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "sidebarAction": {
+        "ImageDataType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getPanel": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getTitle": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setIcon": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setPanel": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setTitle": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "storage": {
+        "StorageArea": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           },
           "clear": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "clearAll": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "create": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45.0"
+                },
+                "firefox_android": {
+                  "version_added": "48.0"
+                },
+                "opera": {
+                  "version_added": "33"
                 }
               }
             }
           },
           "get": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45.0"
+                },
+                "firefox_android": {
+                  "version_added": "48.0"
+                },
+                "opera": {
+                  "version_added": "33"
                 }
               }
             }
           },
-          "getAll": {
+          "getBytesInUse": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onAlarm": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "bookmarks": {
-          "BookmarkTreeNode": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "BookmarkTreeNodeUnmodifiable": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "CreateDetails": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "create": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "get": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getChildren": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getRecent": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getSubTree": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getTree": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "move": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onChildrenReordered": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onCreated": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onImportBegan": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onImportEnded": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onMoved": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onRemoved": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "33"
                 }
               }
             }
           },
           "remove": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeTree": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "search": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "update": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "browserAction": {
-          "ColorArray": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "ImageDataType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "disable": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "enable": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getBadgeBackgroundColor": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getBadgeText": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getPopup": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getTitle": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onClicked": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setBadgeBackgroundColor": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setBadgeText": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setIcon": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true,
-                    "notes": [
-                      "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
-                    ]
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "imageData": {
-                "support": {
-                  "chrome": {
-                    "version_added": "23"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "setPopup": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setTitle": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "browsingData": {
-          "DataTypeSet": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "RemovalOptions": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originTypes.extension": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originTypes.protectedWeb": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "remove": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.",
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeCache": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeCookies": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeDownloads": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeFormData": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeHistory": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removePasswords": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removePluginData": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "settings": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "browserSettings": {
-          "cacheEnabled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": "56"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "commands": {
-          "Command": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getAll": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onCommand": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "contextMenus": {
-          "ACTION_MENU_TOP_LEVEL_LIMIT": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "ContextType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                    ],
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "browser_action": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                    ],
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "page_action": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "launcher": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "password": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "tab": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "ItemType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "OnClickData": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "modifiers": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "create": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
-                    ],
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "notes": [
-                      "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                    ],
-                    "version_added": true
-                  }
-                }
-              },
-              "command": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onClicked": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "remove": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeAll": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "update": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "contextualIdentities": {
-          "ContextualIdentity": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "create": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "get": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "query": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "remove": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "update": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "cookies": {
-          "Cookie": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "CookieStore": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "OnChangedCause": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "get": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Provides access to cookies from private browsing mode and container tabs since version 52."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getAll": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user's machine."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 52, the 'tabIds' list was empty and only cookies from the default cookie store were returned. From version 52 onwards, this has been fixed and the result includes cookies from private browsing mode and container tabs."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getAllCookieStores": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Always returns the same default cookie store with ID 0. All cookies belong to this store."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 52, only the default cookie store was visible. From version 52 onwards, the cookie stores for private browsing mode and container tabs are also readable."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "remove": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45.0"
+                },
+                "firefox_android": {
+                  "version_added": "48.0"
+                },
+                "opera": {
+                  "version_added": "33"
                 }
               }
             }
           },
           "set": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "notes": [
+                    "storage is limited to 1MB per value."
+                  ],
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45.0"
+                },
+                "firefox_android": {
+                  "version_added": "48.0"
+                },
+                "opera": {
+                  "version_added": "33"
                 }
               }
             }
           }
         },
-        "devtools": {
-          "inspectedWindow": {
-            "eval": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "54"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
+        "StorageChange": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "local": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "The storage API is supported in content scripts from version 48."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "managed": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "onChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "sync": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "tabs": {
+        "MutedInfo": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "MutedInfoReason": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "PageSettings": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "TAB_ID_NONE": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "Tab": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "incognito": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
                 },
-                "$0": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "55"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
+                "edge": {
+                  "alternative_name": "inPrivate",
+                  "version_added": true
                 },
-                "inspect()": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "55"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
+                "firefox": {
+                  "version_added": "45"
                 },
-                "options": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": false
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
                 }
+              }
+            }
+          },
+          "highlighted": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "selected": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
+          "width, height": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "31"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "18"
+                }
+              }
+            }
+          },
+          "audible": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "45"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "32"
+                }
+              }
+            }
+          },
+          "mutedInfo": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "46"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "33"
+                }
+              }
+            }
+          },
+          "lastAccessed": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "openerTabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "sessionId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "31"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "18"
+                }
+              }
+            }
+          },
+          "discarded": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "41"
+                }
+              }
+            }
+          },
+          "autoDiscardable": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "41"
+                }
+              }
+            }
+          }
+        },
+        "TabStatus": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "WindowType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ZoomSettings": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ZoomSettingsMode": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ZoomSettingsScope": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "captureVisibleTab": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "connect": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "connectInfo.frameId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "41"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "28"
+                }
+              }
+            }
+          }
+        },
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true,
+                "notes": [
+                  "If the `url` has the `ms-browser-extension://` protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading."
+                ]
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "pinned": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "selected": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
+          "openerTabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          }
+        },
+        "detectLanguage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "duplicate": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "executeScript": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "43",
+                "notes": [
+                  "Before version 50, Firefox would pass a single result value into its callback rather than an array, unless 'allFrames' had been set."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "runAt": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "20"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "43"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "frameId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "43",
+                  "notes": [
+                    "'allFrames' and 'frameId' can't both be set at the same time."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": "54",
+                  "notes": [
+                    "'allFrames' and 'frameId' can't both be set at the same time."
+                  ]
+                },
+                "opera": {
+                  "version_added": "26"
+                }
+              }
+            }
+          },
+          "matchAboutBlank": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "26"
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getAllInWindow": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": false
               }
             },
-            "reload": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "54"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "getCurrent": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getSelected": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             },
-            "tabId": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "54"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "getZoom": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "getZoomSettings": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "highlight": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "insertCSS": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           },
-          "network": {
-            "onNavigated": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "54"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "panels": {
-            "ExtensionPanel": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "54"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
+          "runAt": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "20"
                 },
-                "onSearch": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": false
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "15"
                 }
+              }
+            }
+          },
+          "frameId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "26"
+                }
+              }
+            }
+          },
+          "matchAboutBlank": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "26"
+                }
+              }
+            }
+          },
+          "cssOrigin": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "move": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "46"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onActivated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onActiveChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             },
-            "create": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "54"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": true
-                    }
-                  }
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "onAttached": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onCreated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onDetached": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onHighlightChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             },
-            "onThemeChanged": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": false
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "55"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": false
-                    }
-                  }
-                }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "onHighlighted": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "onMoved": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onRemoved": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onReplaced": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ],
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onSelectionChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             },
-            "themeName": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": "54"
-                    },
-                    "edge": {
-                      "version_added": false
-                    },
-                    "firefox": {
-                      "version_added": "55"
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": "41"
-                    }
-                  }
-                }
-              }
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
-        "downloads": {
-          "BooleanDelta": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "DangerType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "DoubleDelta": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "DownloadItem": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "DownloadQuery": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "DownloadTime": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "FilenameConflictAction": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+        "onUpdated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "prompt": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "InterruptReason": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "State": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "StringDelta": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "acceptDanger": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "cancel": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "download": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "version_added": true
               },
-              "saveAs": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox": {
+                "version_added": "45"
               },
-              "POST": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           },
-          "drag": {
+          "changeInfo.title": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "erase": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getFileIcon": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onCreated": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onErased": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "open": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "pause": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeFile": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "resume": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "search": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setShelfEnabled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "show": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "showDefaultFolder": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "events": {
-          "Event": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "Rule": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "UrlFilter": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "50"
-                  },
-                  "firefox_android": {
-                    "version_added": "50"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "extension": {
-          "ViewType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getBackgroundPage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getExtensionTabs": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "getURL": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "getViews": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "inIncognitoContext": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "isAllowedFileSchemeAccess": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "isAllowedIncognitoAccess": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "lastError": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onRequest": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+                "firefox": {
+                  "version_added": "53"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "onRequestExternal": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+                "firefox_android": {
+                  "version_added": "54"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
+                "opera": {
+                  "version_added": true
                 }
               }
             }
+          }
+        },
+        "onZoomChange": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "print": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "printPreview": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "query": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "The 'panel', 'app', 'devtools' and 'popup' values for 'WindowType' are not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
+                ],
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
           },
-          "sendRequest": {
+          "pinned": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "setUpdateUrlData": {
+          "highlighted": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "extensionTypes": {
-          "ImageDetails": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "ImageFormat": {
+          "index": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "15"
                 }
               }
             }
           },
-          "RunAt": {
+          "currentWindow": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "20"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "history": {
-          "HistoryItem": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "typedCount": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "19"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "15"
                 }
               }
             }
           },
-          "TransitionType": {
+          "lastFocusedWindow": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "50"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "19"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "15"
                 }
               }
             }
           },
-          "VisitItem": {
+          "audible": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "50"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "45"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "32"
                 }
               }
             }
           },
-          "addUrl": {
+          "muted": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "title": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "transition": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "visitTime": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "45"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "32"
                 }
               }
             }
           },
-          "deleteAll": {
+          "cookieStoreId": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
                 }
               }
             }
           },
-          "deleteRange": {
+          "discarded": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "41"
                 }
               }
             }
           },
-          "deleteUrl": {
+          "autoDiscardable": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getVisits": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "50"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onTitleChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onVisitRemoved": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "50"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onVisited": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "50",
-                    "notes": [
-                      "Before version 56, the result object's 'title' was always an empty string. From version 56 onwards, it is set to the last known title, if that is available, or an empty string otherwise."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "search": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "41"
                 }
               }
             }
           }
         },
-        "i18n": {
-          "LanguageCode": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "47"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "34"
-                  }
-                }
+        "reload": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeCSS": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "saveAsPDF": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "This function does not work on Mac OS X."
+                ],
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "sendMessage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true,
+                "notes": [
+                  "No response is sent after the receiving tab is refreshed if there is no `runtime.onMessage` listener."
+                ]
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           },
-          "detectLanguage": {
+          "options.frameId": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "47"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "34"
-                  }
-                }
-              }
-            }
-          },
-          "getAcceptLanguages": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "47"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "34"
-                  }
-                }
-              }
-            }
-          },
-          "getMessage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "17"
-                  },
-                  "edge": {
-                    "version_added": true,
-                    "notes": [
-                      "Throws an exception instead returning an empty string if the message does not exist.",
-                      "Expects substitutions to be strings, while other browsers allow any value which is then converted to a string."
-                    ]
-                  },
-                  "firefox": {
-                    "version_added": "45",
-                    "notes": [
-                      "Firefox 47 and earlier returns \"??\" instead of \"\" if the message is not found in _locales, <a href='https://bugzil.la/1258199'>bug 1258199</a> changed this act to match Chrome, landed on Firefox 48."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "getUILanguage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "35"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "41"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "28"
                 }
               }
             }
           }
         },
-        "identity": {
-          "getRedirectURL": {
+        "sendRequest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "setZoom": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "setZoomSettings": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "pinned": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "launchWebAuthFlow": {
+          "muted": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "45"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "32"
+                }
+              }
+            }
+          },
+          "highlighted": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "selected": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
+          "openerTabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "autoDiscardable": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "41"
+                }
+              }
+            }
+          }
+        }
+      },
+      "theme": {
+        "Theme": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "topSites": {
+        "MostVisitedURL": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "types": {
+        "BrowserSetting": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "onChange": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "webNavigation": {
+        "TransitionQualifier": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "notes": [
+                  "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "17"
+              }
+            }
+          },
+          "from_address_bar": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           }
         },
-        "idle": {
-          "IdleState": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onStateChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+        "TransitionType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "locked": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "queryState": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "version_added": false
               },
-              "locked": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "firefox": {
+                "notes": [
+                  "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "notes": [
+                  "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "17"
+              }
+            }
+          }
+        },
+        "getAllFrames": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "17"
+              }
+            }
+          }
+        },
+        "getFrame": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "17"
+              }
+            }
+          }
+        },
+        "onBeforeNavigate": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ],
+                "version_added": "17"
+              }
+            }
+          }
+        },
+        "onCommitted": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ],
+                "version_added": "17"
+              }
+            }
+          },
+          "transitionQualifiers": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           },
-          "setDetectionInterval": {
+          "transitionType": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           }
         },
-        "management": {
-          "ExtensionInfo": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+        "onCompleted": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ],
+                "version_added": true
               },
-              "disabledReason": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ],
+                "version_added": true
               },
-              "offlineEnabled": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "45"
               },
-              "type": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "48"
               },
-              "versionName": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ],
+                "version_added": "17"
               }
             }
-          },
-          "get": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": "56"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getAll": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55",
-                    "notes": [
-                      "Before version 56, only extensions whose 'type' is 'theme' are returned."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "55",
-                    "notes": [
-                      "Before version 56, only extensions whose 'type' is 'theme' are returned."
-                    ]
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getPermissionWarningsById": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getPermissionWarningsByManifest": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getSelf": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onDisabled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onEnabled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onInstalled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onUninstalled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setEnabled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55",
-                    "notes": [
-                      "Only extensions whose 'type' is 'theme' can be enabled and disabled."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "55",
-                    "notes": [
-                      "Only extensions whose 'type' is 'theme' can be enabled and disabled."
-                    ]
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "uninstall": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "uninstallSelf": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+          }
+        },
+        "onCreatedNavigationTarget": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If a blocked popup is unblocked by the user, the event is still not sent."
+                ],
+                "version_added": true
               },
-              "dialogMessage": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "If the filter parameter is empty, Firefox raises an exception.",
+                  "If a blocked popup is unblocked by the user, the event is then sent."
+                ],
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "notes": [
+                  "If the filter parameter is empty, Firefox raises an exception.",
+                  "If a blocked popup is unblocked by the user, the event is then sent.",
+                  "This event is only sent in the 'window.open()' case."
+                ],
+                "version_added": "54"
+              },
+              "opera": {
+                "notes": [
+                  "If a blocked popup is unblocked by the user, the event is still not sent."
+                ],
+                "version_added": "17"
+              }
+            }
+          },
+          "sourceProcessId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           }
         },
-        "notifications": {
-          "NotificationOptions": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "TemplateType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Only the 'basic' type is supported."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Only the 'basic' type is supported."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "Only the 'basic' type is supported."
-                    ],
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "clear": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "create": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getAll": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onButtonClicked": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onClicked": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onClosed": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+        "onDOMContentLoaded": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ],
+                "version_added": true
               },
-              "byUser": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ],
+                "version_added": "17"
+              }
+            }
+          }
+        },
+        "onErrorOccurred": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Filtering is not supported"
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ],
+                "version_added": "17"
               }
             }
           },
-          "update": {
+          "error": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "notes": [
-                      "Not supported on Macs."
-                    ],
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           }
         },
-        "omnibox": {
-          "OnInputEnteredDisposition": {
+        "onHistoryStateUpdated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "17"
+              }
+            }
+          },
+          "transitionQualifiers": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           },
-          "SuggestResult": {
+          "transitionType": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'description' is interpreted as plain text, and XML markup is not recognised."
-                    ],
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onInputCancelled": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onInputChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onInputEntered": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onInputStarted": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setDefaultSuggestion": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'description' is interpreted as plain text, and XML markup is not recognised."
-                    ],
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           }
         },
-        "pageAction": {
-          "ImageDataType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getPopup": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
-                    ],
-                    "version_added": "50"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getTitle": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "hide": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "The 'tabId' parameter is ignored, and the page action is hidden for all tabs."
-                    ],
-                    "version_added": "50"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onClicked": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "50"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setIcon": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true,
-                    "notes": [
-                      "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
-                    ]
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
+        "onReferenceFragmentUpdated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "If the filter parameter is empty, Chrome matches all URLs."
+                ],
+                "version_added": true
               },
-              "imageData": {
-                "support": {
-                  "chrome": {
-                    "version_added": "23"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "edge": {
+                "notes": [
+                  "Filtering is not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Filtering is supported from version 50.",
+                  "If the filter parameter is empty, Firefox raises an exception."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "If the filter parameter is empty, Opera matches all URLs."
+                ],
+                "version_added": "17"
+              }
+            }
+          },
+          "transitionQualifiers": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           },
-          "setPopup": {
+          "transitionType": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "The 'tabId' parameter is ignored, and the popup is set for all tabs."
-                    ],
-                    "version_added": "50"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setTitle": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "show": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "The 'tabId' parameter is ignored, and the page action is shown for all tabs."
-                    ],
-                    "version_added": "50"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "17"
                 }
               }
             }
           }
         },
-        "permissions": {
-          "contains": {
+        "onTabReplaced": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "17"
+              }
+            }
+          }
+        }
+      },
+      "webRequest": {
+        "BlockingResponse": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "HttpHeaders": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "RequestFilter": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "windowId": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "53"
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getAll": {
+          "tabId": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onAdded": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onRemoved": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "Permissions": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "remove": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "request": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55",
-                    "notes": [
-                      "The user will be prompted again for permissions that have been previously granted and then removed."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "55",
-                    "notes": [
-                      "The user will be prompted again for permissions that have been previously granted and then removed."
-                    ]
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "53"
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           }
         },
-        "privacy": {
-          "network": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+        "ResourceType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "44"
               },
-              "peerConnectionEnabled": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": "31"
+              }
+            }
+          },
+          "ping": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "49",
+                  "notes": [
+                    "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
+                  ]
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "36",
+                  "notes": [
+                    "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
+                  ]
                 }
               }
             }
           },
-          "websites": {
+          "font": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "49"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "36"
                 }
-              },
-              "hyperlinkAuditingEnabled": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              }
+            }
+          },
+          "media": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "58"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "45"
                 }
-              },
-              "protectedContentEnabled": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              }
+            }
+          },
+          "websocket": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "58"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "45"
                 }
-              },
-              "referrersEnabled": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": "56"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              }
+            }
+          },
+          "csp_report": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "58"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "45"
                 }
-              },
-              "thirdPartyCookiesAllowed": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              }
+            }
+          },
+          "xbl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "xslt": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "beacon": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "xml_dtd": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "imageset": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "web_manifest": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "object_subrequest": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": [
+                    "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": "55",
+                  "notes": [
+                    "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                  ]
+                },
+                "opera": {
+                  "version_added": false
                 }
               }
             }
           }
         },
-        "proxy": {
-          "onProxyError": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
+        "UploadData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "handlerBehaviorChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onAuthRequired": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "To handle a request asynchronously, return a Promise from the listener."
+                ],
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "notes": [
+                  "To handle a request asynchronously, return a Promise from the listener."
+                ],
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           },
-          "register": {
+          "asyncBlocking": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 56, this function was called 'registerProxyScript'"
-                    ],
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "unregister": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": "56"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           }
         },
-        "runtime": {
-          "MessageSender": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
+        "onBeforeRedirect": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "url": {
-                "support": {
-                  "chrome": {
-                    "version_added": "28"
-                  },
-                  "edge": {
-                    "version_added": true,
-                    "notes": [
-                      "The `url` is missing when the message was sent by an extension view."
-                    ]
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
+              "edge": {
+                "version_added": true
               },
-              "tlsChannelId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "32"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  }
-                }
+              "firefox": {
+                "version_added": "46"
               },
-              "frameId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  }
-                }
-              }
-            }
-          },
-          "OnInstalledReason": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "OnRestartRequiredReason": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "PlatformArch": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "PlatformInfo": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox_android": {
+                "version_added": "48"
               },
-              "nacl_arch": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "opera": {
+                "version_added": true
               }
             }
           },
-          "PlatformNaclArch": {
+          "originUrl": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
                 }
               }
             }
-          },
-          "PlatformOs": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "Port": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
+          }
+        },
+        "onBeforeRequest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
               },
-              "error": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "edge": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Asynchronous event listeners are supported from version 52."
+                ],
+                "version_added": "46"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Asynchronous event listeners are supported from version 52."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              }
+            }
+          },
+          "requestBody": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "53"
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "RequestUpdateCheckStatus": {
+          "originUrl": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onBeforeSendHeaders": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Asynchronous event listeners are supported from version 52."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Asynchronous event listeners are supported from version 52."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              }
+            }
+          },
+          "originUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onCompleted": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "originUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onErrorOccurred": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "originUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onHeadersReceived": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "Modification of the 'Content-Type' header is supported from version 51.",
+                  "Asynchronous event listeners are supported from version 52."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "notes": [
+                  "Modification of the 'Content-Type' header is supported from version 51.",
+                  "Asynchronous event listeners are supported from version 52."
+                ],
+                "version_added": "48"
+              },
+              "opera": {
+                "notes": [
+                  "Asynchronous event listeners are not supported."
+                ],
+                "version_added": true
+              }
+            }
+          },
+          "originUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onResponseStarted": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "originUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onSendHeaders": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "originUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "windows": {
+        "CreateType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "notes": [
+                  "`detached_panel` is not supported."
+                ]
+              },
+              "edge": {
+                "version_added": true,
+                "notes": [
+                  "`panel` and `detached_panel` are not supported."
+                ]
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true,
+                "notes": [
+                  "`detached_panel` is not supported."
+                ]
+              }
+            }
+          }
+        },
+        "WINDOW_ID_CURRENT": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "WINDOW_ID_NONE": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "Window": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "alwaysOnTop": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "19"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
                 }
               }
             }
           },
-          "connect": {
+          "focused": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "connectNative": {
+          "height": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "29"
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "50"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "16"
-                  }
-                }
-              }
-            }
-          },
-          "getBackgroundPage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "getBrowserInfo": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "getManifest": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "getPackageDirectoryEntry": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "29"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "16"
-                  }
-                }
-              }
-            }
-          },
-          "getPlatformInfo": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "29"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "16"
-                  }
-                }
-              }
-            }
-          },
-          "getURL": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
           "id": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "lastError": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
-                    ],
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onBrowserUpdateAvailable": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "27"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onConnect": {
+          "incognito": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "alternative_name": "inPrivate",
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onConnectExternal": {
+          "left": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onInstalled": {
+          "sessionId": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Before version 55, this event is not triggered for temporarily installed add-ons."
-                    ],
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Before version 55, this event is not triggered for temporarily installed add-ons."
-                    ],
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "details.id": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "details.previousVersion": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "details.reason": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "details.temporary": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "31"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "18"
                 }
               }
             }
           },
-          "onMessage": {
+          "state": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onMessageExternal": {
+          "tabs": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onRestartRequired": {
+          "title": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "29"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "16"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
                 }
               }
             }
           },
-          "onStartup": {
+          "top": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "23"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onSuspend": {
+          "type": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onSuspendCanceled": {
+          "width": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "22"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "onUpdateAvailable": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "openOptionsPage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "42"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "29"
-                  }
-                }
-              }
-            }
-          },
-          "reload": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "51"
-                  },
-                  "firefox_android": {
-                    "version_added": "51"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "requestUpdateCheck": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "25"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "sendMessage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "edge": {
-                    "version_added": true,
-                    "notes": [
-                      "`runtime.onMessage` listeners in extension views receive the messages they sent."
-                    ]
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "options.includeTlsChannelId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "32"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "19"
-                  }
-                }
-              },
-              "options.toProxyScript": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": "55"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "sendNativeMessage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "29"
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "50"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "16"
-                  }
-                }
-              }
-            }
-          },
-          "setUninstallURL": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           }
         },
-        "sessions": {
-          "Filter": {
+        "WindowState": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "minimized": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "MAX_SESSION_RESULTS": {
+          "maximized": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "Session": {
+          "fullscreen": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
-                    ],
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getRecentlyClosed": {
+          "docked": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          }
+        },
+        "WindowType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "panel": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onChanged": {
+          "app": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "restore": {
+          "devtools": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           }
         },
-        "sidebarAction": {
-          "ImageDataType": {
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "'url' and 'tabId options can't both be set together.",
+                  "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
+                ],
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "focused": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getPanel": {
+          "height": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getTitle": {
+          "incognito": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "setIcon": {
+          "left": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "setPanel": {
+          "state": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "44"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "31"
                 }
               }
             }
           },
-          "setTitle": {
+          "tabId": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "titlePreface": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "top": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "notes": [
+                    "'url' does not accept relative paths."
+                  ],
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "width": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           }
         },
-        "storage": {
-          "StorageArea": {
+        "get": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "getInfo": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            },
-            "clear": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "45.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "48.0"
-                    },
-                    "opera": {
-                      "version_added": "33"
-                    }
-                  }
-                }
-              }
-            },
-            "get": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "45.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "48.0"
-                    },
-                    "opera": {
-                      "version_added": "33"
-                    }
-                  }
-                }
-              }
-            },
-            "getBytesInUse": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": false
-                    },
-                    "firefox_android": {
-                      "version_added": false
-                    },
-                    "opera": {
-                      "version_added": "33"
-                    }
-                  }
-                }
-              }
-            },
-            "remove": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "45.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "48.0"
-                    },
-                    "opera": {
-                      "version_added": "33"
-                    }
-                  }
-                }
-              }
-            },
-            "set": {
-              "__compat": {
-                "basic_support": {
-                  "support": {
-                    "chrome": {
-                      "version_added": true
-                    },
-                    "edge": {
-                      "notes": [
-                        "storage is limited to 1MB per value."
-                      ],
-                      "version_added": true
-                    },
-                    "firefox": {
-                      "version_added": "45.0"
-                    },
-                    "firefox_android": {
-                      "version_added": "48.0"
-                    },
-                    "opera": {
-                      "version_added": "33"
-                    }
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
                 }
               }
             }
           },
-          "StorageChange": {
+          "getInfo.windowTypes": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "local": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "The storage API is supported in content scripts from version 48."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "managed": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "sync": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "46"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "33"
                 }
               }
             }
           }
         },
-        "tabs": {
-          "MutedInfo": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "MutedInfoReason": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "PageSettings": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "TAB_ID_NONE": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "Tab": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+        "getAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "incognito": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "alternative_name": "inPrivate",
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "version_added": true
               },
-              "highlighted": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox": {
+                "version_added": "45"
               },
-              "selected": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "populate": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              },
-              "width, height": {
-                "support": {
-                  "chrome": {
-                    "version_added": "31"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "18"
-                  }
-                }
-              },
-              "audible": {
-                "support": {
-                  "chrome": {
-                    "version_added": "45"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "32"
-                  }
-                }
-              },
-              "mutedInfo": {
-                "support": {
-                  "chrome": {
-                    "version_added": "46"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "33"
-                  }
-                }
-              },
-              "lastAccessed": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": "56"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "cookieStoreId": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "openerTabId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "sessionId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "31"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "18"
-                  }
-                }
-              },
-              "discarded": {
-                "support": {
-                  "chrome": {
-                    "version_added": "54"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "41"
-                  }
-                }
-              },
-              "autoDiscardable": {
-                "support": {
-                  "chrome": {
-                    "version_added": "54"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "41"
-                  }
-                }
-              }
-            }
-          },
-          "TabStatus": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "WindowType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "ZoomSettings": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "ZoomSettingsMode": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "ZoomSettingsScope": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "captureVisibleTab": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "connect": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "connectInfo.frameId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  }
-                }
-              }
-            }
-          },
-          "create": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true,
-                    "notes": [
-                      "If the `url` has the `ms-browser-extension://` protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading."
-                    ]
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "pinned": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "cookieStoreId": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "selected": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+                "edge": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              },
-              "openerTabId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "detectLanguage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "duplicate": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "executeScript": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "43",
-                    "notes": [
-                      "Before version 50, Firefox would pass a single result value into its callback rather than an array, unless 'allFrames' had been set."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "runAt": {
-                "support": {
-                  "chrome": {
-                    "version_added": "20"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "43"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "frameId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "39"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "43",
-                    "notes": [
-                      "'allFrames' and 'frameId' can't both be set at the same time."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "54",
-                    "notes": [
-                      "'allFrames' and 'frameId' can't both be set at the same time."
-                    ]
-                  },
-                  "opera": {
-                    "version_added": "26"
-                  }
-                }
-              },
-              "matchAboutBlank": {
-                "support": {
-                  "chrome": {
-                    "version_added": "39"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "26"
-                  }
-                }
-              }
-            }
-          },
-          "get": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getAllInWindow": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+                "firefox": {
+                  "version_added": "45"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "getCurrent": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getSelected": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+                "firefox_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getZoom": {
+          "windowTypes": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "getZoomSettings": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "highlight": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "insertCSS": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "runAt": {
-                "support": {
-                  "chrome": {
-                    "version_added": "20"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "frameId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "39"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "26"
-                  }
-                }
-              },
-              "matchAboutBlank": {
-                "support": {
-                  "chrome": {
-                    "version_added": "39"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "26"
-                  }
-                }
-              },
-              "cssOrigin": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "move": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "46"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onActivated": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onActiveChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "46"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "onAttached": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onCreated": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onDetached": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "15"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onHighlightChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+                "edge": {
+                  "version_added": true
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "onHighlighted": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onMoved": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onRemoved": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onReplaced": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                    ],
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onSelectionChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+                "firefox": {
+                  "version_added": "45"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "onUpdated": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "changeInfo.title": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onZoomChange": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "print": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "printPreview": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "query": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "The 'panel', 'app', 'devtools' and 'popup' values for 'WindowType' are not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "An add-on must have the 'tabs' permission if it wants to use 'url' in the 'queryInfo' parameter."
-                    ],
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "pinned": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "highlighted": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "index": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "currentWindow": {
-                "support": {
-                  "chrome": {
-                    "version_added": "19"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "lastFocusedWindow": {
-                "support": {
-                  "chrome": {
-                    "version_added": "19"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "audible": {
-                "support": {
-                  "chrome": {
-                    "version_added": "45"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "32"
-                  }
-                }
-              },
-              "muted": {
-                "support": {
-                  "chrome": {
-                    "version_added": "45"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "32"
-                  }
-                }
-              },
-              "cookieStoreId": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "discarded": {
-                "support": {
-                  "chrome": {
-                    "version_added": "54"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "41"
-                  }
-                }
-              },
-              "autoDiscardable": {
-                "support": {
-                  "chrome": {
-                    "version_added": "54"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "41"
-                  }
-                }
-              }
-            }
-          },
-          "reload": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "remove": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "removeCSS": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "49"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "saveAsPDF": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "This function does not work on Mac OS X."
-                    ],
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "sendMessage": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true,
-                    "notes": [
-                      "No response is sent after the receiving tab is refreshed if there is no `runtime.onMessage` listener."
-                    ]
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "options.frameId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "41"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "28"
-                  }
-                }
-              }
-            }
-          },
-          "sendRequest": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
+                "firefox_android": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              }
-            }
-          },
-          "setZoom": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "setZoomSettings": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "update": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "pinned": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "muted": {
-                "support": {
-                  "chrome": {
-                    "version_added": "45"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": "32"
-                  }
-                }
-              },
-              "highlighted": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "selected": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
-              },
-              "openerTabId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "autoDiscardable": {
-                "support": {
-                  "chrome": {
-                    "version_added": "54"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "41"
-                  }
+                "opera": {
+                  "version_added": "33"
                 }
               }
             }
           }
         },
-        "theme": {
-          "Theme": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
+        "getCurrent": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           },
-          "update": {
+          "getInfo": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "topSites": {
-          "MostVisitedURL": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "get": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": "52"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "types": {
-          "BrowserSetting": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "onChange": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "webNavigation": {
-          "TransitionQualifier": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
-                    ],
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              },
-              "from_address_bar": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "TransitionType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
-                    ],
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "'link' and 'auto_subframe' are partially supported as the default transition type for top-level frames and subframes respectively. 'reload' and 'form_submit' are supported. All other properties are unsupported."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "getAllFrames": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "getFrame": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onBeforeNavigate": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "If the filter parameter is empty, Chrome matches all URLs."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Filtering is not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "If the filter parameter is empty, Opera matches all URLs."
-                    ],
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onCommitted": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "If the filter parameter is empty, Chrome matches all URLs."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Filtering is not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "If the filter parameter is empty, Opera matches all URLs."
-                    ],
-                    "version_added": "17"
-                  }
-                }
-              },
-              "transitionQualifiers": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              },
-              "transitionType": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onCompleted": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "If the filter parameter is empty, Chrome matches all URLs."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Filtering is not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "If the filter parameter is empty, Opera matches all URLs."
-                    ],
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onCreatedNavigationTarget": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "If a blocked popup is unblocked by the user, the event is still not sent."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "If the filter parameter is empty, Firefox raises an exception.",
-                      "If a blocked popup is unblocked by the user, the event is then sent."
-                    ],
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "If the filter parameter is empty, Firefox raises an exception.",
-                      "If a blocked popup is unblocked by the user, the event is then sent.",
-                      "This event is only sent in the 'window.open()' case."
-                    ],
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "notes": [
-                      "If a blocked popup is unblocked by the user, the event is still not sent."
-                    ],
-                    "version_added": "17"
-                  }
-                }
-              },
-              "sourceProcessId": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onDOMContentLoaded": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "If the filter parameter is empty, Chrome matches all URLs."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Filtering is not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "If the filter parameter is empty, Opera matches all URLs."
-                    ],
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onErrorOccurred": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "If the filter parameter is empty, Chrome matches all URLs."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Filtering is not supported"
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "If the filter parameter is empty, Opera matches all URLs."
-                    ],
-                    "version_added": "17"
-                  }
-                }
-              },
-              "error": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onHistoryStateUpdated": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Filtering is not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "47"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              },
-              "transitionQualifiers": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              },
-              "transitionType": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onReferenceFragmentUpdated": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "If the filter parameter is empty, Chrome matches all URLs."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Filtering is not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Filtering is supported from version 50.",
-                      "If the filter parameter is empty, Firefox raises an exception."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "If the filter parameter is empty, Opera matches all URLs."
-                    ],
-                    "version_added": "17"
-                  }
-                }
-              },
-              "transitionQualifiers": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              },
-              "transitionType": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          },
-          "onTabReplaced": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "17"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "webRequest": {
-          "BlockingResponse": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "HttpHeaders": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "RequestFilter": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "windowId": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "tabId": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "ResourceType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "44"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "31"
-                  }
-                }
-              },
-              "ping": {
-                "support": {
-                  "chrome": {
-                    "version_added": "49",
-                    "notes": [
-                      "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
-                    ]
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "36",
-                    "notes": [
-                      "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
-                    ]
-                  }
-                }
-              },
-              "font": {
-                "support": {
-                  "chrome": {
-                    "version_added": "49"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "36"
-                  }
-                }
-              },
-              "media": {
-                "support": {
-                  "chrome": {
-                    "version_added": "58"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "45"
-                  }
-                }
-              },
-              "websocket": {
-                "support": {
-                  "chrome": {
-                    "version_added": "58"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "45"
-                  }
-                }
-              },
-              "csp_report": {
-                "support": {
-                  "chrome": {
-                    "version_added": "58"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": "45"
-                  }
-                }
-              },
-              "xbl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "xslt": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "beacon": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "xml_dtd": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "imageset": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "web_manifest": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "object_subrequest": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "55",
-                    "notes": [
-                      "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
-                    ]
-                  },
-                  "firefox_android": {
-                    "version_added": "55",
-                    "notes": [
-                      "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
-                    ]
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "UploadData": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "handlerBehaviorChanged": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onAuthRequired": {
-            "__compat": {
-              "asyncBlocking": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "To handle a request asynchronously, return a Promise from the listener."
-                    ],
-                    "version_added": "54"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "To handle a request asynchronously, return a Promise from the listener."
-                    ],
-                    "version_added": "54"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "onBeforeRedirect": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "46"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onBeforeRequest": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Asynchronous event listeners are supported from version 52."
-                    ],
-                    "version_added": "46"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Asynchronous event listeners are supported from version 52."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  }
-                }
-              },
-              "requestBody": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "53"
-                  },
-                  "firefox_android": {
-                    "version_added": "53"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onBeforeSendHeaders": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Asynchronous event listeners are supported from version 52."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Asynchronous event listeners are supported from version 52."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onCompleted": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onErrorOccurred": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onHeadersReceived": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "edge": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "Modification of the 'Content-Type' header is supported from version 51.",
-                      "Asynchronous event listeners are supported from version 52."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": [
-                      "Modification of the 'Content-Type' header is supported from version 51.",
-                      "Asynchronous event listeners are supported from version 52."
-                    ],
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "notes": [
-                      "Asynchronous event listeners are not supported."
-                    ],
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onResponseStarted": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          },
-          "onSendHeaders": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "originUrl": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "48"
-                  },
-                  "firefox_android": {
-                    "version_added": "48"
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "windows": {
-          "CreateType": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true,
-                    "notes": [
-                      "`detached_panel` is not supported."
-                    ]
-                  },
-                  "edge": {
-                    "version_added": true,
-                    "notes": [
-                      "`panel` and `detached_panel` are not supported."
-                    ]
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true,
-                    "notes": [
-                      "`detached_panel` is not supported."
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "WINDOW_ID_CURRENT": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            }
-          },
-          "WINDOW_ID_NONE": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "Window": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "alwaysOnTop": {
-                "support": {
-                  "chrome": {
-                    "version_added": "19"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "focused": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "height": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "id": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "incognito": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "alternative_name": "inPrivate",
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "left": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "sessionId": {
-                "support": {
-                  "chrome": {
-                    "version_added": "31"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "18"
-                  }
-                }
-              },
-              "state": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "tabs": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "title": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "top": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "type": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "width": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "WindowState": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "minimized": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "maximized": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "fullscreen": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "docked": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "18"
                 },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
                 }
               }
             }
           },
-          "WindowType": {
+          "getInfo.windowTypes": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "46"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "33"
                 }
+              }
+            }
+          }
+        },
+        "getLastFocused": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "panel": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "version_added": true
               },
-              "app": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox": {
+                "version_added": "45"
               },
-              "devtools": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "getInfo": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
                 }
               }
             }
           },
-          "create": {
+          "getInfo.windowTypes": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'url' and 'tabId options can't both be set together.",
-                      "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": "46"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "33"
                 }
+              }
+            }
+          }
+        },
+        "onCreated": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "focused": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "version_added": true
               },
-              "height": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox": {
+                "version_added": "45"
               },
-              "incognito": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox_android": {
+                "version_added": false
               },
-              "left": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onFocusChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "state": {
-                "support": {
-                  "chrome": {
-                    "version_added": "44"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "31"
-                  }
-                }
+              "edge": {
+                "version_added": true
               },
-              "tabId": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox": {
+                "version_added": "45"
               },
-              "titlePreface": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
+              "firefox_android": {
+                "version_added": false
               },
-              "top": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "onRemoved": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "type": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "edge": {
+                "version_added": false
               },
-              "url": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "notes": [
-                      "'url' does not accept relative paths."
-                    ],
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
+              "firefox": {
+                "version_added": "45"
               },
-              "width": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
+          "drawAttention": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "get": {
+          "focused": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "getInfo": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "getInfo.windowTypes": {
-                "support": {
-                  "chrome": {
-                    "version_added": "46"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "33"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getAll": {
+          "height": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "populate": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "windowTypes": {
-                "support": {
-                  "chrome": {
-                    "version_added": "46"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "33"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getCurrent": {
+          "left": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "getInfo": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "getInfo.windowTypes": {
-                "support": {
-                  "chrome": {
-                    "version_added": "46"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "33"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "getLastFocused": {
+          "state": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "getInfo": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "15"
-                  }
-                }
-              },
-              "getInfo.windowTypes": {
-                "support": {
-                  "chrome": {
-                    "version_added": "46"
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "33"
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onCreated": {
+          "titlePreface": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
                 }
               }
             }
           },
-          "onFocusChanged": {
+          "top": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }
           },
-          "onRemoved": {
+          "width": {
             "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "remove": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              }
-            }
-          },
-          "update": {
-            "__compat": {
-              "basic_support": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "drawAttention": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "focused": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "height": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "left": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "state": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "titlePreface": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "56"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              },
-              "top": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
-                }
-              },
-              "width": {
-                "support": {
-                  "chrome": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": true
-                  }
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }

--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -1,2023 +1,2098 @@
 {
-  "version": "1.0.0",
-  "data": {
-    "webextensions": {
-      "manifest": {
-        "applications": {
+  "webextensions": {
+    "manifest": {
+      "applications": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "author": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true,
+              "notes": [
+                "This key is mandatory in Microsoft Edge."
+              ]
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "background": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true,
+              "notes": [
+                "The 'persistent' property is mandatory."
+              ]
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "persistent": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "browser_action": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "default_title": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "55",
+                "notes": [
+                  "Browser actions are presented as menu items, and the title is the menu item's label."
+                ]
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "author": {
+        "default_icon": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true,
-                  "notes": [
-                    "This key is mandatory in Microsoft Edge."
-                  ]
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": "52"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "notes": [
+                  "SVG icons are not supported."
+                ]
+              },
+              "edge": {
+                "version_added": true,
+                "notes": [
+                  "SVG icons are not supported.",
+                  "'default_icon' must be an object, with explicit sizes."
+                ]
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "default_popup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "browser_style": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "default_area": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "chrome_settings_overrides": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
+        "homepage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.alternate_urls": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.encoding": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.favicon_url": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.image_url": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.image_url_post_params": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.instant_url": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.instant_url_post_params": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.is_default": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.keyword": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.name": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.prepopulated_id": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.search_url": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.search_url_post_params": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.suggest_url": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "search_provider.suggest_url_post_params": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "startup_pages": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "chrome_url_overrides": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "newtab": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "notes": [
+                  "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
+                ]
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54",
+                "notes": [
+                  "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "54",
+                "notes": [
+                  "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
+                ]
+              },
+              "opera": {
+                "version_added": true,
+                "notes": [
+                  "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
+                ]
+              }
+            }
+          }
+        },
+        "bookmarks": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "history": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "commands": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "F1-F12": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "_execute_sidebar_action": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "MediaNextTrack": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "MediaPlayPause": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "MediaPrevTrack": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "MediaStop": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "content_scripts": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "notes": [
+                "Content scripts are not applied to tabs already open when the extension is loaded."
+              ]
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48",
+              "notes": [
+                "Content scripts won't be injected into empty iframes at 'document_start' even if you specify that value in 'run_at'."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": [
+                "Content scripts won't be injected into empty iframes at 'document_start' even if you specify that value in 'run_at'."
+              ]
+            },
+            "opera": {
+              "version_added": true,
+              "notes": [
+                "Content scripts are not applied to tabs already open when the extension is loaded."
+              ]
+            }
+          }
+        },
+        "match_about_blank": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "content_security_policy": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true,
+              "notes": [
+                "Only the default content security policy is supported: \"script-src 'self'; object-src 'self';\"."
+              ]
+            },
+            "firefox": {
+              "version_added": "48",
+              "notes": [
+                "Firefox does not support 'http://127.0.0.1' or 'http://localhost' as script sources: they must be served over HTTPS."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": [
+                "Firefox does not support 'http://127.0.0.1' or 'http://localhost' as script sources: they must be served over HTTPS."
+              ]
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "default_locale": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "description": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "developer": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "devtools_page": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "homepage_url": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "icons": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "incognito": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "split": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "not_allowed": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      },
+      "manifest_version": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "omnibox": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "optional_permissions": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "bookmarks": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "clipboardRead": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "clipboardWrite": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "cookies": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "history": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "idle": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "notifications": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "tabs": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "topSites": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "webNavigation": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "webRequest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "webRequestBlocking": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
         "background": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true,
-                  "notes": [
-                    "The 'persistent' property is mandatory."
-                  ]
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "persistent": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "browser_action": {
+        "contentSettings": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "default_title": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "55",
-                  "notes": [
-                    "Browser actions are presented as menu items, and the title is the menu item's label."
-                  ]
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "default_icon": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "notes": [
-                    "SVG icons are not supported."
-                  ]
-                },
-                "edge": {
-                  "version_added": true,
-                  "notes": [
-                    "SVG icons are not supported.",
-                    "'default_icon' must be an object, with explicit sizes."
-                  ]
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "default_popup": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "browser_style": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "default_area": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "chrome_settings_overrides": {
+        "contextMenus": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "homepage": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.alternate_urls": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.encoding": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.favicon_url": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.image_url": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.image_url_post_params": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.instant_url": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.instant_url_post_params": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.is_default": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.keyword": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.name": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.prepopulated_id": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.search_url": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.search_url_post_params": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.suggest_url": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "search_provider.suggest_url_post_params": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "startup_pages": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "chrome_url_overrides": {
+        "debugger": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "newtab": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "notes": [
-                    "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
-                  ]
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54",
-                  "notes": [
-                    "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "54",
-                  "notes": [
-                    "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
-                  ]
-                },
-                "opera": {
-                  "version_added": true,
-                  "notes": [
-                    "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
-                  ]
-                }
-              }
-            },
-            "bookmarks": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "history": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "commands": {
+        "management": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "F1-F12": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "_execute_sidebar_action": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "global": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "MediaNextTrack": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "MediaPlayPause": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "MediaPrevTrack": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "MediaStop": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "content_scripts": {
+        "pageCapture": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "notes": [
-                    "Content scripts are not applied to tabs already open when the extension is loaded."
-                  ]
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48",
-                  "notes": [
-                    "Content scripts won't be injected into empty iframes at 'document_start' even if you specify that value in 'run_at'."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "48",
-                  "notes": [
-                    "Content scripts won't be injected into empty iframes at 'document_start' even if you specify that value in 'run_at'."
-                  ]
-                },
-                "opera": {
-                  "version_added": true,
-                  "notes": [
-                    "Content scripts are not applied to tabs already open when the extension is loaded."
-                  ]
-                }
-              }
-            },
-            "match_about_blank": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": "52"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "content_security_policy": {
+        "activeTab": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true,
-                  "notes": [
-                    "Only the default content security policy is supported: \"script-src 'self'; object-src 'self';\"."
-                  ]
-                },
-                "firefox": {
-                  "version_added": "48",
-                  "notes": [
-                    "Firefox does not support 'http://127.0.0.1' or 'http://localhost' as script sources: they must be served over HTTPS."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "48",
-                  "notes": [
-                    "Firefox does not support 'http://127.0.0.1' or 'http://localhost' as script sources: they must be served over HTTPS."
-                  ]
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }
         },
-        "default_locale": {
+        "geolocation": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "options_ui": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "chrome_style": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "description": {
+        "browser_style": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "page_action": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "notes": [
+                "SVG icons are not supported."
+              ]
+            },
+            "edge": {
+              "version_added": true,
+              "notes": [
+                "SVG icons are not supported.",
+                "'default_icon' must be an object, with explicit sizes."
+              ]
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "browser_style": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "permissions": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
+        "background": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "developer": {
+        "unlimitedStorage": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": "52"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "devtools_page": {
+        "geolocation": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "homepage_url": {
+        "activeTab": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "icons": {
+        "clipboardRead": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
         },
-        "incognito": {
+        "clipboardWrite": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "split": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "not_allowed": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
-        },
-        "manifest_version": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+        }
+      },
+      "protocol_handlers": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "opera": {
+              "version_added": false
             }
           }
         },
-        "name": {
+        "gopher": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }
-        },
-        "omnibox": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+        }
+      },
+      "short_name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      },
+      "sidebar_action": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
             }
           }
         },
-        "optional_permissions": {
+        "browser_style": {
           "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "bookmarks": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "clipboardRead": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "clipboardWrite": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "cookies": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "history": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "idle": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "notifications": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "tabs": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "topSites": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "webNavigation": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "webRequest": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "webRequestBlocking": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "background": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "contentSettings": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "contextMenus": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "debugger": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "management": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "pageCapture": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "activeTab": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "geolocation": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "55"
-                },
-                "opera": {
-                  "version_added": false
-                }
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }
-        },
-        "options_ui": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+        }
+      },
+      "theme": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
             },
-            "chrome_style": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+            "edge": {
+              "version_added": false
             },
-            "browser_style": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
             }
           }
-        },
-        "page_action": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "notes": [
-                    "SVG icons are not supported."
-                  ]
-                },
-                "edge": {
-                  "version_added": true,
-                  "notes": [
-                    "SVG icons are not supported.",
-                    "'default_icon' must be an object, with explicit sizes."
-                  ]
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+        }
+      },
+      "version": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "notes": [
+                "Valid Chrome versions are a subset of valid Firefox versions."
+              ]
             },
-            "browser_style": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
             }
           }
-        },
-        "permissions": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+        }
+      },
+      "web_accessible_resources": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true
             },
-            "background": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+            "edge": {
+              "version_added": true
             },
-            "unlimitedStorage": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "56"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+            "firefox": {
+              "version_added": "48"
             },
-            "geolocation": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+            "firefox_android": {
+              "version_added": "48"
             },
-            "activeTab": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "clipboardRead": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "clipboardWrite": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "51"
-                },
-                "firefox_android": {
-                  "version_added": "51"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            }
-          }
-        },
-        "protocol_handlers": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            },
-            "gopher": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "56"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          }
-        },
-        "short_name": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            }
-          }
-        },
-        "sidebar_action": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            },
-            "browser_style": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          }
-        },
-        "theme": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          }
-        },
-        "version": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "notes": [
-                    "Valid Chrome versions are a subset of valid Firefox versions."
-                  ]
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            }
-          }
-        },
-        "web_accessible_resources": {
-          "__compat": {
-            "basic_support": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
+            "opera": {
+              "version_added": true
             }
           }
         }

--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -287,319 +287,319 @@
                 "version_added": false
               }
             }
-          }
-        },
-        "search_provider.alternate_urls": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "alternate_urls": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.encoding": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "encoding": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.favicon_url": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "favicon_url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.image_url": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "image_url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.image_url_post_params": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "image_url_post_params": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.instant_url": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "instant_url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.instant_url_post_params": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "instant_url_post_params": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.is_default": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "is_default": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.keyword": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "keyword": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.name": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "name": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.prepopulated_id": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "prepopulated_id": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.search_url": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "search_url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.search_url_post_params": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "search_url_post_params": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.suggest_url": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "suggest_url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
-          }
-        },
-        "search_provider.suggest_url_post_params": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
+          },
+          "suggest_url_post_params": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           }


### PR DESCRIPTION
This does a few things:

- It changes the schema:
  - no sub features anymore
  - no "version" or "data" anymore
  - basic_support is now __compat and optional
  - "desc" has been renamed to "description"
- It adds a conversion script for these schema changes
- It adds a render script that emulates the {{compat}} macro
  (rendering only works with the new structure)

Of course travis fails, as I have not included the changed data in this PR (yet).

Reviewing this consists of a few things:
- Reviewing the schema change as per what we've discussed in #283 and during the last 2 weeks.
- Reviewing the conversion script
  - Does the code make sense?
  - Does the output make sense? To check the output:
    - `npm run convert $folder` (where `$folder` = each of the folders containing the compat data, i.e. api, css, html, http, javascript, test, webextensions)
    - `npm test` or `npm test $folder` 
- Reviewing render.js can be done, but I will also open a PR against KumaScript that will have the real version of this (as opposed to this "emulation").
  - However, you can use this to review the changed data structures
  - Do so by running `npm run render $queryString $depth` to render a compat table HTML. `$queryString` is something like "css.properties.background" and `$depth` is indicating how many levels of sub features below this query you want to include in the table (flattened).

Things that aren't converted automatically:
- WebExtension features containing a dot. These should now be nested properly but I didn't manage to get the conversion script to do this (yet). It is not much work to do this manually.