### PR TITLE
Opera supports i18n.getUILanugage()

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4037,7 +4037,7 @@
                     "version_added": "48"
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": true
                   }
                 }
               }


### PR DESCRIPTION
According to [Opera's API documentation](https://dev.opera.com/extensions/apis/), `i18n.getUILanugage()` is not supported. However, I just tested on Opera 46, and it does exist and returns the expected result there. The fact that they mentioned lack of this API in their documentation might indicate that it was missing at some point in Opera, while the underlying Chromium version already had `i18n.getUILanugage()`. So the exact Opera version it was introduced is unknown, therefore setting the value to `true`.