### PR TITLE
Add support for unlimitedStorage

### DIFF
--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -1754,10 +1754,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "opera": {
                   "version_added": true


### PR DESCRIPTION
Firefox 56 added support for the "unlimitedStorage" permission:
https://bugzilla.mozilla.org/show_bug.cgi?id=1331618
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/permissions#Unlimited_storage