### PR TITLE
Rename `contextMenus` -> `menus`

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4120,12 +4120,15 @@
                 "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This property is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4147,13 +4150,18 @@
                 "alternative_name": "contextMenus.ContextType",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This type is also available under the <code>contextMenus</code> namespace.",
-                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "notes": [
+                    "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                  ],
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.ContextType",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4283,12 +4291,15 @@
                 "alternative_name": "contextMenus.ItemType",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This type is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.ItemType",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4310,12 +4321,15 @@
                 "alternative_name": "contextMenus.OnClickData",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This type is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.OnClickData",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4364,13 +4378,18 @@
                 ],
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace.",
-                  "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "notes": [
+                    "Before version 53, items that don't specify 'contexts' do not inherit contexts from their parents."
+                  ],
+                  "alternative_name": "contextMenus.create",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4416,12 +4435,15 @@
                 "alternative_name": "contextMenus.onClicked",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This event is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.onClicked",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4443,12 +4465,15 @@
                 "alternative_name": "contextMenus.remove",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.remove",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4470,12 +4495,15 @@
                 "alternative_name": "contextMenus.removeAll",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.removeAll",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4497,12 +4525,15 @@
                 "alternative_name": "contextMenus.update",
                 "version_added": true
               },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "contextMenus.update",
+                  "version_added": "48"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -4715,6 +4746,27 @@
                 "opera": {
                   "version_added": true
                 }
+              }
+            }
+          }
+        },
+        "onShown": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }
@@ -5623,10 +5675,16 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": [
+                  "Uses 'chrome_update' instead of 'browser_update'."
+                ]
               },
               "edge": {
-                "version_added": true
+                "version_added": true,
+                "notes": [
+                  "Only supports 'install' and 'update'."
+                ]
               },
               "firefox": {
                 "version_added": "45"
@@ -5635,7 +5693,10 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "notes": [
+                  "Uses 'chrome_update' instead of 'browser_update'."
+                ]
               }
             }
           }
@@ -7376,10 +7437,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "57"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "57"
                 },
                 "opera": {
                   "version_added": "41"
@@ -9546,6 +9607,27 @@
                 },
                 "firefox_android": {
                   "version_added": false
+                },
+                "opera": {
+                  "version_added": "17"
+                }
+              }
+            }
+          },
+          "windowId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
                 },
                 "opera": {
                   "version_added": "17"

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1348,23 +1348,29 @@
           }
         }
       },
-      "contextMenus": {
+      "menus": {
         "ACTION_MENU_TOP_LEVEL_LIMIT": {
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "This property is also available under the <code>contextMenus</code> namespace."
+                ],
                 "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
                 "version_added": true
               }
             }
@@ -1374,13 +1380,16 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.ContextType",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.ContextType",
                 "version_added": true
               },
               "firefox": {
                 "notes": [
+                  "This type is also available under the <code>contextMenus</code> namespace.",
                   "'The 'editable' context does not include password fields. Use the 'password' context for this."
                 ],
                 "version_added": "48"
@@ -1389,6 +1398,7 @@
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.ContextType",
                 "version_added": true
               }
             }
@@ -1506,18 +1516,24 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.ItemType",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.ItemType",
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "This type is also available under the <code>contextMenus</code> namespace."
+                ],
                 "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.ItemType",
                 "version_added": true
               }
             }
@@ -1527,18 +1543,24 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.OnClickData",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.OnClickData",
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "This type is also available under the <code>contextMenus</code> namespace."
+                ],
                 "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.OnClickData",
                 "version_added": true
               }
             }
@@ -1569,12 +1591,14 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.create",
                 "notes": [
                   "Items that don't specify 'contexts' do not inherit contexts from their parents."
                 ],
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.create",
                 "notes": [
                   "Items that don't specify 'contexts' do not inherit contexts from their parents."
                 ],
@@ -1582,6 +1606,7 @@
               },
               "firefox": {
                 "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace.",
                   "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
                 ],
                 "version_added": "48"
@@ -1590,6 +1615,7 @@
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.create",
                 "notes": [
                   "Items that don't specify 'contexts' do not inherit contexts from their parents."
                 ],
@@ -1623,18 +1649,24 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.onClicked",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.onClicked",
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "This event is also available under the <code>contextMenus</code> namespace."
+                ],
                 "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.onClicked",
                 "version_added": true
               }
             }
@@ -1644,18 +1676,24 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.remove",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.remove",
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace."
+                ],
                 "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.remove",
                 "version_added": true
               }
             }
@@ -1665,18 +1703,24 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.removeAll",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.removeAll",
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace."
+                ],
                 "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.removeAll",
                 "version_added": true
               }
             }
@@ -1686,18 +1730,24 @@
           "__compat": {
             "support": {
               "chrome": {
+                "alternative_name": "contextMenus.update",
                 "version_added": true
               },
               "edge": {
+                "alternative_name": "contextMenus.update",
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace."
+                ],
                 "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "contextMenus.update",
                 "version_added": true
               }
             }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1348,412 +1348,6 @@
           }
         }
       },
