### PR TITLE
Add border-inline CSS properties compat data

### DIFF
--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -25,7 +25,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": true,
                 "alternative_name": "-moz-border-end-color"
               }
             ],
@@ -43,7 +43,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": true,
                 "alternative_name": "-moz-border-end-color"
               }
             ],

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -1,0 +1,78 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-end-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-end-color"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-end-color"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -1,0 +1,78 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-end-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-end-style"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-end-style"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -25,7 +25,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": true,
                 "alternative_name": "-moz-border-end-width"
               }
             ],
@@ -43,7 +43,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": true,
                 "alternative_name": "-moz-border-end-width"
               }
             ],

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -1,0 +1,78 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-end-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-end-width"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-end-width"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -1,0 +1,68 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -1,0 +1,78 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-start-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-start-color"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-start-color"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -1,0 +1,78 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-start-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-start-style"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              },
+              {
+                "version_added": "38",
+                "alternative_name": "-moz-border-start-style"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -25,7 +25,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": true,
                 "alternative_name": "-moz-border-start-style"
               }
             ],
@@ -43,7 +43,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": true,
                 "alternative_name": "-moz-border-start-style"
               }
             ],

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -1,0 +1,70 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-start-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Enabled by default since Firefox 41."
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -1,0 +1,68 @@
+{
+  "css": {
+    "properties": {
+      "border-inline-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [`border-inline-end-color`](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color)
* [`border-inline-end-style`](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style)
* [`border-inline-end-width`](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width)
* [`border-inline-end`](https://developer.mozilla.org/docs/Web/CSS/border-inline-end)
* [`border-inline-start-color`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color)
* [`border-inline-start-style`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style)
* [`border-inline-start-width`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width)
* [`border-inline-start`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start)
