### PR TITLE
Add a note to WebExtensions/getMessage for Firefox

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4005,7 +4005,10 @@
                     ]
                   },
                   "firefox": {
-                    "version_added": "45"
+                    "version_added": "45",
+                    "notes": [
+                      "version 47 and earlier returns \"??\" instead of \"\" if the message is not found in _locales, <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1258199'>bug 1258199</a> changed this act to match Google Chrome, landed on version 48."
+                    ]
                   },
                   "firefox_android": {
                     "version_added": "48"


### PR DESCRIPTION
I don't know its format condition, it need to check.