### PR TITLE
Add compatibility info for extensionTypes.CSSOrigin

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3081,6 +3081,27 @@
               }
             }
           }
+        },
+        "CSSOrigin": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       },
       "history": {


### PR DESCRIPTION
`tabs.insertCSS()` got support for the `cssOrigin` option In Firefox 53. ([Bug 1310026](https://bugzilla.mozilla.org/show_bug.cgi?id=1310026)). Since then there is also `extensionTypes.CSSOrigin`.