### PR TITLE
Updated browsingData compat info for Fennec 56

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -927,7 +927,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "56"
               },
               "opera": {
                 "version_added": true
@@ -948,7 +948,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "56"
               },
               "opera": {
                 "version_added": true
@@ -1084,7 +1084,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "56"
               },
               "opera": {
                 "version_added": true
@@ -1225,7 +1225,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "56"
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
Please see:

https://bugzilla.mozilla.org/show_bug.cgi?id=1362994
https://bugzilla.mozilla.org/show_bug.cgi?id=1362998

These add support for [browsingData.settings()](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/settings) and [browsingData.removeCookies()](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/removeCookies), as well as the data types used in those APIs, [DataTypeSet](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/DataTypeSet) and https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/RemovalOptions.




