### PR TITLE
Add data for OnClickData.linkText

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4360,6 +4360,27 @@
               }
             }
           },
+          "linkText": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "modifiers": {
             "__compat": {
               "support": {


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1343236

This adds a new `linkText` attribute to the [`OnClickData`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/OnClickData) object that gets passed into `onClicked` listeners.