### PR TITLE
Add border-bottom CSS properties

### DIFF
--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -19,11 +19,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-color'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
             },
             "firefox_android": {
               "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-color'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-color",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": "1"
             },
-            "webview_android": {
+            "chrome": {
               "version_added": "1"
             },
             "edge": {

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-bottom-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-color",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-color'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
+            },
+            "firefox_android": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-color'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6.5"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-style",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-bottom-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-style",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "firefox_android": {
+              "version_added": true,
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-bottom-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-width",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "2.3"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-width",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": "2.3"
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-bottom": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": "1"
             },
-            "webview_android": {
+            "chrome": {
               "version_added": "1"
             },
             "edge": {


### PR DESCRIPTION
This PR adds the remaining border-bottom CSS properties:

* `border-bottom`
* `border-bottom-color`
* `border-bottom-style`
* `border-bottom-width`

One thing that's not covered here is `-moz-border-bottom-colors`, though it is referenced in notes (it's not a mere prefix, it's different behavior than the singular form). I assumed, since it's a Mozilla-only, non-standards-track property, that it's out of scope for this project. But I'm happy to add it in, if I'm mistaken.