### PR TITLE
Add Safari 11 Intl updates

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -95,10 +95,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               }
             },
             "status": {
@@ -202,10 +202,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "11"
                 }
               },
               "status": {
@@ -692,10 +692,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "11"
                 }
               },
               "status": {


### PR DESCRIPTION
Safari 11 added DateTimeFormat.prototype.formatToParts, Collator's caseFirst option, and the Intl.getCannonicalLocales function.