### PR TITLE
Add border-width CSS property compat data

### DIFF
--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -5,10 +5,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "2.0"
+              "version_added": "2"
             },
             "edge": {
               "version_added": true
@@ -17,16 +17,16 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "ie_mobile": {
-              "version_added": "6.0"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "3.5"
@@ -35,10 +35,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "3.0"
+              "version_added": "3"
             }
           },
           "status": {

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -17,10 +17,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0 (1.7 or earlier)"
+              "version_added": "1.0"
             },
             "firefox_android": {
-              "version_added": "1.0 (1.9.2)"
+              "version_added": "1.0"
             },
             "ie": {
               "version_added": "4.0"
@@ -35,7 +35,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "1.0 (85)"
+              "version_added": "1.0"
             },
             "safari_ios": {
               "version_added": "3.0"

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -1,0 +1,53 @@
+{
+  "css": {
+    "properties": {
+      "border-width": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1.0"
+            },
+            "chrome_android": {
+              "version_added": "2.0"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.0 (1.7 or earlier)"
+            },
+            "firefox_android": {
+              "version_added": "1.0 (1.9.2)"
+            },
+            "ie": {
+              "version_added": "4.0"
+            },
+            "ie_mobile": {
+              "version_added": "6.0"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1.0 (85)"
+            },
+            "safari_ios": {
+              "version_added": "3.0"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -3,6 +3,7 @@
     "properties": {
       "border-width": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-width",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds the [border-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) CSS property.

This is my first PR with compat data, so it's very possible I made some mistakes. Specifically, I wasn't 100% sure how to enter the version numbers that had parentheticals. For example, the table on MDN says it was added to Firefox with version "1.0 (1.7 or earlier)". I'm not sure if that means that "1.0" is a special value (that means it's from some version 1.7 or earlier) or if the entire string was meaningful, so I kept it all. Similar questions came up for Safari and Android.