### PR TITLE
Use a footnote for alternative_name

### DIFF
--- a/test/render.js
+++ b/test/render.js
@@ -189,6 +189,12 @@ function writeFlagsNote(supportData, browserId) {
   return output;
 }
 
+/*
+Generate the note to add when a feature is given an alternative name.
+*/
+function writeAlternativeNameNote(alternativeName) {
+  return `Supported as <code>${alternativeName}</code>.`;
+}
 
 /*
 Main function responsible for the contents of a support cell in the table.
@@ -225,13 +231,8 @@ function writeSupportInfo(supportData, browserId, compatNotes) {
       </a></span>`;
     }
 
-    // Add alternative name
-    if (supportData.alternative_name) {
-      output += ` (as <code>${supportData.alternative_name}</code>)`;
-    }
-
     // Add note anchors
-    // There are two types of notes (notes, and flag notes).
+    // There are three types of notes (notes, flag notes, and alternative names).
     // Collect them and order them, before adding them to the cell
     let noteAnchors = [];
 
@@ -254,6 +255,14 @@ function writeSupportInfo(supportData, browserId, compatNotes) {
       let noteIndex = compatNotes.indexOf(flagNote);
       noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
     }
+
+    // add a link to the alternative name note, if there is one
+    if (supportData.alternative_name) {
+      let altNameNote = writeAlternativeNameNote(supportData.alternative_name);
+      let noteIndex = compatNotes.indexOf(altNameNote);
+      noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
+    }
+
     noteAnchors = noteAnchors.sort();
     if ((supportData.partial_support || noteAnchors.length > 0) && aggregateMode) {
       output += ' *';
@@ -289,6 +298,13 @@ function collectCompatNotes() {
     // collect flags
     if (supportEntry.hasOwnProperty('flag')) {
       let flagNote = writeFlagsNote(supportEntry, browserName);
+      if (notesArray.indexOf(flagNote) === -1) {
+        notesArray.push(flagNote);
+      }
+    }
+    // collect alternative names
+    if (supportEntry.hasOwnProperty('alternative_name')) {
+      let flagNote = writeAlternativeNameNote(supportEntry.alternative_name);
       if (notesArray.indexOf(flagNote) === -1) {
         notesArray.push(flagNote);
       }

--- a/test/render.js
+++ b/test/render.js
@@ -304,9 +304,9 @@ function collectCompatNotes() {
     }
     // collect alternative names
     if (supportEntry.hasOwnProperty('alternative_name')) {
-      let flagNote = writeAlternativeNameNote(supportEntry.alternative_name);
-      if (notesArray.indexOf(flagNote) === -1) {
-        notesArray.push(flagNote);
+      let altNameNote = writeAlternativeNameNote(supportEntry.alternative_name);
+      if (notesArray.indexOf(altNameNote) === -1) {
+        notesArray.push(altNameNote);
       }
     }
   }

--- a/test/render.js
+++ b/test/render.js
@@ -237,7 +237,7 @@ function writeSupportInfo(supportData, browserId, compatNotes) {
     let noteAnchors = [];
 
     // Generate notes, if any
-    if (compatNotes && supportData.notes) {
+    if (supportData.notes) {
       if (Array.isArray(supportData.notes)) {
         for (let note of supportData.notes) {
           let noteIndex = compatNotes.indexOf(note);
@@ -250,7 +250,7 @@ function writeSupportInfo(supportData, browserId, compatNotes) {
     }
 
     // there is a flag and it needs a note, too
-    if (compatNotes && supportData.flag) {
+    if (supportData.flag) {
       let flagNote = writeFlagsNote(supportData, browserId);
       let noteIndex = compatNotes.indexOf(flagNote);
       noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);


### PR DESCRIPTION
This should be a fix for https://github.com/mdn/browser-compat-data/issues/390.

It turned out to be pretty simple (maybe too simple?). I've tested it with tables with and without alternative_names.

I suspect that all these extra things (like prefixes) should be handled in notes, too. But for now, it would be good to get this fix in so the `menus` table looks reasonable.