### PR TITLE
Added compatibility info for frameAncestors in webrequest.onBeforeRequest

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -10693,6 +10693,27 @@
                 }
               }
             }
+          },
+          "frameAncestors": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "58"
+                },
+                "firefox_android": {
+                  "version_added": "58"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "onBeforeSendHeaders": {


### PR DESCRIPTION
For reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1305237

I also documented `frameAncestors` on the MDN page, just now.