### PR TITLE
Add data for ContextType.tools_menu

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4299,6 +4299,27 @@
                 }
               }
             }
+          },
+          "tools_menu": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "ItemType": {


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1268020.

This adds a new value `tools_menu` to [menus.ContextType](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/ContextType).