### PR TITLE
Add columns CSS properties compat data

### DIFF
--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -78,9 +78,15 @@
               "prefix": "-webkit-",
               "version_added": "3"
             },
-            "safari_ios": {
-              "version_added": true
-            }
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -140,6 +140,11 @@
               "safari_ios": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -62,12 +62,18 @@
             "ie_mobile": {
               "version_added": true
             },
-            "opera": {
-              "version_added": "11.10"
-            },
             "opera_android": {
               "version_added": true
             },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -53,7 +53,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "1.5"
+                "version_added": "1"
               }
             ],
             "ie": {

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -62,9 +62,6 @@
             "ie_mobile": {
               "version_added": true
             },
-            "opera_android": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "11.10"
@@ -72,6 +69,15 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
               }
             ],
             "safari": {

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -1,0 +1,131 @@
+{
+  "css": {
+    "properties": {
+      "column-count": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-count",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5"
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "on_display_table_caption": {
+          "__compat": {
+            "description": "On <code>display: table-caption</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "37"
+              },
+              "firefox_android": {
+                "version_added": "37"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -1,0 +1,51 @@
+{
+  "css": {
+    "properties": {
+      "column-fill": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-fill",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "13"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "13"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -1,0 +1,81 @@
+{
+  "css": {
+    "properties": {
+      "column-gap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "52",
+                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52",
+                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5"
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -40,18 +40,17 @@
             ],
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+                "version_added": "52"
               },
               {
                 "prefix": "-moz-",
-                "version_added": "1.5"
+                "version_added": "1.5",
+                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
               }
             ],
             "firefox_android": [
               {
-                "version_added": "52",
-                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+                "version_added": "52"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -61,9 +61,15 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "11.10"
-            },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -74,9 +74,9 @@
             }
           },
           "status": {
-            "experimental": null,
-            "standard_track": null,
-            "deprecated": null
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -1,0 +1,85 @@
+{
+  "css": {
+    "properties": {
+      "column-rule-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-color",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "3.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": null,
+            "standard_track": null,
+            "deprecated": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -65,9 +65,15 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "11.10"
-            },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -1,0 +1,85 @@
+{
+  "css": {
+    "properties": {
+      "column-rule-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-style",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -65,9 +65,15 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "11.10"
-            },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -55,9 +55,15 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "11.10"
-            },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -1,0 +1,75 @@
+{
+  "css": {
+    "properties": {
+      "column-rule-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-width",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "3.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -56,9 +56,15 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "11.10"
-            },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -1,0 +1,76 @@
+{
+  "css": {
+    "properties": {
+      "column-rule": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "52",
+                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "3.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52",
+                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -35,18 +35,17 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+                "version_added": "52"
               },
               {
                 "prefix": "-moz-",
-                "version_added": "3.5"
+                "version_added": "3.5",
+                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
               }
             ],
             "firefox_android": [
               {
-                "version_added": "52",
-                "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
+                "version_added": "52"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -1,0 +1,86 @@
+{
+  "css": {
+    "properties": {
+      "column-span": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-span",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -59,9 +59,15 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "11.10"
-            },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "opera_android": {
               "version_added": null
             },

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -122,6 +122,11 @@
               "safari_ios": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -1,0 +1,177 @@
+{
+  "css": {
+    "properties": {
+      "column-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-width",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1"
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "11.10"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "intrinsic_sizes": {
+          "__compat": {
+            "description": "Intrinsic sizes",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "on_display_table_caption": {
+          "__compat": {
+            "description": "On <code>display: table-caption</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": "50"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "37"
+              },
+              "firefox_android": {
+                "version_added": "37"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -173,6 +173,11 @@
               "safari_ios": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -141,6 +141,11 @@
               "safari_ios": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -1,0 +1,150 @@
+{
+  "css": {
+    "properties": {
+      "columns": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/columns",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.1"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "50"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "9"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "22"
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": "10"
+            },
+            "opera": [
+              {
+                "version_added": "11.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "11.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "32"
+              }
+            ],
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "on_display_table_caption": {
+          "__compat": {
+            "description": "On <code>display: table-caption</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "37"
+              },
+              "firefox_android": {
+                "version_added": "37"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [columns](https://developer.mozilla.org/docs/Web/CSS/columns)
* [column-width](https://developer.mozilla.org/docs/Web/CSS/column-width)
* [column-span](https://developer.mozilla.org/docs/Web/CSS/column-span)
* [column-rule-width](https://developer.mozilla.org/docs/Web/CSS/column-rule-width)
* [column-rule-style](https://developer.mozilla.org/docs/Web/CSS/column-rule-style)
* [column-rule-color](https://developer.mozilla.org/docs/Web/CSS/column-rule-color)
* [column-rule-color](https://developer.mozilla.org/docs/Web/CSS/column-rule-color)
* [column-rule](https://developer.mozilla.org/docs/Web/CSS/column-rule)
* [column-gap](https://developer.mozilla.org/docs/Web/CSS/column-gap)
* [column-fill](https://developer.mozilla.org/docs/Web/CSS/column-fill)
* [column-count](https://developer.mozilla.org/docs/Web/CSS/column-count)

The source tables are a bit iffy, with lots of suspect columns for Android, Android Webview, and Chrome for Android. The `columns` property is probably a good example of how I've tried to interpret the tables (e.g., rather than reconcile Webview and Android version numbers, I went with `true` in some cases). Happy to make corrections, if desired.