### PR TITLE
Mark extensionTypes as partially implemented on Chrome/Opera/Edge

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -3023,10 +3023,18 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               },
               "edge": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               },
               "firefox": {
                 "version_added": "45"
@@ -3035,7 +3043,11 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               }
             }
           }
@@ -3044,10 +3056,18 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               },
               "edge": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               },
               "firefox": {
                 "version_added": "45"
@@ -3056,7 +3076,11 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               }
             }
           }
@@ -3065,7 +3089,11 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "20"
+                "version_added": "20",
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               },
               "edge": {
                 "version_added": false
@@ -3077,7 +3105,11 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object."
+                ]
               }
             }
           }


### PR DESCRIPTION
Following up on the discussion from #380, the `extensionTypes` object only exists on Firefox. The current compatibility information don't indicate the presence of the properties on the `extensionTypes` object, but the availability of the corresponding feature (in other APIs). This should be clarified in a note (and also be marked as `partial_implementation`?).