### PR TITLE
Add flex CSS properties compat data

### DIFF
--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -92,10 +92,15 @@
                 "version_added": "15"
               }
             ],
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "7"
-            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
             "safari_ios": {
               "version_added": false
             }

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -74,10 +74,16 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": "12.10"
-            },
             "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
               {
                 "version_added": "12.10"
               },

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -1,0 +1,175 @@
+{
+  "css": {
+    "properties": {
+      "flex-basis": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-basis",
+          "support": {
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "21"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "22",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": "When a non-<code>auto</code> <code>flex-basis</code> is specified, Internet Explorer 10 and 11 always uses a <code>content-box</code> box model to calculate the size of a flex item, even if <a href='http://developer.mozilla.org/docs/Web/CSS/box-sizing'><code>box-sizing: border-box</code></a> is applied to the element. See <a href='https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box'>Flexbug #7</a> for more info."
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "12.10"
+            },
+            "opera_android": {
+              "version_added": "12.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "chrome": {
+                "version_added": "21"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "18"
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "opera": {
+                "version_added": "12.10"
+              },
+              "safari": {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            }
+          }
+        },
+        "content": {
+          "__compat": {
+            "description": "<code>content</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "fill": {
+          "__compat": {
+            "description": "<code>fill</code>",
+            "support": {
+              "firefox": {
+                "alternative_name": "-moz-available",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "max_content": {
+          "__compat": {
+            "description": "<code>max_content</code>",
+            "support": {
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "min_content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            }
+          }
+        },
+        "fit_content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -39,7 +39,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "20",
+                "version_removed": "28",
                 "flag": {
                   "type": "preference",
                   "name": "layout.css.flexbox.enabled",

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -188,54 +188,6 @@
               }
             }
           }
-        },
-        "fill": {
-          "__compat": {
-            "description": "<code>fill</code>",
-            "support": {
-              "firefox": {
-                "alternative_name": "-moz-available",
-                "version_added": true
-              },
-              "firefox_android": {
-                "alternative_name": "-moz-available",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "max_content": {
-          "__compat": {
-            "description": "<code>max_content</code>",
-            "support": {
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "min_content": {
-          "__compat": {
-            "description": "<code>min-content</code>",
-            "support": {
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": true
-              }
-            }
-          }
-        },
-        "fit_content": {
-          "__compat": {
-            "description": "<code>fit-content</code>",
-            "support": {
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": true
-              }
-            }
-          }
         }
       }
     }

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -102,7 +102,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": false
+              "version_added": "9.2"
             }
           },
           "status": {

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -74,12 +74,18 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "12.10"
-            },
             "opera_android": {
               "version_added": "12.10"
             },
+            "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "7"

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -121,13 +121,22 @@
               "edge": {
                 "version_added": true
               },
+              "edge_mobile": {
+                "version_added": true
+              },
               "firefox": {
+                "version_added": "18"
+              },
+              "firefox_android": {
                 "version_added": "18"
               },
               "ie": {
                 "version_added": "11"
               },
               "opera": {
+                "version_added": "12.10"
+              },
+              "opera_android": {
                 "version_added": "12.10"
               },
               "safari": {
@@ -144,19 +153,37 @@
               "chrome": {
                 "version_added": false
               },
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
                 "version_added": false
               },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
                 "version_added": false
               },
+              "opera_android": {
+                "version_added": false
+              },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -47,6 +47,26 @@
                 }
               }
             ],
+            "firefox_android": [
+              {
+                "version_added": "22",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
             "ie": {
               "version_added": "11",
               "notes": "When a non-<code>auto</code> <code>flex-basis</code> is specified, Internet Explorer 10 and 11 always uses a <code>content-box</code> box model to calculate the size of a flex item, even if <a href='http://developer.mozilla.org/docs/Web/CSS/box-sizing'><code>box-sizing: border-box</code></a> is applied to the element. See <a href='https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box'>Flexbug #7</a> for more info."
@@ -130,6 +150,10 @@
             "description": "<code>fill</code>",
             "support": {
               "firefox": {
+                "alternative_name": "-moz-available",
+                "version_added": true
+              },
+              "firefox_android": {
                 "alternative_name": "-moz-available",
                 "version_added": true
               }

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -1,0 +1,85 @@
+{
+  "css": {
+    "properties": {
+      "flex-direction": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-direction",
+          "support": {
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "21"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "12.10"
+            },
+            "opera_android": {
+              "version_added": "12.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -59,10 +59,6 @@
             "ie_mobile": {
               "version_added": false
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "7"
-            },
             "opera": [
               {
                 "version_added": "12.10"
@@ -79,6 +75,15 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
               }
             ],
             "safari_ios": {

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -87,7 +87,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -59,14 +59,20 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": "12.10"
-            },
             "safari": {
               "prefix": "-webkit-",
               "version_added": "7"
             },
             "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
               {
                 "version_added": "12.10"
               },

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -59,9 +59,6 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "12.10"
-            },
             "opera_android": {
               "version_added": "12.10"
             },
@@ -69,6 +66,15 @@
               "prefix": "-webkit-",
               "version_added": "7"
             },
+            "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari_ios": {
               "version_added": false
             }

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -46,12 +46,18 @@
             "ie_mobile": {
               "version_added": "11"
             },
-            "opera": {
-              "version_added": "12.10"
-            },
             "opera_android": {
               "version_added": "12.10"
             },
+            "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "6.1"

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -46,10 +46,16 @@
             "ie_mobile": {
               "version_added": "11"
             },
-            "opera_android": {
-              "version_added": "12.10"
-            },
             "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
               {
                 "version_added": "12.10"
               },

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -64,10 +64,15 @@
                 "version_added": "15"
               }
             ],
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "6.1"
-            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
             "safari_ios": {
               "prefix": "-webkit-",
               "version_added": "7.1"

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -73,10 +73,15 @@
                 "version_added": "6.1"
               }
             ],
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "7.1"
-            }
+            "safari_ios": [
+              {
+                "version_added": "9.2"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7.1"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -1,0 +1,73 @@
+{
+  "css": {
+    "properties": {
+      "flex-flow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-flow",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              }
+            ],
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12.10"
+            },
+            "opera_android": {
+              "version_added": "12.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "7.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -64,10 +64,16 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": "12.10"
-            },
             "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
               {
                 "version_added": "12.10"
               },

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -123,6 +123,11 @@
               "safari_ios": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -87,7 +87,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -64,12 +64,18 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "12.10"
-            },
             "opera_android": {
               "version_added": "12.10"
             },
+            "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "6.1"

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -1,0 +1,120 @@
+{
+  "css": {
+    "properties": {
+      "flex-grow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-grow",
+          "support": {
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "21"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "20",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "alternative_name": "-ms-flex-positive",
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "12.10"
+            },
+            "opera_android": {
+              "version_added": "12.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "less_than_zero_animate": {
+          "__compat": {
+            "description": "<0 animate",
+            "support": {
+              "chrome": {
+                "version_added": "49"
+              },
+              "firefox": {
+                "version_added": "32",
+                "notes": "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
+              },
+              "firefox_android": {
+                "version_added": "32",
+                "notes": "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -80,12 +80,18 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "12.10"
-            },
             "opera_android": {
               "version_added": "12.10"
             },
+            "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "8"

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -80,10 +80,16 @@
             "ie_mobile": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": "12.10"
-            },
             "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
               {
                 "version_added": "12.10"
               },

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -103,7 +103,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -1,0 +1,106 @@
+{
+  "css": {
+    "properties": {
+      "flex-shrink": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-shrink",
+          "support": {
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "21"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": [
+                  "Since Firefox 28, multi-line flexbox is supported.",
+                  "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
+                ]
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "20",
+                "notes": [
+                  "Since Firefox 28, multi-line flexbox is supported.",
+                  "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
+                ]
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10",
+              "notes": "Internet Explorer 10 uses <code>0</code> instead of <code>1</code> as the initial value for the <code>flex-shrink</code> property. A workaround is to always set an explicit value for <code>flex-shrink</code>. See <a href='https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed'>Flexbug #6</a> for more info."
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "12.10"
+            },
+            "opera_android": {
+              "version_added": "12.10"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "flex-wrap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-wrap",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "version_added": "29"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "28"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Partial support due to large number of bugs present. See <a href='https://github.com/philipwalton/flexbugs'>Flexbugs</a>."
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "17"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -102,10 +102,15 @@
                 "version_added": "6.1"
               }
             ],
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "7.1"
-            }
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7.1"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -5,9 +5,15 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex",
           "support": {
-            "webview_android": {
-              "version_added": "4.4"
-            },
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "chrome": [
               {
                 "version_added": "29"

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -53,7 +53,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "20",
+                "version_removed": "28",
                 "flag": {
                   "type": "preference",
                   "name": "layout.css.flexbox.enabled",

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -1,0 +1,109 @@
+{
+  "css": {
+    "properties": {
+      "flex": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": [
+                  "Since Firefox 28, multi-line flexbox is supported.",
+                  "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
+                ]
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49",
+                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11",
+                "notes": [
+                  "Internet Explorer 10 and 11 ignore uses of <a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> in the <code>flex-basis</code> part of the <code>flex</code> syntax. This can be worked around by using the longhand properties instead of the shorthand. See <a href='https://github.com/philipwalton/flexbugs#8-flex-basis-doesnt-support-calc'>Flexbug #8</a> for more info.",
+                  "Internet Explorer 10 and 11 consider a unitless value in the <code>flex-basis</code> part to be syntactically invalid (and will thus be ignored). A workaround is to always include a unit in the <code>flex-basis</code> part of the <code>flex</code> shorthand value. See <a href='https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored'>Flexbug #4</a> for more info."
+                ]
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12.10"
+            },
+            "opera_android": {
+              "version_added": "12.10"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "7.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -71,13 +71,17 @@
               {
                 "version_added": "11",
                 "notes": [
-                  "Internet Explorer 10 and 11 ignore uses of <a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> in the <code>flex-basis</code> part of the <code>flex</code> syntax. This can be worked around by using the longhand properties instead of the shorthand. See <a href='https://github.com/philipwalton/flexbugs#8-flex-basis-doesnt-support-calc'>Flexbug #8</a> for more info.",
-                  "Internet Explorer 10 and 11 consider a unitless value in the <code>flex-basis</code> part to be syntactically invalid (and will thus be ignored). A workaround is to always include a unit in the <code>flex-basis</code> part of the <code>flex</code> shorthand value. See <a href='https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored'>Flexbug #4</a> for more info."
+                  "Internet Explorer 11 ignores uses of <a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> in the <code>flex-basis</code> part of the <code>flex</code> syntax. This can be worked around by using the longhand properties instead of the shorthand. See <a href='https://github.com/philipwalton/flexbugs#8-flex-basis-doesnt-support-calc'>Flexbug #8</a> for more info.",
+                  "Internet Explorer 11 considers a unitless value in the <code>flex-basis</code> part to be syntactically invalid (and will thus be ignored). A workaround is to always include a unit in the <code>flex-basis</code> part of the <code>flex</code> shorthand value. See <a href='https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored'>Flexbug #4</a> for more info."
                 ]
               },
               {
                 "prefix": "-ms-",
-                "version_added": "10"
+                "version_added": "10",
+                "notes": [
+                  "Internet Explorer 10 and 11 ignore uses of <a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> in the <code>flex-basis</code> part of the <code>flex</code> syntax. This can be worked around by using the longhand properties instead of the shorthand. See <a href='https://github.com/philipwalton/flexbugs#8-flex-basis-doesnt-support-calc'>Flexbug #8</a> for more info.",
+                  "Internet Explorer 10 and 11 consider a unitless value in the <code>flex-basis</code> part to be syntactically invalid (and will thus be ignored). A workaround is to always include a unit in the <code>flex-basis</code> part of the <code>flex</code> shorthand value. See <a href='https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored'>Flexbug #4</a> for more info."
+                ]
               }
             ],
             "ie_mobile": {


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [`flex-wrap`](https://developer.mozilla.org/docs/Web/CSS/flex-wrap)
* [`flex-shrink`](https://developer.mozilla.org/docs/Web/CSS/flex-shrink)
* [`flex-grow`](https://developer.mozilla.org/docs/Web/CSS/flex-grow)
* [`flex-flow`](https://developer.mozilla.org/docs/Web/CSS/flex-flow)
* [`flex-direction`](https://developer.mozilla.org/docs/Web/CSS/flex-direction)
* [`flex-basis`](https://developer.mozilla.org/docs/Web/CSS/flex-basis)
* [`flex`](https://developer.mozilla.org/docs/Web/CSS/flex)
