### PR TITLE
Add data for notifications.onShown

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4669,6 +4669,27 @@
             }
           }
         },
+        "onShown": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "update": {
           "__compat": {
             "support": {


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1352711. This was an intermittent which was fixed by adding a new API to notifications, onShown: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/onShown.