### PR TITLE
Update privacy data for Firefox 56

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5251,7 +5251,7 @@
                 }
               }
             }
-          }  
+          }
         },
         "websites": {
           "hyperlinkAuditingEnabled": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5228,8 +5228,7 @@
                 }
               }
             }
-          },
-          
+          }
         },
         "services": {
           "passwordSavingEnabled": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5166,22 +5166,24 @@
       },
       "privacy": {
         "network": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": true
+          "networkPredictionEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
               }
             }
           },
@@ -5205,28 +5207,54 @@
                 }
               }
             }
-          }
-        },
-        "websites": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "54"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": true
+          },
+          "webRTCIPHandlingPolicy": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
               }
             }
           },
+          
+        },
+        "services": {
+          "passwordSavingEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          }  
+        },
+        "websites": {
           "hyperlinkAuditingEnabled": {
             "__compat": {
               "support": {


### PR DESCRIPTION
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1361364
documented as: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/privacy/services

I also updated the data for:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/privacy/network
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/privacy/websites

...to remove the old generic `__compat` and add more fine-grained info.
