### PR TITLE
Add a few border-related CSS properties

### DIFF
--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -1,0 +1,153 @@
+{
+  "css": {
+    "properties": {
+      "border-top-right-radius": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "4",
+                "notes": "Prior to Gecko 50.0 (Firefox 50.0 / Thunderbird 50.0 / SeaMonkey 2.47), border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Gecko 50.0."
+              },
+              {
+                "alternative_name": "-moz-border-radius-topright",
+                "version_added": "1",
+                "version_removed": "12"
+              }
+            ],
+            "firefox_android": {
+              "version_added": true,
+              "notes": "Prior to Gecko 50.0 (Firefox 50.0 / Thunderbird 50.0 / SeaMonkey 2.47), border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Gecko 50.0."
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "safari": [
+              {
+                "version_added": "5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "Percentages",
+            "support": {
+              "chrome": {
+                "version_added": "4"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "4"
+                },
+                {
+                  "version_added": "1",
+                  "notes": "Before Firefox 4, the <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a> was relative to the width of the box even when specifying the radius for a height. This implied that <code>-moz-border-radius-topright</code> was always drawing an arc of circle, and never an ellipse, when followed by a single value."
+                }
+              ],
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "safari": {
+                "version_added": "5"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ellipitcal_corners": {
+          "__compat": {
+            "description": "Ellipitcal corners",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "safari": {
+                "version_added": "3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -35,7 +35,7 @@
             "firefox": [
               {
                 "version_added": "4",
-                "notes": "Prior to Gecko 50.0 (Firefox 50.0 / Thunderbird 50.0 / SeaMonkey 2.47), border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Gecko 50.0."
+                "notes": "Prior to Firefox 50.0, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
               },
               {
                 "alternative_name": "-moz-border-radius-topright",
@@ -45,7 +45,7 @@
             ],
             "firefox_android": {
               "version_added": true,
-              "notes": "Prior to Gecko 50.0 (Firefox 50.0 / Thunderbird 50.0 / SeaMonkey 2.47), border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Gecko 50.0."
+              "notes": "Prior to Firefox 50.0, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
             },
             "ie": {
               "version_added": "9"

--- a/css/properties/border-top-style.json
+++ b/css/properties/border-top-style.json
@@ -1,0 +1,44 @@
+{
+  "css": {
+    "properties": {
+      "border-top-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-style",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-top-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "firefox_android": {
+              "version_added": true,
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-top-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "opera": {
+              "version_added": "9.2"
+            },
+            "safari": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -8,7 +8,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "android_webview": {
+            "webview_android": {
               "version_added": "2.3"
             },
             "edge": {

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-top-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-width",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "2.3"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -8,7 +8,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
+            "android_webview": {
               "version_added": "2.3"
             },
             "edge": {

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -8,7 +8,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
+            "android_webview": {
               "version_added": "2"
             },
             "edge": {

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -8,7 +8,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "android_webview": {
+            "webview_android": {
               "version_added": "2"
             },
             "edge": {


### PR DESCRIPTION
This PR adds:

* `border-top-width`
* `border-top-style`
* `border-top-right-radius`

The last one is my first encounter with subfeatures, which raised a couple questions that I couldn't find answers for in the docs.

1. On subfeatures, should notes which apply only to a prefix also include the prefix and version numbers in the subfeature? The source table on MDN doesn't do that (so I didn't do it here), but I'm not sure how much specificity is desirable in this repo.
2. Should notes be edited to remove mention of software which is out-of-scope for this repo? For example, this PR mentions Gecko, Thunderbird, and SeaMonkey. Should it be edited down to refer to Firefox only? Or is retaining such information from the MDN wiki desirable?
