### PR TITLE
Update browsingData compat info for Fennec 57

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1062,7 +1062,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "opera": {
                 "version_added": true
@@ -1086,7 +1086,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "opera": {
                 "version_added": true
@@ -1134,7 +1134,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "opera": {
                 "version_added": true
@@ -1158,7 +1158,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
I have recently landed support for following methods of browsingData API:

https://bugzilla.mozilla.org/show_bug.cgi?id=1363014 [browsingData.remove]
https://bugzilla.mozilla.org/show_bug.cgi?id=1363004 [browsingData.removeFormData]
https://bugzilla.mozilla.org/show_bug.cgi?id=1363001 [browsingData.removeDownloads]
https://bugzilla.mozilla.org/show_bug.cgi?id=1362996 [browsingData.removeCache]
