### PR TITLE
Add border-image* CSS properties compat data

### DIFF
--- a/css/properties/border-image-outset.json
+++ b/css/properties/border-image-outset.json
@@ -1,0 +1,45 @@
+{
+  "css": {
+    "properties": {
+      "border-image-outset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-outset",
+          "support": {
+            "chrome": {
+              "version_added": "15"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "15"
+            },
+            "firefox_android": {
+              "version_added": "15"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "6"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -33,8 +33,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "9.3",
-              "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=14185'>WebKit bug 14185</a>."
+              "version_added": "9.3"
             }
           },
           "status": {
@@ -48,8 +47,7 @@
             "description": "<code>round</code>",
             "support": {
               "chrome": {
-                "version_added": "30",
-                "notes": "See <a href='https://crbug.com/169254'>Chromium bug 169254</a>."
+                "version_added": "30"
               },
               "edge": {
                 "version_added": true
@@ -67,8 +65,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "9.1",
-                "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=14185'>WebKit bug 14185</a>."
+                "version_added": "9.1"
               }
             }
           }
@@ -78,8 +75,7 @@
             "description": "<code>space</code>",
             "support": {
               "chrome": {
-                "version_added": "56",
-                "notes": "Supports the <code>space</code> value, but the actual effect is the same as the <code>repeat</code> value. See <a href='https://crbug.com/584916'>Chromium bug 584916</a>."
+                "version_added": "56"
               },
               "edge": {
                 "version_added": true
@@ -88,12 +84,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "50",
-                "notes": "Implemented in <a href='https://bugzil.la/720531'>bug 720531</a>."
+                "version_added": "50"
               },
               "firefox_android": {
-                "version_added": "50",
-                "notes": "Implemented in <a href='https://bugzil.la/720531'>bug 720531</a>."
+                "version_added": "50"
               },
               "ie": {
                 "version_added": "11"
@@ -102,8 +96,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "9.1",
-                "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=14185'>WebKit bug 14185</a>."
+                "version_added": "9.1"
               }
             }
           }

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -1,0 +1,114 @@
+{
+  "css": {
+    "properties": {
+      "border-image-repeat": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-repeat",
+          "support": {
+            "chrome": {
+              "version_added": "15"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "15"
+            },
+            "firefox_android": {
+              "version_added": "15"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "9.3",
+              "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=14185'>WebKit bug 14185</a>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "round": {
+          "__compat": {
+            "description": "<code>round</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30",
+                "notes": "See <a href='https://crbug.com/169254'>Chromium bug 169254</a>."
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": {
+                "version_added": "15"
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "safari": {
+                "version_added": "9.1",
+                "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=14185'>WebKit bug 14185</a>."
+              }
+            }
+          }
+        },
+        "space": {
+          "__compat": {
+            "description": "<code>space</code>",
+            "support": {
+              "chrome": {
+                "version_added": "56",
+                "notes": "Supports the <code>space</code> value, but the actual effect is the same as the <code>repeat</code> value. See <a href='https://crbug.com/584916'>Chromium bug 584916</a>."
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "50",
+                "notes": "Implemented in <a href='https://bugzil.la/720531'>bug 720531</a>."
+              },
+              "firefox_android": {
+                "version_added": "50",
+                "notes": "Implemented in <a href='https://bugzil.la/720531'>bug 720531</a>."
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1",
+                "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=14185'>WebKit bug 14185</a>."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -1,0 +1,64 @@
+{
+  "css": {
+    "properties": {
+      "border-image-slice": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-slice",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.1"
+            },
+            "chrome": {
+              "version_added": "15"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "15",
+              "notes": [
+                "Small SVGs are incorrectly stretched, because percentages in <a href='https://developer.mozilla.org/docs/Web/CSS/border-image-slice'><code>border-image-slice</code></a> are computed to integers instead of floats (<a href='https://bugzil.la/1284797'>bug 1284797</a>).",
+                "Until Firefox 47, SVGs without viewport were not sliced correctly (<a href='https://bugzil.la/619500'>bug 619500</a>).",
+                "From Firefox 48 until Firefox 49, SVGs without viewport are displayed the same as SVGs with viewport, but if the slices are not exactly 50%, they are incorrectly stretched (<a href='https://bugzil.la/1264809' >bug 1264809</a>).",
+                "Until Firefox 57, an issue persisted for SVGs without viewport when <a href='https://wiki.mozilla.org/Electrolysis'>e10s</a> was disabled (<a href='https://bugzil.la/1290782'>bug 1290782</a>)."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "15",
+              "notes": [
+                "Small SVGs are incorrectly stretched, because percentages in <a href='https://developer.mozilla.org/docs/Web/CSS/border-image-slice'><code>border-image-slice</code></a> are computed to integers instead of floats (<a href='https://bugzil.la/1284797'>bug 1284797</a>).",
+                "Until Firefox 47, SVGs without viewport were not sliced correctly (<a href='https://bugzil.la/619500'>bug 619500</a>).",
+                "From Firefox 48 until Firefox 49, SVGs without viewport are displayed the same as SVGs with viewport, but if the slices are not exactly 50%, they are incorrectly stretched (<a href='https://bugzil.la/1264809' >bug 1264809</a>).",
+                "Until Firefox 57, an issue persisted for SVGs without viewport when <a href='https://wiki.mozilla.org/Electrolysis'>e10s</a> was disabled (<a href='https://bugzil.la/1290782'>bug 1290782</a>)."
+              ]
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "6"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-image-source.json
+++ b/css/properties/border-image-source.json
@@ -17,6 +17,9 @@
             "firefox": {
               "version_added": "15"
             },
+            "firefox_android": {
+              "version_added": "15"
+            },
             "ie": {
               "version_added": "11"
             },

--- a/css/properties/border-image-source.json
+++ b/css/properties/border-image-source.json
@@ -1,0 +1,42 @@
+{
+  "css": {
+    "properties": {
+      "border-image-source": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-source",
+          "support": {
+            "chrome": {
+              "version_added": "15"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "15"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "6"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -1,0 +1,45 @@
+{
+  "css": {
+    "properties": {
+      "border-image-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-width",
+          "support": {
+            "chrome": {
+              "version_added": "15"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "13"
+            },
+            "firefox_android": {
+              "version_added": "13"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "6"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -1,0 +1,211 @@
+{
+  "css": {
+    "properties": {
+      "border-image": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "2.1"
+            },
+            "chrome": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "15",
+                "notes": [
+                  "Small SVGs are incorrectly stretched, because percentages in <a href='https://developer.mozilla.org/docs/Web/CSS/border-image-slice'><code>border-image-slice</code></a> are computed to integers instead of floats (<a href='https://bugzil.la/1284797'>bug 1284797</a>).",
+                  "Until Firefox 47, SVGs without viewport were not sliced correctly (<a href='https://bugzil.la/619500'>bug 619500</a>).",
+                  "From Firefox 48 until Firefox 49, SVGs without viewport are displayed the same as SVGs with viewport, but if the slices are not exactly 50%, they are incorrectly stretched (<a href='https://bugzil.la/1264809' >bug 1264809</a>).",
+                  "Until Firefox 57, an issue persisted for SVGs without viewport when <a href='https://wiki.mozilla.org/Electrolysis'>e10s</a> was disabled (<a href='https://bugzil.la/1290782'>bug 1290782</a>)."
+                ]
+              },
+              {
+                "version_added": "3.5",
+                "prefix": "-moz-",
+                "notes": "An earlier version of the specification was implemented, prefixed, in Firefox versions prior to 15."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "15",
+                "notes": [
+                  "Small SVGs are incorrectly stretched, because percentages in <a href='https://developer.mozilla.org/docs/Web/CSS/border-image-slice'><code>border-image-slice</code></a> are computed to integers instead of floats (<a href='https://bugzil.la/1284797'>bug 1284797</a>).",
+                  "Until Firefox 47, SVGs without viewport were not sliced correctly (<a href='https://bugzil.la/619500'>bug 619500</a>).",
+                  "From Firefox 48 until Firefox 49, SVGs without viewport are displayed the same as SVGs with viewport, but if the slices are not exactly 50%, they are incorrectly stretched (<a href='https://bugzil.la/1264809' >bug 1264809</a>).",
+                  "Until Firefox 57, an issue persisted for SVGs without viewport when <a href='https://wiki.mozilla.org/Electrolysis'>e10s</a> was disabled (<a href='https://bugzil.la/1290782'>bug 1290782</a>)."
+                ]
+              },
+              {
+                "version_added": "3.5",
+                "prefix": "-moz-",
+                "notes": "An earlier version of the specification was implemented, prefixed, in Firefox versions prior to 15."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "10.5"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11"
+              }
+            ],
+            "opera_android": {
+              "prefix": "-o-",
+              "version_added": "11"
+            },
+            "safari": [
+              {
+                "version_added": "6"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "6"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "optional_border_image_slice": {
+          "__compat": {
+            "description": "optional <code>&lt;border-image-slice&gt;</code>",
+            "support": {
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "fill_keyword": {
+          "__compat": {
+            "description": "<code>fill</code> keyword",
+            "support": {
+              "webview_android": {
+                "version_added": "18"
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": {
+                "version_added": "15"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              }
+            }
+          }
+        },
+        "gradient": {
+          "__compat": {
+            "description": "<code>&lt;gradient&gt;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [`border-image-outset`](https://developer.mozilla.org/docs/Web/CSS/border-image-outset)
* [`border-image-repeat`](https://developer.mozilla.org/docs/Web/CSS/border-image-repeat)
* [`border-image-slice`](https://developer.mozilla.org/docs/Web/CSS/border-image-slice)
* [`border-image-source`](https://developer.mozilla.org/docs/Web/CSS/border-image-source)
* [`border-image-width`](https://developer.mozilla.org/docs/Web/CSS/border-image-width)
* [`border-image`](https://developer.mozilla.org/docs/Web/CSS/border-image)

There are parts of this that might not be suitable for merging. See line comments for details.