### PR TITLE
Don't check __compat for features that don't have it

### DIFF
--- a/test/render.js
+++ b/test/render.js
@@ -404,7 +404,9 @@ function traverseFeatures(obj, depth, identifier) {
             // there are sub features below this node,
             // so we need to identify partial support for the main feature
             for (let subfeatureName of featureNames) {
-              if (subfeatureName !== '__compat') {
+              // if this is actually a subfeature (i.e. it is not a __compat object)
+              // and the subfeature has a __compat object
+              if ((subfeatureName !== '__compat') &&  (obj[i][subfeatureName].__compat)) {
                 let browserNames = Object.keys(obj[i].__compat.support);
                 for (let browser of browserNames) {
                   if (obj[i].__compat.support[browser].version_added !=

--- a/test/render.js
+++ b/test/render.js
@@ -406,7 +406,7 @@ function traverseFeatures(obj, depth, identifier) {
             for (let subfeatureName of featureNames) {
               // if this is actually a subfeature (i.e. it is not a __compat object)
               // and the subfeature has a __compat object
-              if ((subfeatureName !== '__compat') &&  (obj[i][subfeatureName].__compat)) {
+              if ((subfeatureName !== '__compat') && (obj[i][subfeatureName].__compat)) {
                 let browserNames = Object.keys(obj[i].__compat.support);
                 for (let browser of browserNames) {
                   if (obj[i].__compat.support[browser].version_added !=


### PR DESCRIPTION
This should be a fix for https://github.com/mdn/browser-compat-data/issues/342.

`traverseFeatures()` is a bit hairy, so we might want to consider reworking it, but I'm not sure if there's a better way.