### PR TITLE
Fix bug 1275856 - added MediaRecorderErrorEvent

### DIFF
--- a/api/MediaRecorderErrorEvent.json
+++ b/api/MediaRecorderErrorEvent.json
@@ -1,0 +1,114 @@
+{
+  "api": {
+    "MediaRecorderErrorEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": false,
+            "notes": "Uses a generic event with an <code>error</code> property."
+          },
+          "chrome_android": {
+            "version_added": false,
+            "notes": "Uses a generic event with an <code>error</code> property."
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "57"
+          },
+          "firefox_android": {
+            "version_added": "57"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "ie_mobile": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false,
+            "notes": "Uses a generic event with an <code>error</code> property."
+          },
+          "opera_android": {
+            "version_added": false,
+            "notes": "Uses a generic event with an <code>error</code> property."
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "error": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent/error",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "Uses a generic event with an <code>error</code> property."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "Uses a generic event with an <code>error</code> property."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "Uses a generic event with an <code>error</code> property."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "Uses a generic event with an <code>error</code> property."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added BCD data for the interface and its one member, the error
property. Tested using both npm test and npm render.