### PR TITLE
Add Referrer-Policy same-origin / strict-origin version for Chrome

### DIFF
--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -56,14 +56,13 @@
             "description": "same-origin",
             "support": {
               "webview_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
+                "version_added": "61"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "edge": {
                 "version_added": false
@@ -84,10 +83,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "48"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -108,14 +107,13 @@
             "description": "strict-origin",
             "support": {
               "webview_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
+                "version_added": "61"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "edge": {
                 "version_added": false
@@ -136,10 +134,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "48"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -160,14 +158,13 @@
             "description": "strict-origin-when-cross-origin",
             "support": {
               "webview_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/627968'>Chromium bug 627968</a>."
+                "version_added": "61"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "edge": {
                 "version_added": false
@@ -188,10 +185,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "48"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
This was implemented as of Google Chrome 61: https://bugs.chromium.org/p/chromium/issues/detail?id=627968#c15.

Most likely it is implemented in mobile Chrome 61 as well, but I did not check. Feel free to adapt the pull request.