### PR TITLE
Add left border CSS properties compat data

### DIFF
--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-left-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-color",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a> CSS property that sets the bottom border to multiple colors."
+            },
+            "firefox_android": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a> CSS property that sets the bottom border to multiple colors."
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6.5"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-color",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": "1"
             },
-            "webview_android": {
+            "chrome": {
               "version_added": "1"
             },
             "edge": {

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -5,14 +5,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-style",
           "support": {
+            "webview_android": {
+              "version_added": "2.3"
+            },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
-            },
-            "webview_android": {
-              "version_added": "2.3"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "properties": {
+      "border-left-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-style",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "2.3"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "firefox_android": {
+              "version_added": "14",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-width",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": "2.3"
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-left-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-width",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "2.3"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": "1"
             },
-            "webview_android": {
+            "chrome": {
               "version_added": "1"
             },
             "edge": {

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-left": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds data for the `border-left` CSS properties:

* https://developer.mozilla.org/en-US/docs/Web/CSS/border-left
* https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color
* https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style
* https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width