### PR TITLE
Rename registerProxyScript

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5654,6 +5654,29 @@
                 }
               }
             }
+          },
+          "unregister": {
+            "__compat": {
+              "basic_support": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "56"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
           }
         },
         "runtime": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5629,7 +5629,7 @@
               }
             }
           },
-          "registerProxyScript": {
+          "register": {
             "__compat": {
               "basic_support": {
                 "support": {
@@ -5640,6 +5640,9 @@
                     "version_added": false
                   },
                   "firefox": {
+                    "notes": [
+                      "Before version 56, this function was called 'registerProxyScript'"
+                    ],
                     "version_added": "55"
                   },
                   "firefox_android": {


### PR DESCRIPTION
See https://reviewboard.mozilla.org/r/152464/diff/1#index_header.

I should probably use `alternative_name`, but the webext macro doesn't understand it.

I also added data for proxy.unregister(), which got added in the same bug.