### PR TITLE
Fix feature label linking

### DIFF
--- a/test/render.js
+++ b/test/render.js
@@ -362,7 +362,6 @@ function writeTable(browserPlatformType) {
   for (let row of features) {
     let feature = Object.keys(row).map((k) => row[k])[0];
     let desc = '';
-    if (feature.mdn_url) { desc += `<a href="${feature.mdn_url}">`; }
     if (feature.description) {
       let label = Object.keys(row)[0];
       // Basic support or unnested features need no prefixing
@@ -375,7 +374,9 @@ function writeTable(browserPlatformType) {
     } else {
       desc += `<code>${Object.keys(row)[0]}</code>`;
     }
-    if (feature.mdn_url) { desc += '</a>'; }
+    if (feature.mdn_url) {
+      desc = `<a href="${feature.mdn_url}">${desc}</a>`;
+    }
     output += `<tr><td>${desc}</td>`;
     output += `${writeSupportCells(feature.support, compatNotes, browserPlatformType)}</tr>`;
   }

--- a/test/render.js
+++ b/test/render.js
@@ -361,20 +361,21 @@ function writeTable(browserPlatformType) {
   output += '<tbody>';
   for (let row of features) {
     let feature = Object.keys(row).map((k) => row[k])[0];
-    let desc = `<code>${Object.keys(row)[0]}</code>`;
-    if (feature.mdn_url) {
-      desc = `<a href="${feature.mdn_url}"><code>${Object.keys(row)[0]}</code></a>`;
-    }
+    let desc = '';
+    if (feature.mdn_url) { desc += `<a href="${feature.mdn_url}">`; }
     if (feature.description) {
       let label = Object.keys(row)[0];
       // Basic support or unnested features need no prefixing
       if (label.indexOf('.') === -1) {
-        desc = feature.description;
+        desc += feature.description;
         // otherwise add a prefix so that we know where this belongs to (e.g. "parse: ISO 8601 format")
       } else {
-        desc = `<code>${label.slice(0, label.lastIndexOf('.'))}</code>: ${feature.description}`;
+        desc += `<code>${label.slice(0, label.lastIndexOf('.'))}</code>: ${feature.description}`;
       }
+    } else {
+      desc += `<code>${Object.keys(row)[0]}</code>`;
     }
+    if (feature.mdn_url) { desc += '</a>'; }
     output += `<tr><td>${desc}</td>`;
     output += `${writeSupportCells(feature.support, compatNotes, browserPlatformType)}</tr>`;
   }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object where `__count__` etc. aren't linked, although they have an `mdn_url`.

(yes, we should write exhaustive tests for this code/macro – there are more bugs in here, for sure)