### PR TITLE
Add JS classes compat data

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -7,17 +7,12 @@
           "webview_android": {
             "version_added": null
           },
-          "chrome": [
-            {
-              "version_added": "49"
-            },
-            {
-              "version_added": "42",
-              "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
-            }
-          ],
+          "chrome": {
+            "version_added": "49",
+            "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+          },
           "chrome_android": {
-            "version_added": "56"
+            "version_added": true
           },
           "edge": {
             "version_added": "13"
@@ -66,17 +61,12 @@
             "webview_android": {
               "version_added": null
             },
-            "chrome": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "42",
-                "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
-              }
-            ],
+            "chrome": {
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+            },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "13"
@@ -126,17 +116,12 @@
             "webview_android": {
               "version_added": null
             },
-            "chrome": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "42",
-                "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
-              }
-            ],
+            "chrome": {
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+            },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "13"
@@ -186,17 +171,12 @@
             "webview_android": {
               "version_added": null
             },
-            "chrome": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "42",
-                "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
-              }
-            ],
+            "chrome": {
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+            },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "13"

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -1,0 +1,244 @@
+{
+  "javascript": {
+    "classes": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": [
+            {
+              "version_added": "49"
+            },
+            {
+              "version_added": "42",
+              "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
+            }
+          ],
+          "chrome_android": {
+            "version_added": "56"
+          },
+          "edge": {
+            "version_added": "13"
+          },
+          "edge_mobile": {
+            "version_added": "13"
+          },
+          "firefox": {
+            "version_added": "45"
+          },
+          "firefox_android": {
+            "version_added": "45"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "ie_mobile": {
+            "version_added": false
+          },
+          "nodejs": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "43"
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": "9"
+          },
+          "safari_ios": {
+            "version_added": "9"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "constructor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "42",
+                "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
+              }
+            ],
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "13"
+            },
+            "edge_mobile": {
+              "version_added": "13"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "extends": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/extends",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "42",
+                "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
+              }
+            ],
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "13"
+            },
+            "edge_mobile": {
+              "version_added": "13"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "static": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "42",
+                "notes": "Requires strict mode. Non-strict mode support is behind the flag \"Enable Experimental JavaScript\", disabled by default."
+              }
+            ],
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "13"
+            },
+            "edge_mobile": {
+              "version_added": "13"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes and sub pages.

- extends: I didn't include "array subclassing", I think it doesn't belong there (we are also not mentioning subclassing of other objects).
- constructor: I didn't include "default constructor", seems like it is the same version in Firefox and otherwise unknown. Should be included in basic support.