### PR TITLE
Load .json files only

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,33 +3,38 @@ var fs = require('fs'),
     extend = require('extend');
 
 function load() {
-    // Recursively load one or more directories passed as arguments.
+  // Recursively load one or more directories passed as arguments.
+  var dir, result = {};
 
-    var dir, result = {};
+  function processFilename(fn) {
+    let fp = path.join(dir, fn);
+    let extra;
 
-    function processFilename(fn) {
-        var fp = path.join(dir, fn),
-            // If the given filename is a directory, recursively load it.
-            extra = fs.statSync(fp).isDirectory() ? load(fp) : require(fp);
-
-        // The JSON data is independent of the actual file
-        // hierarchy, so it is essential to extend "deeply".
-        result = extend(true, result, extra);
+    // If the given filename is a directory, recursively load it.
+    if (fs.statSync(fp).isDirectory()) {
+      extra = load(fp);
+    } else if (path.extname(fp) === '.json') {
+      extra = require(fp);
     }
 
-    for (dir of arguments) {
-        dir = path.resolve(__dirname, dir);
-        fs.readdirSync(dir).forEach(processFilename);
-    }
+    // The JSON data is independent of the actual file
+    // hierarchy, so it is essential to extend "deeply".
+    result = extend(true, result, extra);
+  }
 
-    return result;
+  for (dir of arguments) {
+    dir = path.resolve(__dirname, dir);
+    fs.readdirSync(dir).forEach(processFilename);
+  }
+
+  return result;
 }
 
 module.exports = load(
-    'api',
-    'css',
-    'html',
-    'http',
-    'javascript',
-    'webextensions'
+  'api',
+  'css',
+  'html',
+  'http',
+  'javascript',
+  'webextensions'
 );


### PR DESCRIPTION
Fix for https://github.com/mdn/browser-compat-data/issues/402.
Better diff (w/o whitespace): https://github.com/mdn/browser-compat-data/pull/411/files?w=1