### PR TITLE
Add wasm compat data

### DIFF
--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -1,0 +1,1350 @@
+{
+  "javascript": {
+    "builtins": {
+      "WebAssembly": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly",
+          "support": {
+            "webview_android": {
+              "version_added": "57"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "52",
+              "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+            },
+            "firefox_android": {
+              "version_added": "52",
+              "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "CompileError": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Instance": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "exports": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "prototype": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/prototype",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "LinkError": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Memory": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "buffer": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "grow": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "prototype": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/prototype",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "Module": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "customSections": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "exports": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "imports": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "prototype": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/prototype",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "RuntimeError": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Table": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "get": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "grow": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "length": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "set": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "compile": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compile",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "instantiate": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "validate": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -18,7 +18,11 @@
               "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "Experimental JavaScript Features"
+              }
             },
             "firefox": {
               "version_added": "52",
@@ -73,7 +77,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -129,7 +137,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -184,7 +196,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -240,7 +256,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -297,7 +317,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -353,7 +377,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -408,7 +436,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -464,7 +496,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -520,7 +556,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -577,7 +617,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -632,7 +676,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -688,7 +736,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -744,7 +796,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -800,7 +856,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -857,7 +917,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -913,7 +977,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -968,7 +1036,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1024,7 +1096,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1080,7 +1156,71 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "prototype": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/prototype",
+              "support": {
+                "webview_android": {
+                  "version_added": "57"
+                },
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "edge_mobile": {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1136,7 +1276,11 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": true
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1193,7 +1337,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -1249,7 +1397,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",
@@ -1305,7 +1457,11 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
               },
               "firefox": {
                 "version_added": "52",


### PR DESCRIPTION
Adds compat data for https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly and subpages.