### PR TITLE
Add data for 'icons' argument to menus.create()

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4422,6 +4422,27 @@
                 }
               }
             }
+          },
+          "icons": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "onClicked": {


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1321544

This adds an `icons` property to the options for [menus.create()](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/create#Browser_compatibility).