-      "menus": {
-        "ACTION_MENU_TOP_LEVEL_LIMIT": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This property is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "ContextType": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.ContextType",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.ContextType",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This type is also available under the <code>contextMenus</code> namespace.",
-                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.ContextType",
-                "version_added": true
-              }
-            }
-          },
-          "browser_action": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "notes": [
-                    "'The 'editable' context does not include password fields. Use the 'password' context for this."
-                  ],
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            }
-          },
-          "page_action": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            }
-          },
-          "launcher": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              }
-            }
-          },
-          "password": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
-          "tab": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          }
-        },
-        "ItemType": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.ItemType",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.ItemType",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This type is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.ItemType",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "OnClickData": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.OnClickData",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.OnClickData",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This type is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.OnClickData",
-                "version_added": true
-              }
-            }
-          },
-          "modifiers": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "54"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          }
-        },
-        "create": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.create",
-                "notes": [
-                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ],
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.create",
-                "notes": [
-                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ],
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace.",
-                  "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.create",
-                "notes": [
-                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
-                ],
-                "version_added": true
-              }
-            }
-          },
-          "command": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          }
-        },
-        "onClicked": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.onClicked",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.onClicked",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This event is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.onClicked",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "remove": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.remove",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.remove",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.remove",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "removeAll": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.removeAll",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.removeAll",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.removeAll",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "update": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "alternative_name": "contextMenus.update",
-                "version_added": true
-              },
-              "edge": {
-                "alternative_name": "contextMenus.update",
-                "version_added": true
-              },
-              "firefox": {
-                "notes": [
-                  "This method is also available under the <code>contextMenus</code> namespace."
-                ],
-                "version_added": "48"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "alternative_name": "contextMenus.update",
-                "version_added": true
-              }
-            }
-          }
-        }
-      },
       "contextualIdentities": {
         "ContextualIdentity": {
           "__compat": {
@@ -4509,6 +4103,412 @@
                 "opera": {
                   "version_added": false
                 }
+              }
+            }
+          }
+        }
+      },
+      "menus": {
+        "ACTION_MENU_TOP_LEVEL_LIMIT": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This property is also available under the <code>contextMenus</code> namespace."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ContextType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.ContextType",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.ContextType",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This type is also available under the <code>contextMenus</code> namespace.",
+                  "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.ContextType",
+                "version_added": true
+              }
+            }
+          },
+          "browser_action": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "notes": [
+                    "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                  ],
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "page_action": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "launcher": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "password": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "tab": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "ItemType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.ItemType",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.ItemType",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This type is also available under the <code>contextMenus</code> namespace."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.ItemType",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "OnClickData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.OnClickData",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.OnClickData",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This type is also available under the <code>contextMenus</code> namespace."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.OnClickData",
+                "version_added": true
+              }
+            }
+          },
+          "modifiers": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "create": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.create",
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ],
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.create",
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ],
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace.",
+                  "From version 53, items that don't specify 'contexts' will inherit contexts from their parents."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.create",
+                "notes": [
+                  "Items that don't specify 'contexts' do not inherit contexts from their parents."
+                ],
+                "version_added": true
+              }
+            }
+          },
+          "command": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "onClicked": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.onClicked",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.onClicked",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This event is also available under the <code>contextMenus</code> namespace."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.onClicked",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "remove": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.remove",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.remove",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.remove",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeAll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.removeAll",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.removeAll",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.removeAll",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "alternative_name": "contextMenus.update",
+                "version_added": true
+              },
+              "edge": {
+                "alternative_name": "contextMenus.update",
+                "version_added": true
+              },
+              "firefox": {
+                "notes": [
+                  "This method is also available under the <code>contextMenus</code> namespace."
+                ],
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "alternative_name": "contextMenus.update",
+                "version_added": true
               }
             }
           }


### PR DESCRIPTION
[Bug 1333403](https://bugzilla.mozilla.org/show_bug.cgi?id=1333403) introduced `browser.menus` as a replacement for `browser.contextMenus`, keeping `contextMenus` as an alias but recommending `menus` as the preferred form.

Chrome, Opera, and Edge only support `contextMenus` at this time. So, I've tried to handle this by:

* renaming the `contextMenus` node in the data to `menus`
* adding `alternative_name` for Chrome, Opera, and Edge, indicating that these APIs are available under `contextMenus` for those browsers
* adding a note for the Firefox data, indicating that  that these APIs are *also* available under `contextMenus` for Firefox.

I also need to move `menus` to keep things alphabetical. But that makes the diff really hard to read. So I'v made the change in 2 commits:

* this commit: https://github.com/mdn/browser-compat-data/pull/367/commits/73c00b3a8648498c0b32b30b827423c42fb02b9c is the one that actually changes the data, but doesn't move `menus`, so should be readable

* this commit: https://github.com/mdn/browser-compat-data/commit/eb1b58457bfba153467ca1c58071f52c40c1343a only moves `menus`, and doesn't change the data at all.
