### PR TITLE
proxy.register() should use alternative_name

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -5917,12 +5917,15 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "notes": [
-                  "Before version 56, this function was called 'registerProxyScript'"
-                ],
-                "version_added": "55"
-              },
+              "firefox": [
+                {
+                  "version_added": "56"
+                },
+                {
+                  "alternative_name": "registerProxyScript",
+                  "version_added": "55"
+                }
+              ],
               "firefox_android": {
                 "version_added": "55"
               },


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/312