### PR TITLE
Update browsingData.RemovalOptions for Firefox 56

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -949,7 +949,7 @@
                   "version_added": "56"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "opera": {
                   "version_added": false
@@ -1033,7 +1033,7 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "opera": {
                   "version_added": true

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -936,22 +936,24 @@
           }
         },
         "RemovalOptions": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "version_added": "56"
-              },
-              "opera": {
-                "version_added": true
+          "hostnames": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -1014,6 +1016,27 @@
                   "opera": {
                     "version_added": true
                   }
+                }
+              }
+            }
+          },
+          "since": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1376991. This adds a `hostnames` property to [`browsingData.RemovalOptions`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/RemovalOptions).

I've also split out `since` into its own feature and removed the now redundant `RemovalOptions.__compat` entry.