### PR TITLE
Add remaining border CSS properties compat data

### DIFF
--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-collapse": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-collapse",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "2.3"
+            },
+            "edge": {
+              "version_added": "true"
+            },
+            "edge_mobile": {
+              "version_added": "true"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "ie_mobile": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1.2"
+            },
+            "safari_ios": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -12,10 +12,10 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": "true"
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": "true"
+              "version_added": true
             },
             "firefox": {
               "version_added": "1"

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-collapse",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": "2.3"
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": "true"

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -5,11 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-color",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
             "webview_android": {
               "version_added": "4"
+            },
+            "chrome": {
+              "version_added": "1"
             },
             "edge": {
               "version_added": true

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "border-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-color",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "4"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Firefox also supports the following non-standard CSS properties to set the border sides to multiple colors: <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a>"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -22,7 +22,8 @@
               "notes": "Firefox also supports the following non-standard CSS properties to set the border sides to multiple colors: <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a>"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Firefox also supports the following non-standard CSS properties to set the border sides to multiple colors: <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a>"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -129,7 +129,7 @@
             "description": "4 values for 4 corners",
             "support": {
               "chrome": {
-                "version_added": "4.0"
+                "version_added": "4"
               },
               "edge": {
                 "version_added": true

--- a/css/properties/border-spacing.json
+++ b/css/properties/border-spacing.json
@@ -1,0 +1,42 @@
+{
+  "css": {
+    "properties": {
+      "border-spacing": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-spacing",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "safari": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-style",
+          "support": {
+            "webview_android": {
+              "version_added": "2.6"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
+            },
+            "firefox_android": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -19,11 +19,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
+              "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50."
             },
             "firefox_android": {
               "version_added": "1",
-              "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
+              "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50."
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "border-top-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-color",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a> CSS property that sets the top border to multiple colors."
+            },
+            "firefox_android": {
+              "version_added": "1",
+              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a> CSS property that sets the top border to multiple colors."
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6.5"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -35,7 +35,7 @@
             "firefox": [
               {
                 "version_added": "4",
-                "notes": "Prior to Firefox 50.0, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
+                "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50."
               },
               {
                 "prefix": "-webkit-",
@@ -50,7 +50,7 @@
             ],
             "firefox_android": {
               "version_added": true,
-              "notes": "Prior to Firefox 50.0, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50.0."
+              "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50."
             },
             "ie": {
               "version_added": "9"

--- a/css/properties/border-top.json
+++ b/css/properties/border-top.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "border-top": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -1,0 +1,45 @@
+{
+  "css": {
+    "properties": {
+      "border": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the last of the border CSS properties:

* [`border-collapse`](https://developer.mozilla.org/docs/Web/CSS/border-collapse)
* [`border-color`](https://developer.mozilla.org/docs/Web/CSS/border-color)
* [`border-spacing`](https://developer.mozilla.org/docs/Web/CSS/border-spacing)
* [`border-style`](https://developer.mozilla.org/docs/Web/CSS/border-style)
* [`border-top-color`](https://developer.mozilla.org/docs/Web/CSS/border-top-color)
* [`border-top`](https://developer.mozilla.org/docs/Web/CSS/border-top)
* [`border`](https://developer.mozilla.org/docs/Web/CSS/border)

It also cleans up a few border-related version number mistakes which into while I was preparing this PR.

There may be a problem with the `border-style` property. See comments for details.