### PR TITLE
Add JS grammar compat data

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -1,6 +1,61 @@
 {
   "javascript": {
     "grammar": {
+      "array_literals": {
+        "__compat": {
+          "description": "Array literals (<code>[1, 2, 3]</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Array_literals",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "binary_numeric_literals": {
         "__compat": {
           "description": "Binary numeric literals (<code>0b</code>)",
@@ -56,6 +111,281 @@
           }
         }
       },
+      "boolean_literals": {
+        "__compat": {
+          "description": "Boolean literals (<code>true</code>/<code>false</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Boolean_literal",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "decimal_numeric_literals": {
+        "__compat": {
+          "description": "Decimal numeric literals (<code>1234567890</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Decimal",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hexadecimal_escape_sequences": {
+        "__compat": {
+          "description": "Hexadecimal escape sequences (<code>'\\0xA9'</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal_escape_sequences",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hexadecimal_numeric_literals": {
+        "__compat": {
+          "description": "Hexadecimal numeric literals (<code>0xAF</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "null_literal": {
+        "__compat": {
+          "description": "Null literal (<code>null</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Null_literal",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "octal_numeric_literals": {
         "__compat": {
           "description": "Octal numeric literals (<code>0o</code>)",
@@ -99,6 +429,171 @@
             },
             "safari": {
               "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "regular_expression_literals": {
+        "__compat": {
+          "description": "Regular expression literals (<code>/ab+c/g</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Regular_expression_literals",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "string_literals": {
+        "__compat": {
+          "description": "String literals (<code>'Hello world'</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#String_literals",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unicode_escape_sequences": {
+        "__compat": {
+          "description": "Unicode escape sequences (<code>'\\u00A9'</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_escape_sequences",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
             },
             "safari_ios": {
               "version_added": true

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -1,0 +1,497 @@
+{
+  "javascript": {
+    "grammar": {
+      "binary_numeric_literals": {
+        "__compat": {
+          "description": "Binary numeric literals (<code>0b</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Binary",
+          "support": {
+            "webview_android": {
+              "version_added": "41"
+            },
+            "chrome": {
+              "version_added": "41"
+            },
+            "chrome_android": {
+              "version_added": "41"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "25"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "28"
+            },
+            "opera_android": {
+              "version_added": "28"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "octal_numeric_literals": {
+        "__compat": {
+          "description": "Octal numeric literals (<code>0o</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Octal",
+          "support": {
+            "webview_android": {
+              "version_added": "41"
+            },
+            "chrome": {
+              "version_added": "41"
+            },
+            "chrome_android": {
+              "version_added": "41"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "25"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "28"
+            },
+            "opera_android": {
+              "version_added": "28"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unicode_point_escapes": {
+        "__compat": {
+          "description": "Unicode point escapes (<code>\\u{}</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_code_point_escapes",
+          "support": {
+            "webview_android": {
+              "version_added": "44"
+            },
+            "chrome": {
+              "version_added": "44"
+            },
+            "chrome_android": {
+              "version_added": "44"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "40"
+            },
+            "firefox_android": {
+              "version_added": "40"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "31"
+            },
+            "opera_android": {
+              "version_added": "31"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shorthand_object_literals": {
+        "__compat": {
+          "description": "Shorthand notation for object literals",
+          "support": {
+            "webview_android": {
+              "version_added": "43"
+            },
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "template_literals": {
+        "__compat": {
+          "description": "Template literals",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Template_literals",
+          "support": {
+            "webview_android": {
+              "version_added": "41"
+            },
+            "chrome": {
+              "version_added": "41"
+            },
+            "chrome_android": {
+              "version_added": "41"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "28"
+            },
+            "opera_android": {
+              "version_added": "28"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "template_literal_revision": {
+          "__compat": {
+            "description": "Template literal revision",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "trailing_commas": {
+        "__compat": {
+          "description": "Trailing commas",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Trailing_commas",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "trailing_commas_in_object_literals": {
+          "__compat": {
+            "description": "Trailing comma in object literals",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "trailing_commas_in_functions": {
+          "__compat": {
+            "description": "Trailing comma in functions",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -210,7 +210,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -265,7 +265,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -276,7 +276,7 @@
         },
         "template_literal_revision": {
           "__compat": {
-            "description": "Template literal revision",
+            "description": "Escape sequences allowed in tagged template literals",
             "support": {
               "webview_android": {
                 "version_added": false


### PR DESCRIPTION
Compat data for 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas