### PR TITLE
Add CSS border-block-* properties

### DIFF
--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-end-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-color",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-style",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-end-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-style",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-end-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-width",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-width",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-start-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-color",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-start-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-style",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-style",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-width",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-start-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-width",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -11,14 +11,34 @@
             "chrome": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
-            "firefox_android": {
-              "version_added": "41",
-              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+                {
+                  "version_added": "41"
+                },
+                {
+                  "version_added": "38",
+                  "version_removed": "51",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": false
             },
-            "webview_android": {
+            "chrome": {
               "version_added": false
             },
             "firefox": {

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -1,0 +1,50 @@
+{
+  "css": {
+    "properties": {
+      "border-block-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Available since Firefox 38, but behind the preference <code>layout.css.vertical-text.enabled</code>, disabled by default. The preference has been removed in Firefox 51 and this property cannot be disabled since this version."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -26,18 +26,18 @@
               }
             ],
             "firefox_android": [
-                {
-                  "version_added": "41"
-                },
-                {
-                  "version_added": "38",
-                  "version_removed": "51",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
                 }
+              }
             ],
             "ie": {
               "version_added": false


### PR DESCRIPTION
I've made significant progress on the remaining CSS `border-` properties, but it was growing a bit large for a single PR. This is going to be the first of a few PRs to cover the various border-related properties.