### PR TITLE
Add incognito option; split up other options

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -2315,7 +2315,7 @@
               }
             }
           },
-          "saveAs": {
+          "body": {
             "__compat": {
               "support": {
                 "chrome": {
@@ -2336,7 +2336,118 @@
               }
             }
           },
-          "POST": {
+          "conflictAction": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "filename": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "headers": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "incognito": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": "57"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "method": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "POST is supported from version 52."
+                  ],
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "notes": [
+                    "POST is supported from version 52."
+                  ],
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "saveAs": {
             "__compat": {
               "support": {
                 "chrome": {


### PR DESCRIPTION
This is basically for https://bugzilla.mozilla.org/show_bug.cgi?id=1362448, which adds an `incognito` option to [`downloads.download()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/downloads/download) in Firefoxes 57.

But I've also taken the chance to split out the other optional properties.

Note that:

* I didn't split out `url`, since you can't use the API at all without it, so it's implicit in basic support (and I think keeping basic support is clearer than replacing it with `url`).

* I've marked `body` as supported in 52+ in Firefoxes, because AFAICT its only use is when `method===POST`.

* I've made `POST` support a note on `method` rather than a subfeature, I think this is clearer.
