### PR TITLE
Added note for ContextType.tools_menu

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4342,6 +4342,9 @@
                   "version_added": false
                 },
                 "firefox": {
+                  "notes": [
+                    "This context is not available if 'ContextType' is accessed through the 'contextMenus' namespace."
+                  ],
                   "version_added": "56"
                 },
                 "firefox_android": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4343,7 +4343,7 @@
                 },
                 "firefox": {
                   "notes": [
-                    "This context is not available if 'ContextType' is accessed through the 'contextMenus' namespace."
+                    "Only available at 'menus.ContextType', not at 'contextMenus.ContextType'."
                   ],
                   "version_added": "56"
                 },

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -4343,7 +4343,7 @@
                 },
                 "firefox": {
                   "notes": [
-                    "Only available at 'menus.ContextType', not at 'contextMenus.ContextType'."
+                    "Only available at <code>menus.ContextType</code>, not at <code>contextMenus.ContextType</code>."
                   ],
                   "version_added": "56"
                 },


### PR DESCRIPTION
`tools_menu` is not available if you access `ContextType` through the `contextMenus` namespace.

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/ContextType