### PR TITLE
Modify onCreatedNavigationTarget support for Chrome (WebExtensions)

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -9502,6 +9502,27 @@
                 }
               }
             }
+          },
+          "windowId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "17"
+                }
+              }
+            }
           }
         },
         "onDOMContentLoaded": {


### PR DESCRIPTION
The value windowId is not supported by Chrome in the API chrome.webNavigation.onCreatedNavigationTarget.
I encountered this issue when developping my addon for Firefox and Chrome while it doesn't appear in MDN.
MDN: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/onCreatedNavigationTarget#details
Chrome: https://developer.chrome.com/extensions/webNavigation#event-onCreatedNavigationTarget