### PR TITLE
Add information about is_default in Firefox 57

### DIFF
--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -445,7 +445,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "57",
+                  "notes": [
+                    "Only built-in engines can be set as default."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
We have is_default support in 57 now, but only for built-in engines (for now).