### PR TITLE
Methods for opening popups and sidebars

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -783,6 +783,27 @@
             }
           }
         },
+        "openPopup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "setBadgeBackgroundColor": {
           "__compat": {
             "support": {
@@ -5377,6 +5398,27 @@
             }
           }
         },
+        "openPopup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "setIcon": {
           "__compat": {
             "support": {
@@ -7075,6 +7117,27 @@
             }
           }
         },
+        "close": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "getPanel": {
           "__compat": {
             "support": {
@@ -7113,6 +7176,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          }
+        },
+        "open": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1341126

This adds four new methods:
browserAction.openPopup
pageAction.openPopup
sidebarAction.open
sidebarAction.close

None are available on Android yet, and I've not yet written the docs pages.