### PR TITLE
Add ElementsPanel.onSelectionChanged

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2312,6 +2312,27 @@
               }
             }
           },
+          "elements": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
           "onThemeChanged": {
             "__compat": {
               "support": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2203,25 +2203,50 @@
           }
         },
         "panels": {
-          "ExtensionPanel": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
+          "ElementsPanel": {
+            "onSelectionChanged": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "56"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
+            }
+          },
+          "ExtensionPanel": {
+            "onHidden": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+               }
             },
             "onSearch": {
               "__compat": {
@@ -2234,6 +2259,27 @@
                   },
                   "firefox": {
                     "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "onShown": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
                   },
                   "firefox_android": {
                     "version_added": false

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2246,7 +2246,7 @@
                     "version_added": true
                   }
                 }
-               }
+              }
             },
             "onSearch": {
               "__compat": {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1341304

That bug adds an `elements` property to [devtools.panels](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels), which is an [ElementsPanel](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel) object, which has an [onSelectionChanged](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel/onSelectionChanged) event emitter.

I've also split out the onShown and onHidden events in [ExtensionPanel](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels/ExtensionPanel), to be consistent with onSearch.