### PR TITLE
Add support for the gopher protocol in Firefox 56

### DIFF
--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -1862,6 +1862,25 @@
                   "version_added": false
                 }
               }
+            },
+            "gopher": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1385357.

I didn't split all the protocols out, since it seemed like overkill.