### PR TITLE
Add Edge support for `extension.getViews()`

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3277,7 +3277,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": true
                   },
                   "firefox": {
                     "version_added": "45"


### PR DESCRIPTION
Microsoft declares the API supported on this page https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis