### PR TITLE
browserAction badge text is not automatically cleared on navigation on Firefox

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -814,7 +814,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "45"
+                "version_added": "45",
+                "notes": [
+                  "On Firefox, the badge text is not cleared on navigation, see <a href='https://bugzil.la/1395074'>bug 1395074</a>."
+                ]
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
See https://bugzil.la/1395074