### PR TITLE
Add right border CSS properties compat data

### DIFF
--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -5,10 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-color",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": "1"
             },
-            "webview_android": {
+            "chrome": {
               "version_added": "1"
             },
             "edge": {

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -19,11 +19,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
             },
             "firefox_android": {
               "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-right-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-color",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
+            },
+            "firefox_android": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6.5"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-style",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-right-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-style",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "firefox_android": {
+              "version_added": "14",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-width",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": "2.3"
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-right-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-width",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "2.3"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -18,12 +18,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1",
-              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-right-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "14",
-              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-right-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+              "version_added": "14"
             },
             "ie": {
               "version_added": "5.5"

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-right": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-right-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "firefox_android": {
+              "version_added": "14",
+              "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-right-style</code> was <code>solid</code>. This has been fixed in Firefox 50."
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds data for the `border-right` CSS properties:

* https://developer.mozilla.org/docs/Web/CSS/border-right-color
* https://developer.mozilla.org/docs/Web/CSS/border-right-style
* https://developer.mozilla.org/docs/Web/CSS/border-right-width
* https://developer.mozilla.org/docs/Web/CSS/border-right