### PR TITLE
Edge doesn't support `isIntersecting`

### DIFF
--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -131,7 +131,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "false"
+              "version_added": false
             },
             "firefox": [
               {

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -131,7 +131,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "false"
             },
             "firefox": [
               {
@@ -154,7 +154,7 @@
               "version_added": "51"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "ie_mobile": {
               "version_added": false


### PR DESCRIPTION
Using Microsoft Edge 40.15063.0.0, Microsoft EdgeHTML 15.15063

![image](https://user-images.githubusercontent.com/2827047/31010485-4c9fe1a2-a50b-11e7-8572-965b42876077.png)
