### PR TITLE
Rename __proto__ and friends to avoid to actually set the proto

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -108,8 +108,9 @@
             }
           }
         },
-        "__count__": {
+        "count": {
           "__compat": {
+            "description": "<code>__count__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/count",
             "support": {
               "webview_android": {
@@ -162,8 +163,9 @@
             }
           }
         },
-        "__noSuchMethod__": {
+        "noSuchMethod": {
           "__compat": {
+            "description": "<code>__noSuchMethod__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/noSuchMethod",
             "support": {
               "webview_android": {
@@ -218,8 +220,9 @@
             }
           }
         },
-        "__parent__": {
+        "parent": {
           "__compat": {
+            "description": "<code>__parent__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/parent",
             "support": {
               "webview_android": {
@@ -272,8 +275,9 @@
             }
           }
         },
-        "__proto__": {
+        "proto": {
           "__compat": {
+            "description": "<code>__proto__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/proto",
             "support": {
               "webview_android": {
@@ -1464,8 +1468,9 @@
             }
           }
         },
-        "__defineGetter__": {
+        "defineGetter": {
           "__compat": {
+            "description": "<code>__defineGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__",
             "support": {
               "webview_android": {
@@ -1519,8 +1524,9 @@
             }
           }
         },
-        "__defineSetter__": {
+        "defineSetter": {
           "__compat": {
+            "description": "<code>__defineSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__",
             "support": {
               "webview_android": {
@@ -1574,8 +1580,9 @@
             }
           }
         },
-        "__lookupGetter__": {
+        "lookupGetter": {
           "__compat": {
+            "description": "<code>__lookupGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__",
             "support": {
               "webview_android": {
@@ -1628,8 +1635,9 @@
             }
           }
         },
-        "__lookupSetter__": {
+        "lookupSetter": {
           "__compat": {
+            "description": "<code>__lookupSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__",
             "support": {
               "webview_android": {


### PR DESCRIPTION
Looks like the `__proto__` is set when running scripts like test/render.js and causes weirdness. I renamed all "__" properties to defuse future bugs.

This is documented here btw https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Prototype_mutation :slightly_smiling_face: 