### PR TITLE
Refactor tests and add browser version validation

### DIFF
--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1,1083 +1,888 @@
 {
   "chrome": {
-    "releases": [
-      {
-        "version": "1",
+    "releases": {
+      "1": {
         "release_date": "2008-12-11",
         "status": "retired"
       },
-      {
-        "version": "2",
+      "2": {
         "release_date": "2009-05-24",
         "status": "retired"
       },
-      {
-        "version": "3",
+      "3": {
         "release_date": "2009-10-12",
         "status": "retired"
       },
-      {
-        "version": "4",
+      "4": {
         "release_date": "2010-01-25",
         "status": "retired"
       },
-      {
-        "version": "4",
-        "release_date": "2010-01-25",
-        "status": "retired"
-      },
-      {
-        "version": "5",
+      "5": {
         "release_date": "2010-05-21",
         "status": "retired"
       },
-      {
-        "version": "6",
+      "6": {
         "release_date": "2010-09-02",
         "status": "retired"
       },
-      {
-        "version": "7",
+      "7": {
         "release_date": "2010-10-21",
         "status": "retired"
       },
-      {
-        "version": "8",
+      "8": {
         "release_date": "2010-12-02",
         "status": "retired"
       },
-      {
-        "version": "9",
+      "9": {
         "release_date": "2011-02-03",
         "status": "retired"
       },
-      {
-        "version": "10",
+      "10": {
         "release_date": "2011-03-08",
         "status": "retired"
       },
-      {
-        "version": "11",
+      "11": {
         "release_date": "2011-04-27",
         "status": "retired"
       },
-      {
-        "version": "12",
+      "12": {
         "release_date": "2011-06-07",
         "status": "retired"
       },
-      {
-        "version": "13",
+      "13": {
         "release_date": "2011-08-02",
         "status": "retired"
       },
-      {
-        "version": "14",
+      "14": {
         "release_date": "2011-09-16",
         "status": "retired"
       },
-      {
-        "version": "15",
+      "15": {
         "release_date": "2011-10-25",
         "status": "retired"
       },
-      {
-        "version": "16",
+      "16": {
         "release_date": "2011-12-13",
         "status": "retired"
       },
-      {
-        "version": "17",
+      "17": {
         "release_date": "2012-02-08",
         "status": "retired"
       },
-      {
-        "version": "18",
+      "18": {
         "release_date": "2012-03-28",
         "status": "retired"
       },
-      {
-        "version": "19",
+      "19": {
         "release_date": "2012-05-15",
         "status": "retired"
       },
-      {
-        "version": "20",
+      "20": {
         "release_date": "2012-06-26",
         "status": "retired"
       },
-      {
-        "version": "21",
+      "21": {
         "release_date": "2012-07-31",
         "status": "retired"
       },
-      {
-        "version": "22",
+      "22": {
         "release_date": "2012-09-25",
         "status": "retired"
       },
-      {
-        "version": "23",
+      "23": {
         "release_date": "2012-11-06",
         "status": "retired"
       },
-      {
-        "version": "24",
+      "24": {
         "release_date": "2013-01-10",
         "status": "retired"
       },
-      {
-        "version": "25",
+      "25": {
         "release_date": "2013-02-21",
         "status": "retired"
       },
-      {
-        "version": "26",
+      "26": {
         "release_date": "2013-03-26",
         "status": "retired"
       },
-      {
-        "version": "27",
+      "27": {
         "release_date": "2013-05-21",
         "status": "retired"
       },
-      {
-        "version": "28",
+      "28": {
         "release_date": "2013-07-09",
         "status": "retired"
       },
-      {
-        "version": "29",
+      "29": {
         "release_date": "2013-08-20",
         "status": "retired"
       },
-      {
-        "version": "30",
+      "30": {
         "release_date": "2013-10-01",
         "status": "retired"
       },
-      {
-        "version": "31",
+      "31": {
         "release_date": "2013-11-12",
         "status": "retired"
       },
-      {
-        "version": "32",
+      "32": {
         "release_date": "2014-01-14",
         "status": "retired"
       },
-      {
-        "version": "33",
+      "33": {
         "release_date": "2014-02-20",
         "status": "retired"
       },
-      {
-        "version": "34",
+      "34": {
         "release_date": "2014-04-08",
         "status": "retired"
       },
-      {
-        "version": "35",
+      "35": {
         "release_date": "2014-05-20",
         "status": "retired"
       },
-      {
-        "version": "36",
+      "36": {
         "release_date": "2014-07-16",
         "status": "retired"
       },
-      {
-        "version": "37",
+      "37": {
         "release_date": "2014-08-26",
         "status": "retired"
       },
-      {
-        "version": "38",
+      "38": {
         "release_date": "2014-10-07",
         "status": "retired"
       },
-      {
-        "version": "39",
+      "39": {
         "release_date": "2014-11-18",
         "status": "retired"
       },
-      {
-        "version": "40",
+      "40": {
         "release_date": "2015-01-21",
         "status": "retired"
       },
-      {
-        "version": "41",
+      "41": {
         "release_date": "2015-03-03",
         "status": "retired"
       },
-      {
-        "version": "42",
+      "42": {
         "release_date": "2015-04-14",
         "status": "retired"
       },
-      {
-        "version": "43",
+      "43": {
         "release_date": "2015-05-19",
         "status": "retired"
       },
-      {
-        "version": "44",
+      "44": {
         "release_date": "2015-07-21",
         "status": "retired"
       },
-      {
-        "version": "45",
+      "45": {
         "release_date": "2015-09-01",
         "status": "retired"
       },
-      {
-        "version": "46",
+      "46": {
         "release_date": "2015-10-13",
         "status": "retired"
       },
-      {
-        "version": "47",
+      "47": {
         "release_date": "2015-12-01",
         "status": "retired"
       },
-      {
-        "version": "48",
+      "48": {
         "release_date": "2016-01-20",
         "status": "retired"
       },
-      {
-        "version": "49",
+      "49": {
         "release_date": "2016-03-02",
         "status": "retired"
       },
-      {
-        "version": "50",
+      "50": {
         "release_date": "2016-04-13",
         "status": "retired"
       },
-      {
-        "version": "51",
+      "51": {
         "release_date": "2016-05-25",
         "status": "retired"
       },
-      {
-        "version": "52",
+      "52": {
         "release_date": "2016-07-20",
         "status": "retired"
       },
-      {
-        "version": "53",
+      "53": {
         "release_date": "2016-08-31",
         "status": "retired"
       },
-      {
-        "version": "54",
+      "54": {
         "release_date": "2016-10-12",
         "status": "retired"
       },
-      {
-        "version": "55",
+      "55": {
         "release_date": "2016-12-01",
         "status": "retired"
       },
-      {
-        "version": "56",
+      "56": {
         "release_date": "2017-01-25",
         "status": "retired"
       },
-      {
-        "version": "57",
+      "57": {
         "release_date": "2017-03-09",
         "status": "retired"
       },
-      {
-        "version": "58",
+      "58": {
         "release_date": "2017-04-19",
         "status": "retired"
       },
-      {
-        "version": "59",
+      "59": {
         "release_date": "2017-06-05",
         "status": "retired"
       },
-      {
-        "version": "60",
+      "60": {
         "release_date": "2017-07-25",
         "status": "retired"
       },
-      {
-        "version": "61",
+      "61": {
         "release_date": "2017-09-05",
         "status": "current"
       },
-      {
-        "version": "62",
+      "62": {
         "status": "beta"
       },
-      {
-        "version": "63",
+      "63": {
         "status": "nightly"
       }
-    ]
+    }
   },
   "firefox": {
-    "releases": [
-      {
-        "version": "1",
+    "releases": {
+      "1": {
         "release_date": "2004-11-09",
         "release_notes": "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.0.html",
         "status": "retired"
       },
-      {
-        "version": "1.5",
+      "1.5": {
         "release_date": "2005-11-25",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/1.5",
         "status": "retired"
       },
-      {
-        "version": "2",
+      "2": {
         "release_date": "2006-10-24",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/2",
         "status": "retired"
       },
-      {
-        "version": "3",
+      "3": {
         "release_date": "2008-06-17",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/3",
         "status": "retired"
       },
-      {
-        "version": "3.5",
+      "3.5": {
         "release_date": "2009-06-30",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.5",
         "status": "retired"
       },
-      {
-        "version": "3.6",
+      "3.6": {
         "release_date": "2010-01-21",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.6",
         "status": "retired"
       },
-      {
-        "version": "4",
+      "4": {
         "release_date": "2011-03-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",
         "status": "retired"
       },
-      {
-        "version": "5",
+      "5": {
         "release_date": "2011-06-21",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/5",
         "status": "retired"
       },
-      {
-        "version": "6",
+      "6": {
         "release_date": "2011-08-16",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/6",
         "status": "retired"
       },
-      {
-        "version": "7",
+      "7": {
         "release_date": "2011-09-26",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/7",
         "status": "retired"
       },
-      {
-        "version": "8",
+      "8": {
         "release_date": "2011-11-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/8",
         "status": "retired"
       },
-      {
-        "version": "9",
+      "9": {
         "release_date": "2011-12-20",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/9",
         "status": "retired"
       },
-      {
-        "version": "10",
+      "10": {
         "release_date": "2012-01-31",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/10",
         "status": "retired"
       },
-      {
-        "version": "11",
+      "11": {
         "release_date": "2012-03-13",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/11",
         "status": "retired"
       },
-      {
-        "version": "12",
+      "12": {
         "release_date": "2012-04-24",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/12",
         "status": "retired"
       },
-      {
-        "version": "13",
+      "13": {
         "release_date": "2012-06-05",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/13",
         "status": "retired"
       },
-      {
-        "version": "14",
+      "14": {
         "release_date": "2012-07-17",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/14",
         "status": "retired"
       },
-      {
-        "version": "15",
+      "15": {
         "release_date": "2012-08-28",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/15",
         "status": "retired"
       },
-      {
-        "version": "16",
+      "16": {
         "release_date": "2012-10-09",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/16",
         "status": "retired"
       },
-      {
-        "version": "17",
+      "17": {
         "release_date": "2012-11-20",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/17",
         "status": "retired"
       },
-      {
-        "version": "18",
+      "18": {
         "release_date": "2013-01-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/18",
         "status": "retired"
       },
-      {
-        "version": "19",
+      "19": {
         "release_date": "2013-02-19",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/19",
         "status": "retired"
       },
-      {
-        "version": "20",
+      "20": {
         "release_date": "2013-04-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/20",
         "status": "retired"
       },
-      {
-        "version": "21",
+      "21": {
         "release_date": "2013-05-14",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/21",
         "status": "retired"
       },
-      {
-        "version": "22",
+      "22": {
         "release_date": "2013-06-25",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/22",
         "status": "retired"
       },
-      {
-        "version": "23",
+      "23": {
         "release_date": "2013-08-06",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/23",
         "status": "retired"
       },
-      {
-        "version": "24",
+      "24": {
         "release_date": "2013-09-17",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/24",
         "status": "retired"
       },
-      {
-        "version": "25",
+      "25": {
         "release_date": "2013-10-29",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/25",
         "status": "retired"
       },
-      {
-        "version": "26",
+      "26": {
         "release_date": "2013-12-10",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/26",
         "status": "retired"
       },
-      {
-        "version": "27",
+      "27": {
         "release_date": "2014-02-04",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/27",
         "status": "retired"
       },
-      {
-        "version": "28",
+      "28": {
         "release_date": "2014-03-18",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/28",
         "status": "retired"
       },
-      {
-        "version": "29",
+      "29": {
         "release_date": "2014-04-29",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/29",
         "status": "retired"
       },
-      {
-        "version": "30",
+      "30": {
         "release_date": "2014-06-10",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/30",
         "status": "retired"
       },
-      {
-        "version": "31",
+      "31": {
         "release_date": "2014-07-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/31",
         "status": "retired"
       },
-      {
-        "version": "32",
+      "32": {
         "release_date": "2014-09-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/32",
         "status": "retired"
       },
-      {
-        "version": "33",
+      "33": {
         "release_date": "2014-10-14",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/33",
         "status": "retired"
       },
-      {
-        "version": "34",
+      "34": {
         "release_date": "2014-12-01",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/34",
         "status": "retired"
       },
-      {
-        "version": "35",
+      "35": {
         "release_date": "2015-01-13",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/35",
         "status": "retired"
       },
-      {
-        "version": "36",
+      "36": {
         "release_date": "2015-02-24",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/36",
         "status": "retired"
       },
-      {
-        "version": "37",
+      "37": {
         "release_date": "2015-04-07",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/37",
         "status": "retired"
       },
-      {
-        "version": "38",
+      "38": {
         "release_date": "2015-05-19",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/38",
         "status": "retired"
       },
-      {
-        "version": "39",
+      "39": {
         "release_date": "2015-06-30",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/39",
         "status": "retired"
       },
-      {
-        "version": "40",
+      "40": {
         "release_date": "2015-08-11",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/40",
         "status": "retired"
       },
-      {
-        "version": "41",
+      "41": {
         "release_date": "2015-09-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/41",
         "status": "retired"
       },
-      {
-        "version": "42",
+      "42": {
         "release_date": "2015-11-03",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/42",
         "status": "retired"
       },
-      {
-        "version": "43",
+      "43": {
         "release_date": "2015-12-15",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/43",
         "status": "retired"
       },
-      {
-        "version": "44",
+      "44": {
         "release_date": "2016-01-26",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/44",
         "status": "retired"
       },
-      {
-        "version": "45",
+      "45": {
         "release_date": "2016-03-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/45",
         "status": "retired"
       },
-      {
-        "version": "46",
+      "46": {
         "release_date": "2016-04-26",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/46",
         "status": "retired"
       },
-      {
-        "version": "47",
+      "47": {
         "release_date": "2016-06-07",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/47",
         "status": "retired"
       },
-      {
-        "version": "48",
+      "48": {
         "release_date": "2016-08-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/48",
         "status": "retired"
       },
-      {
-        "version": "49",
+      "49": {
         "release_date": "2016-09-13",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/49",
         "status": "retired"
       },
-      {
-        "version": "50",
+      "50": {
         "release_date": "2016-11-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/50",
         "status": "retired"
       },
-      {
-        "version": "50.0.1",
+      "50.0.1": {
         "release_date": "2016-12-13",
         "status": "retired"
       },
-      {
-        "version": "51",
+      "51": {
         "release_date": "2017-01-24",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/51",
         "status": "retired"
       },
-      {
-        "version": "52",
+      "52": {
         "release_date": "2017-03-07",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
         "status": "esr"
       },
-      {
-        "version": "53",
+      "53": {
         "release_date": "2017-04-18",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/53",
         "status": "retired"
       },
-      {
-        "version": "54",
+      "54": {
         "release_date": "2017-06-13",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/54",
         "status": "retired"
       },
-      {
-        "version": "55",
+      "55": {
         "release_date": "2017-08-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/55",
-        "status": "current"
+        "status": "retired"
       },
-      {
-        "version": "56",
+      "56": {
         "release_date": "2017-10-03",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
-        "status": "beta"
+        "status": "current"
       },
-      {
-        "version": "57",
+      "57": {
         "release_date": "2017-11-28",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
-        "status": "nightly"
+        "status": "beta"
       },
-      {
-        "version": "58",
+      "58": {
         "release_date": "2018-01-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
-        "status": "planned"
+        "status": "nightly"
       }
-    ]
+    }
   },
   "firefox_android": {
-    "releases": [
-      {
-        "version": "4",
+    "releases": {
+      "4": {
         "release_date": "2011-03-29",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",
         "status": "retired"
       },
-      {
-        "version": "5",
+      "5": {
         "release_date": "2011-06-21",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/5",
         "status": "retired"
       },
-      {
-        "version": "6",
+      "6": {
         "release_date": "2011-08-16",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/6",
         "status": "retired"
       },
-      {
-        "version": "7",
+      "7": {
         "release_date": "2011-09-27",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/7",
         "status": "retired"
       },
-      {
-        "version": "8",
+      "8": {
         "release_date": "2011-11-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/8",
         "status": "retired"
       },
-      {
-        "version": "9",
+      "9": {
         "release_date": "2011-12-21",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/9",
         "status": "retired"
       },
-      {
-        "version": "10",
+      "10": {
         "release_date": "2012-01-31",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/10",
         "status": "retired"
       },
-      {
-        "version": "14",
+      "14": {
         "release_date": "2012-06-26",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/14",
         "status": "retired"
       },
-      {
-        "version": "15",
+      "15": {
         "release_date": "2012-08-28",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/15",
         "status": "retired"
       },
-      {
-        "version": "16",
+      "16": {
         "release_date": "2012-10-09",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/16",
         "status": "retired"
       },
-      {
-        "version": "17",
+      "17": {
         "release_date": "2012-11-19",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/17",
         "status": "retired"
       },
-      {
-        "version": "18",
+      "18": {
         "release_date": "2013-01-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/18",
         "status": "retired"
       },
-      {
-        "version": "19",
+      "19": {
         "release_date": "2013-02-19",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/19",
         "status": "retired"
       },
-      {
-        "version": "20",
+      "20": {
         "release_date": "2013-04-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/20",
         "status": "retired"
       },
-      {
-        "version": "21",
+      "21": {
         "release_date": "2013-05-14",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/21",
         "status": "retired"
       },
-      {
-        "version": "22",
+      "22": {
         "release_date": "2013-06-25",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/22",
         "status": "retired"
       },
-      {
-        "version": "23",
+      "23": {
         "release_date": "2013-08-06",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/23",
         "status": "retired"
       },
-      {
-        "version": "24",
+      "24": {
         "release_date": "2013-09-17",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/24",
         "status": "retired"
       },
-      {
-        "version": "25",
+      "25": {
         "release_date": "2013-10-29",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/25",
         "status": "retired"
       },
-      {
-        "version": "26",
+      "26": {
         "release_date": "2013-12-10",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/26",
         "status": "retired"
       },
-      {
-        "version": "27",
+      "27": {
         "release_date": "2014-02-04",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/27",
         "status": "retired"
       },
-      {
-        "version": "28",
+      "28": {
         "release_date": "2014-03-18",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/28",
         "status": "retired"
       },
-      {
-        "version": "29",
+      "29": {
         "release_date": "2014-04-29",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/29",
         "status": "retired"
       },
-      {
-        "version": "30",
+      "30": {
         "release_date": "2014-06-10",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/30",
         "status": "retired"
       },
-      {
-        "version": "31",
+      "31": {
         "release_date": "2014-07-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/31",
         "status": "retired"
       },
-      {
-        "version": "32",
+      "32": {
         "release_date": "2014-09-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/32",
         "status": "retired"
       },
-      {
-        "version": "33",
+      "33": {
         "release_date": "2014-10-13",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/33",
         "status": "retired"
       },
-      {
-        "version": "34",
+      "34": {
         "release_date": "2014-12-01",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/34",
         "status": "retired"
       },
-      {
-        "version": "35",
+      "35": {
         "release_date": "2015-01-13",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/35",
         "status": "retired"
       },
-      {
-        "version": "36",
+      "36": {
         "release_date": "2015-02-27",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/36",
         "status": "retired"
       },
-      {
-        "version": "37",
+      "37": {
         "release_date": "2015-03-31",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/37",
         "status": "retired"
       },
-      {
-        "version": "38",
+      "38": {
         "release_date": "2015-05-12",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/38",
         "status": "retired"
       },
-      {
-        "version": "39",
+      "39": {
         "release_date": "2015-07-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/39",
         "status": "retired"
       },
-      {
-        "version": "40",
+      "40": {
         "release_date": "2015-08-11",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/40",
         "status": "retired"
       },
-      {
-        "version": "41",
+      "41": {
         "release_date": "2015-09-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/41",
         "status": "retired"
       },
-      {
-        "version": "42",
+      "42": {
         "release_date": "2015-11-03",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/42",
         "status": "retired"
       },
-      {
-        "version": "43",
+      "43": {
         "release_date": "2015-12-15",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/43",
         "status": "retired"
       },
-      {
-        "version": "44",
+      "44": {
         "release_date": "2016-01-26",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/44",
         "status": "retired"
       },
-      {
-        "version": "45",
+      "45": {
         "release_date": "2016-03-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/45",
         "status": "retired"
       },
-      {
-        "version": "46",
+      "46": {
         "release_date": "2016-04-26",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/46",
         "status": "retired"
       },
-      {
-        "version": "47",
+      "47": {
         "release_date": "2016-06-07",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/47",
         "status": "retired"
       },
-      {
-        "version": "48",
+      "48": {
         "release_date": "2016-08-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/48",
         "status": "retired"
       },
-      {
-        "version": "49",
+      "49": {
         "release_date": "2016-09-20",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/49",
         "status": "retired"
       },
-      {
-        "version": "50",
+      "50": {
         "release_date": "2016-11-15",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/50",
         "status": "retired"
       },
-      {
-        "version": "51",
+      "51": {
         "release_date": "2017-01-24",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/51",
         "status": "retired"
       },
-      {
-        "version": "52",
+      "52": {
         "release_date": "2017-03-07",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
         "status": "esr"
       },
-      {
-        "version": "53",
+      "53": {
         "release_date": "2017-04-19",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/53",
         "status": "retired"
       },
-      {
-        "version": "54",
+      "54": {
         "release_date": "2017-06-13",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/54",
         "status": "retired"
       },
-      {
-        "version": "55",
+      "55": {
         "release_date": "2017-08-08",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/55",
         "status": "retired"
       },
-      {
-        "version": "56",
+      "56": {
         "release_date": "2017-10-03",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
         "status": "current"
       },
-      {
-        "version": "57",
+      "57": {
         "release_date": "2017-11-28",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
         "status": "beta"
       },
-      {
-        "version": "58",
+      "58": {
         "release_date": "2018-01-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
         "status": "nightly"
       }
-    ]
+    }
   },
   "ie": {
-    "releases": [
-      {
-        "version": "1",
+    "releases": {
+      "1": {
         "release_date": "1995-08-16",
         "status": "retired"
       },
-      {
-        "version": "1.5",
+      "1.5": {
         "status": "retired"
       },
-      {
-        "version": "2",
+      "2": {
         "release_date": "1995-11-22",
         "status": "retired"
       },
-      {
-        "version": "3",
+      "3": {
         "release_date": "1996-08-13",
         "status": "retired"
       },
-      {
-        "version": "4",
+      "4": {
         "release_date": "1997-09-01",
         "status": "retired"
       },
-      {
-        "version": "5",
+      "5": {
         "release_date": "1999-03-18",
         "status": "retired"
       },
-      {
-        "version": "5.5",
+      "5.5": {
         "release_date": "2000-07-01",
         "status": "retired"
       },
-      {
-        "version": "6",
+      "6": {
         "release_date": "2001-08-27",
         "status": "retired"
       },
-      {
-        "version": "7",
+      "7": {
         "release_date": "2006-10-18",
         "status": "retired"
       },
-      {
-        "version": "8",
+      "8": {
         "release_date": "2009-03-19",
         "status": "retired"
       },
-      {
-        "version": "9",
+      "9": {
         "release_date": "2011-03-14",
         "status": "retired"
       },
-      {
-        "version": "10",
+      "10": {
         "release_date": "2012-10-26",
         "status": "retired"
       },
-      {
-        "version": "11",
+      "11": {
         "release_date": "2013-10-17",
         "status": "current"
       }
-    ]
+    }
   }
 }

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1214,6 +1214,9 @@
       "48": {
         "release_date": "2017-09-27",
         "status": "current"
+      },
+      "49": {
+        "status": "planned"
       }
     }
   }

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1,0 +1,761 @@
+{
+  "firefox": {
+    "releases": [
+      {
+        "version": "1",
+        "release_date": "2004-11-09",
+        "release_notes": "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.0.html",
+        "status": "retired"
+      },
+      {
+        "version": "1.5",
+        "release_date": "2005-11-25",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/1.5",
+        "status": "retired"
+      },
+      {
+        "version": "2",
+        "release_date": "2006-10-24",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/2",
+        "status": "retired"
+      },
+      {
+        "version": "3",
+        "release_date": "2008-06-17",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/3",
+        "status": "retired"
+      },
+      {
+        "version": "3.5",
+        "release_date": "2009-06-30",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.5",
+        "status": "retired"
+      },
+      {
+        "version": "3.6",
+        "release_date": "2010-01-21",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.6",
+        "status": "retired"
+      },
+      {
+        "version": "4",
+        "release_date": "2011-03-22",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",
+        "status": "retired"
+      },
+      {
+        "version": "5",
+        "release_date": "2011-06-21",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/5",
+        "status": "retired"
+      },
+      {
+        "version": "6",
+        "release_date": "2011-08-16",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/6",
+        "status": "retired"
+      },
+      {
+        "version": "7",
+        "release_date": "2011-09-26",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/7",
+        "status": "retired"
+      },
+      {
+        "version": "8",
+        "release_date": "2011-11-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/8",
+        "status": "retired"
+      },
+      {
+        "version": "9",
+        "release_date": "2011-12-20",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/9",
+        "status": "retired"
+      },
+      {
+        "version": "10",
+        "release_date": "2012-01-31",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/10",
+        "status": "retired"
+      },
+      {
+        "version": "11",
+        "release_date": "2012-03-13",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/11",
+        "status": "retired"
+      },
+      {
+        "version": "12",
+        "release_date": "2012-04-24",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/12",
+        "status": "retired"
+      },
+      {
+        "version": "13",
+        "release_date": "2012-06-05",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/13",
+        "status": "retired"
+      },
+      {
+        "version": "14",
+        "release_date": "2012-07-17",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/14",
+        "status": "retired"
+      },
+      {
+        "version": "15",
+        "release_date": "2012-08-28",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/15",
+        "status": "retired"
+      },
+      {
+        "version": "16",
+        "release_date": "2012-10-09",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/16",
+        "status": "retired"
+      },
+      {
+        "version": "17",
+        "release_date": "2012-11-20",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/17",
+        "status": "retired"
+      },
+      {
+        "version": "18",
+        "release_date": "2013-01-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/18",
+        "status": "retired"
+      },
+      {
+        "version": "19",
+        "release_date": "2013-02-19",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/19",
+        "status": "retired"
+      },
+      {
+        "version": "20",
+        "release_date": "2013-04-02",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/20",
+        "status": "retired"
+      },
+      {
+        "version": "21",
+        "release_date": "2013-05-14",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/21",
+        "status": "retired"
+      },
+      {
+        "version": "22",
+        "release_date": "2013-06-25",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/22",
+        "status": "retired"
+      },
+      {
+        "version": "23",
+        "release_date": "2013-08-06",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/23",
+        "status": "retired"
+      },
+      {
+        "version": "24",
+        "release_date": "2013-09-17",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/24",
+        "status": "retired"
+      },
+      {
+        "version": "25",
+        "release_date": "2013-10-29",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/25",
+        "status": "retired"
+      },
+      {
+        "version": "26",
+        "release_date": "2013-12-10",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/26",
+        "status": "retired"
+      },
+      {
+        "version": "27",
+        "release_date": "2014-02-04",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/27",
+        "status": "retired"
+      },
+      {
+        "version": "28",
+        "release_date": "2014-03-18",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/28",
+        "status": "retired"
+      },
+      {
+        "version": "29",
+        "release_date": "2014-04-29",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/29",
+        "status": "retired"
+      },
+      {
+        "version": "30",
+        "release_date": "2014-06-10",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/30",
+        "status": "retired"
+      },
+      {
+        "version": "31",
+        "release_date": "2014-07-22",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/31",
+        "status": "retired"
+      },
+      {
+        "version": "32",
+        "release_date": "2014-09-02",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/32",
+        "status": "retired"
+      },
+      {
+        "version": "33",
+        "release_date": "2014-10-14",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/33",
+        "status": "retired"
+      },
+      {
+        "version": "34",
+        "release_date": "2014-12-01",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/34",
+        "status": "retired"
+      },
+      {
+        "version": "35",
+        "release_date": "2015-01-13",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/35",
+        "status": "retired"
+      },
+      {
+        "version": "36",
+        "release_date": "2015-02-24",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/36",
+        "status": "retired"
+      },
+      {
+        "version": "37",
+        "release_date": "2015-04-07",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/37",
+        "status": "retired"
+      },
+      {
+        "version": "38",
+        "release_date": "2015-05-19",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/38",
+        "status": "retired"
+      },
+      {
+        "version": "39",
+        "release_date": "2015-06-30",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/39",
+        "status": "retired"
+      },
+      {
+        "version": "40",
+        "release_date": "2015-08-11",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/40",
+        "status": "retired"
+      },
+      {
+        "version": "41",
+        "release_date": "2015-09-22",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/41",
+        "status": "retired"
+      },
+      {
+        "version": "42",
+        "release_date": "2015-11-03",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/42",
+        "status": "retired"
+      },
+      {
+        "version": "43",
+        "release_date": "2015-12-15",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/43",
+        "status": "retired"
+      },
+      {
+        "version": "44",
+        "release_date": "2016-01-26",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/44",
+        "status": "retired"
+      },
+      {
+        "version": "45",
+        "release_date": "2016-03-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/45",
+        "status": "retired"
+      },
+      {
+        "version": "46",
+        "release_date": "2016-04-26",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/46",
+        "status": "retired"
+      },
+      {
+        "version": "47",
+        "release_date": "2016-06-07",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/47",
+        "status": "retired"
+      },
+      {
+        "version": "48",
+        "release_date": "2016-08-02",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/48",
+        "status": "retired"
+      },
+      {
+        "version": "49",
+        "release_date": "2016-09-13",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/49",
+        "status": "retired"
+      },
+      {
+        "version": "50",
+        "release_date": "2016-11-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/50",
+        "status": "retired"
+      },
+      {
+        "version": "50.0.1",
+        "release_date": "2016-12-13",
+        "status": "retired"
+      },
+      {
+        "version": "51",
+        "release_date": "2017-01-24",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/51",
+        "status": "retired"
+      },
+      {
+        "version": "52",
+        "release_date": "2017-03-07",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
+        "status": "esr"
+      },
+      {
+        "version": "53",
+        "release_date": "2017-04-18",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/53",
+        "status": "retired"
+      },
+      {
+        "version": "54",
+        "release_date": "2017-06-13",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/54",
+        "status": "retired"
+      },
+      {
+        "version": "55",
+        "release_date": "2017-08-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/55",
+        "status": "current"
+      },
+      {
+        "version": "56",
+        "release_date": "2017-10-03",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
+        "status": "beta"
+      },
+      {
+        "version": "57",
+        "release_date": "2017-11-28",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
+        "status": "nightly"
+      },
+      {
+        "version": "58",
+        "release_date": "2018-01-22",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
+        "status": "planned"
+      }
+    ]
+  },
+  "firefox_android": {
+    "releases": [
+      {
+        "version": "4",
+        "release_date": "2011-03-29",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",
+        "status": "retired"
+      },
+      {
+        "version": "5",
+        "release_date": "2011-06-21",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/5",
+        "status": "retired"
+      },
+      {
+        "version": "6",
+        "release_date": "2011-08-16",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/6",
+        "status": "retired"
+      },
+      {
+        "version": "7",
+        "release_date": "2011-09-27",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/7",
+        "status": "retired"
+      },
+      {
+        "version": "8",
+        "release_date": "2011-11-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/8",
+        "status": "retired"
+      },
+      {
+        "version": "9",
+        "release_date": "2011-12-21",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/9",
+        "status": "retired"
+      },
+      {
+        "version": "10",
+        "release_date": "2012-01-31",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/10",
+        "status": "retired"
+      },
+      {
+        "version": "14",
+        "release_date": "2012-06-26",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/14",
+        "status": "retired"
+      },
+      {
+        "version": "15",
+        "release_date": "2012-08-28",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/15",
+        "status": "retired"
+      },
+      {
+        "version": "16",
+        "release_date": "2012-10-09",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/16",
+        "status": "retired"
+      },
+      {
+        "version": "17",
+        "release_date": "2012-11-19",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/17",
+        "status": "retired"
+      },
+      {
+        "version": "18",
+        "release_date": "2013-01-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/18",
+        "status": "retired"
+      },
+      {
+        "version": "19",
+        "release_date": "2013-02-19",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/19",
+        "status": "retired"
+      },
+      {
+        "version": "20",
+        "release_date": "2013-04-02",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/20",
+        "status": "retired"
+      },
+      {
+        "version": "21",
+        "release_date": "2013-05-14",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/21",
+        "status": "retired"
+      },
+      {
+        "version": "22",
+        "release_date": "2013-06-25",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/22",
+        "status": "retired"
+      },
+      {
+        "version": "23",
+        "release_date": "2013-08-06",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/23",
+        "status": "retired"
+      },
+      {
+        "version": "24",
+        "release_date": "2013-09-17",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/24",
+        "status": "retired"
+      },
+      {
+        "version": "25",
+        "release_date": "2013-10-29",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/25",
+        "status": "retired"
+      },
+      {
+        "version": "26",
+        "release_date": "2013-12-10",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/26",
+        "status": "retired"
+      },
+      {
+        "version": "27",
+        "release_date": "2014-02-04",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/27",
+        "status": "retired"
+      },
+      {
+        "version": "28",
+        "release_date": "2014-03-18",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/28",
+        "status": "retired"
+      },
+      {
+        "version": "29",
+        "release_date": "2014-04-29",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/29",
+        "status": "retired"
+      },
+      {
+        "version": "30",
+        "release_date": "2014-06-10",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/30",
+        "status": "retired"
+      },
+      {
+        "version": "31",
+        "release_date": "2014-07-22",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/31",
+        "status": "retired"
+      },
+      {
+        "version": "32",
+        "release_date": "2014-09-02",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/32",
+        "status": "retired"
+      },
+      {
+        "version": "33",
+        "release_date": "2014-10-13",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/33",
+        "status": "retired"
+      },
+      {
+        "version": "34",
+        "release_date": "2014-12-01",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/34",
+        "status": "retired"
+      },
+      {
+        "version": "35",
+        "release_date": "2015-01-13",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/35",
+        "status": "retired"
+      },
+      {
+        "version": "36",
+        "release_date": "2015-02-27",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/36",
+        "status": "retired"
+      },
+      {
+        "version": "37",
+        "release_date": "2015-03-31",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/37",
+        "status": "retired"
+      },
+      {
+        "version": "38",
+        "release_date": "2015-05-12",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/38",
+        "status": "retired"
+      },
+      {
+        "version": "39",
+        "release_date": "2015-07-02",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/39",
+        "status": "retired"
+      },
+      {
+        "version": "40",
+        "release_date": "2015-08-11",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/40",
+        "status": "retired"
+      },
+      {
+        "version": "41",
+        "release_date": "2015-09-22",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/41",
+        "status": "retired"
+      },
+      {
+        "version": "42",
+        "release_date": "2015-11-03",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/42",
+        "status": "retired"
+      },
+      {
+        "version": "43",
+        "release_date": "2015-12-15",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/43",
+        "status": "retired"
+      },
+      {
+        "version": "44",
+        "release_date": "2016-01-26",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/44",
+        "status": "retired"
+      },
+      {
+        "version": "45",
+        "release_date": "2016-03-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/45",
+        "status": "retired"
+      },
+      {
+        "version": "46",
+        "release_date": "2016-04-26",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/46",
+        "status": "retired"
+      },
+      {
+        "version": "47",
+        "release_date": "2016-06-07",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/47",
+        "status": "retired"
+      },
+      {
+        "version": "48",
+        "release_date": "2016-08-02",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/48",
+        "status": "retired"
+      },
+      {
+        "version": "49",
+        "release_date": "2016-09-20",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/49",
+        "status": "retired"
+      },
+      {
+        "version": "50",
+        "release_date": "2016-11-15",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/50",
+        "status": "retired"
+      },
+      {
+        "version": "51",
+        "release_date": "2017-01-24",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/51",
+        "status": "retired"
+      },
+      {
+        "version": "52",
+        "release_date": "2017-03-07",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
+        "status": "esr"
+      },
+      {
+        "version": "53",
+        "release_date": "2017-04-19",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/53",
+        "status": "retired"
+      },
+      {
+        "version": "54",
+        "release_date": "2017-06-13",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/54",
+        "status": "retired"
+      },
+      {
+        "version": "55",
+        "release_date": "2017-08-08",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/55",
+        "status": "retired"
+      },
+      {
+        "version": "56",
+        "release_date": "2017-10-03",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
+        "status": "current"
+      },
+      {
+        "version": "57",
+        "release_date": "2017-11-28",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
+        "status": "beta"
+      },
+      {
+        "version": "58",
+        "release_date": "2018-01-22",
+        "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
+        "status": "nightly"
+      }
+    ]
+  },
+  "ie": {
+    "releases": [
+      {
+        "version": "1",
+        "release_date": "1995-08-16",
+        "status": "retired"
+      },
+      {
+        "version": "1.5",
+        "status": "retired"
+      },
+      {
+        "version": "2",
+        "release_date": "1995-11-22",
+        "status": "retired"
+      },
+      {
+        "version": "3",
+        "release_date": "1996-08-13",
+        "status": "retired"
+      },
+      {
+        "version": "4",
+        "release_date": "1997-09-01",
+        "status": "retired"
+      },
+      {
+        "version": "5",
+        "release_date": "1999-03-18",
+        "status": "retired"
+      },
+      {
+        "version": "5.5",
+        "release_date": "2000-07-01",
+        "status": "retired"
+      },
+      {
+        "version": "6",
+        "release_date": "2001-08-27",
+        "status": "retired"
+      },
+      {
+        "version": "7",
+        "release_date": "2006-10-18",
+        "status": "retired"
+      },
+      {
+        "version": "8",
+        "release_date": "2009-03-19",
+        "status": "retired"
+      },
+      {
+        "version": "9",
+        "release_date": "2011-03-14",
+        "status": "retired"
+      },
+      {
+        "version": "10",
+        "release_date": "2012-10-26",
+        "status": "retired"
+      },
+      {
+        "version": "11",
+        "release_date": "2013-10-17",
+        "status": "current"
+      }
+    ]
+  }
+}

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -303,7 +303,7 @@
         "status": "retired"
       },
       "1.5": {
-        "release_date": "2005-11-25",
+        "release_date": "2005-11-29",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/1.5",
         "status": "retired"
       },
@@ -348,7 +348,7 @@
         "status": "retired"
       },
       "7": {
-        "release_date": "2011-09-26",
+        "release_date": "2011-09-27",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/7",
         "status": "retired"
       },
@@ -498,17 +498,17 @@
         "status": "retired"
       },
       "37": {
-        "release_date": "2015-04-07",
+        "release_date": "2015-03-31",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/37",
         "status": "retired"
       },
       "38": {
-        "release_date": "2015-05-19",
+        "release_date": "2015-05-12",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/38",
         "status": "retired"
       },
       "39": {
-        "release_date": "2015-06-30",
+        "release_date": "2015-07-02",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/39",
         "status": "retired"
       },
@@ -558,17 +558,17 @@
         "status": "retired"
       },
       "49": {
-        "release_date": "2016-09-13",
+        "release_date": "2016-09-20",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/49",
         "status": "retired"
       },
       "50": {
-        "release_date": "2016-11-08",
+        "release_date": "2016-11-15",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/50",
         "status": "retired"
       },
       "50.0.1": {
-        "release_date": "2016-12-13",
+        "release_date": "2016-11-28",
         "status": "retired"
       },
       "51": {
@@ -582,7 +582,7 @@
         "status": "esr"
       },
       "53": {
-        "release_date": "2017-04-18",
+        "release_date": "2017-04-19",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/53",
         "status": "retired"
       },
@@ -597,7 +597,7 @@
         "status": "retired"
       },
       "56": {
-        "release_date": "2017-10-03",
+        "release_date": "2017-09-28",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
         "status": "current"
       },
@@ -666,7 +666,7 @@
         "status": "retired"
       },
       "17": {
-        "release_date": "2012-11-19",
+        "release_date": "2012-11-20",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/17",
         "status": "retired"
       },
@@ -746,7 +746,7 @@
         "status": "retired"
       },
       "33": {
-        "release_date": "2014-10-13",
+        "release_date": "2014-10-14",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/33",
         "status": "retired"
       },
@@ -861,7 +861,7 @@
         "status": "retired"
       },
       "56": {
-        "release_date": "2017-10-03",
+        "release_date": "2017-09-28",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
         "status": "current"
       },
@@ -895,7 +895,7 @@
         "status": "retired"
       },
       "4": {
-        "release_date": "1997-09-01",
+        "release_date": "1997-09-30",
         "status": "retired"
       },
       "5": {
@@ -903,7 +903,7 @@
         "status": "retired"
       },
       "5.5": {
-        "release_date": "2000-07-01",
+        "release_date": "2000-07-06",
         "status": "retired"
       },
       "6": {
@@ -935,7 +935,7 @@
   "opera": {
     "releases": {
       "2": {
-        "release_date": "1996-12-01",
+        "release_date": "1996-07-14",
         "status": "retired"
       },
       "3": {

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -889,5 +889,290 @@
         "status": "current"
       }
     }
+  },
+  "opera": {
+    "releases": {
+      "2": {
+        "release_date": "1996-12-01",
+        "status": "retired"
+      },
+      "3": {
+        "release_date": "1997-12-01",
+        "status": "retired"
+      },
+      "3.5": {
+        "release_date": "1998-11-18",
+        "status": "retired"
+      },
+      "3.6": {
+        "release_date": "1999-05-06",
+        "status": "retired"
+      },
+      "4": {
+        "release_date": "2000-06-28",
+        "status": "retired"
+      },
+      "5": {
+        "release_date": "2000-12-06",
+        "status": "retired"
+      },
+      "5.1": {
+        "release_date": "2001-04-10",
+        "status": "retired"
+      },
+      "6": {
+        "release_date": "2001-12-18",
+        "status": "retired"
+      },
+      "7": {
+        "release_date": "2003-01-28",
+        "status": "retired"
+      },
+      "7.1": {
+        "release_date": "2003-04-11",
+        "status": "retired"
+      },
+      "7.2": {
+        "release_date": "2003-09-23",
+        "status": "retired"
+      },
+      "7.5": {
+        "release_date": "2004-05-12",
+        "status": "retired"
+      },
+      "8": {
+        "release_date": "2005-04-19",
+        "status": "retired"
+      },
+      "8.5": {
+        "release_date": "2005-09-20",
+        "status": "retired"
+      },
+      "9": {
+        "release_date": "2006-06-20",
+        "status": "retired"
+      },
+      "9.1": {
+        "release_date": "2006-12-18",
+        "status": "retired"
+      },
+      "9.2": {
+        "release_date": "2007-04-11",
+        "status": "retired"
+      },
+      "9.5": {
+        "release_date": "2008-06-12",
+        "status": "retired"
+      },
+      "9.6": {
+        "release_date": "2008-10-08",
+        "status": "retired"
+      },
+      "10": {
+        "release_date": "2009-09-01",
+        "status": "retired"
+      },
+      "10.1": {
+        "release_date": "2009-11-23",
+        "status": "retired"
+      },
+      "10.5": {
+        "release_date": "2010-03-02",
+        "status": "retired"
+      },
+      "10.6": {
+        "release_date": "2010-07-01",
+        "status": "retired"
+      },
+      "11": {
+        "release_date": "2010-12-16",
+        "status": "retired"
+      },
+      "11.1": {
+        "release_date": "2011-04-12",
+        "status": "retired"
+      },
+      "11.5": {
+        "release_date": "2011-06-28",
+        "status": "retired"
+      },
+      "11.6": {
+        "release_date": "2011-12-06",
+        "status": "retired"
+      },
+      "12": {
+        "release_date": "2012-06-14",
+        "status": "retired"
+      },
+      "12.1": {
+        "release_date": "2012-11-20",
+        "status": "retired"
+      },
+      "15": {
+        "release_date": "2013-07-02",
+        "status": "retired"
+      },
+      "16": {
+        "release_date": "2013-08-27",
+        "status": "retired"
+      },
+      "17": {
+        "release_date": "2013-10-08",
+        "status": "retired"
+      },
+      "18": {
+        "release_date": "2013-11-19",
+        "status": "retired"
+      },
+      "19": {
+        "release_date": "2014-01-28",
+        "release_notes": "https://dev.opera.com/blog/opera-19/",
+        "status": "retired"
+      },
+      "20": {
+        "release_date": "2014-03-04",
+        "release_notes": "https://dev.opera.com/blog/opera-20/",
+        "status": "retired"
+      },
+      "21": {
+        "release_date": "2014-05-06",
+        "release_notes": "https://dev.opera.com/blog/opera-21/",
+        "status": "retired"
+      },
+      "22": {
+        "release_date": "2014-06-03",
+        "release_notes": "https://dev.opera.com/blog/opera-22/",
+        "status": "retired"
+      },
+      "23": {
+        "release_date": "2014-07-22",
+        "release_notes": "https://dev.opera.com/blog/opera-23/",
+        "status": "retired"
+      },
+      "24": {
+        "release_date": "2014-09-02",
+        "release_notes": "https://dev.opera.com/blog/opera-24/",
+        "status": "retired"
+      },
+      "25": {
+        "release_date": "2014-10-15",
+        "release_notes": "https://dev.opera.com/blog/opera-25/",
+        "status": "retired"
+      },
+      "26": {
+        "release_date": "2014-12-03",
+        "release_notes": "https://dev.opera.com/blog/opera-26/",
+        "status": "retired"
+      },
+      "27": {
+        "release_date": "2015-01-27",
+        "release_notes": "https://dev.opera.com/blog/opera-27/",
+        "status": "retired"
+      },
+      "28": {
+        "release_date": "2015-03-10",
+        "release_notes": "https://dev.opera.com/blog/opera-28/",
+        "status": "retired"
+      },
+      "29": {
+        "release_date": "2015-04-28",
+        "release_notes": "https://dev.opera.com/blog/opera-29/",
+        "status": "retired"
+      },
+      "30": {
+        "release_date": "2015-06-09",
+        "release_notes": "https://dev.opera.com/blog/opera-30/",
+        "status": "retired"
+      },
+      "31": {
+        "release_date": "2015-08-04",
+        "release_notes": "https://dev.opera.com/blog/opera-31/",
+        "status": "retired"
+      },
+      "32": {
+        "release_date": "2015-09-15",
+        "release_notes": "https://dev.opera.com/blog/opera-32/",
+        "status": "retired"
+      },
+      "33": {
+        "release_date": "2015-10-27",
+        "release_notes": "https://dev.opera.com/blog/opera-33/",
+        "status": "retired"
+      },
+      "34": {
+        "release_date": "2015-12-08",
+        "release_notes": "https://dev.opera.com/blog/opera-34/",
+        "status": "retired"
+      },
+      "35": {
+        "release_date": "2016-02-02",
+        "release_notes": "https://dev.opera.com/blog/opera-35/",
+        "status": "retired"
+      },
+      "36": {
+        "release_date": "2016-03-15",
+        "release_notes": "https://dev.opera.com/blog/opera-36/",
+        "status": "retired"
+      },
+      "37": {
+        "release_date": "2016-05-04",
+        "release_notes": "https://dev.opera.com/blog/opera-37/",
+        "status": "retired"
+      },
+      "38": {
+        "release_date": "2016-06-08",
+        "release_notes": "https://dev.opera.com/blog/opera-38/",
+        "status": "retired"
+      },
+      "39": {
+        "release_date": "2016-08-02",
+        "release_notes": "https://dev.opera.com/blog/opera-39/",
+        "status": "retired"
+      },
+      "40": {
+        "release_date": "2016-09-20",
+        "release_notes": "https://dev.opera.com/blog/opera-40/",
+        "status": "retired"
+      },
+      "41": {
+        "release_date": "2016-10-25",
+        "release_notes": "https://dev.opera.com/blog/opera-41/",
+        "status": "retired"
+      },
+      "42": {
+        "release_date": "2016-12-13",
+        "release_notes": "https://dev.opera.com/blog/opera-42/",
+        "status": "retired"
+      },
+      "43": {
+        "release_date": "2017-02-07",
+        "release_notes": "https://dev.opera.com/blog/opera-43/",
+        "status": "retired"
+      },
+      "44": {
+        "release_date": "2017-03-21",
+        "release_notes": "https://dev.opera.com/blog/opera-44/",
+        "status": "retired"
+      },
+      "45": {
+        "release_date": "2017-05-10",
+        "release_notes": "https://dev.opera.com/blog/opera-45/",
+        "status": "retired"
+      },
+      "46": {
+        "release_date": "2017-06-22",
+        "release_notes": "https://dev.opera.com/blog/opera-46/",
+        "status": "retired"
+      },
+      "47": {
+        "release_date": "2017-08-09",
+        "release_notes": "https://dev.opera.com/blog/opera-47/",
+        "status": "retired"
+      },
+      "48": {
+        "release_date": "2017-09-27",
+        "status": "current"
+      }
+    }
   }
 }

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -285,6 +285,11 @@
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.6",
         "status": "retired"
       },
+      "3.6.9": {
+        "release_date": "2010-09-07",
+        "release_notes": "https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/3.6.9/releasenotes/",
+        "status": "retired"
+      },
       "4": {
         "release_date": "2011-03-22",
         "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1217,6 +1217,9 @@
       },
       "49": {
         "status": "planned"
+      },
+      "50": {
+        "status": "planned"
       }
     }
   }

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1,4 +1,326 @@
 {
+  "chrome": {
+    "releases": [
+      {
+        "version": "1",
+        "release_date": "2008-12-11",
+        "status": "retired"
+      },
+      {
+        "version": "2",
+        "release_date": "2009-05-24",
+        "status": "retired"
+      },
+      {
+        "version": "3",
+        "release_date": "2009-10-12",
+        "status": "retired"
+      },
+      {
+        "version": "4",
+        "release_date": "2010-01-25",
+        "status": "retired"
+      },
+      {
+        "version": "4",
+        "release_date": "2010-01-25",
+        "status": "retired"
+      },
+      {
+        "version": "5",
+        "release_date": "2010-05-21",
+        "status": "retired"
+      },
+      {
+        "version": "6",
+        "release_date": "2010-09-02",
+        "status": "retired"
+      },
+      {
+        "version": "7",
+        "release_date": "2010-10-21",
+        "status": "retired"
+      },
+      {
+        "version": "8",
+        "release_date": "2010-12-02",
+        "status": "retired"
+      },
+      {
+        "version": "9",
+        "release_date": "2011-02-03",
+        "status": "retired"
+      },
+      {
+        "version": "10",
+        "release_date": "2011-03-08",
+        "status": "retired"
+      },
+      {
+        "version": "11",
+        "release_date": "2011-04-27",
+        "status": "retired"
+      },
+      {
+        "version": "12",
+        "release_date": "2011-06-07",
+        "status": "retired"
+      },
+      {
+        "version": "13",
+        "release_date": "2011-08-02",
+        "status": "retired"
+      },
+      {
+        "version": "14",
+        "release_date": "2011-09-16",
+        "status": "retired"
+      },
+      {
+        "version": "15",
+        "release_date": "2011-10-25",
+        "status": "retired"
+      },
+      {
+        "version": "16",
+        "release_date": "2011-12-13",
+        "status": "retired"
+      },
+      {
+        "version": "17",
+        "release_date": "2012-02-08",
+        "status": "retired"
+      },
+      {
+        "version": "18",
+        "release_date": "2012-03-28",
+        "status": "retired"
+      },
+      {
+        "version": "19",
+        "release_date": "2012-05-15",
+        "status": "retired"
+      },
+      {
+        "version": "20",
+        "release_date": "2012-06-26",
+        "status": "retired"
+      },
+      {
+        "version": "21",
+        "release_date": "2012-07-31",
+        "status": "retired"
+      },
+      {
+        "version": "22",
+        "release_date": "2012-09-25",
+        "status": "retired"
+      },
+      {
+        "version": "23",
+        "release_date": "2012-11-06",
+        "status": "retired"
+      },
+      {
+        "version": "24",
+        "release_date": "2013-01-10",
+        "status": "retired"
+      },
+      {
+        "version": "25",
+        "release_date": "2013-02-21",
+        "status": "retired"
+      },
+      {
+        "version": "26",
+        "release_date": "2013-03-26",
+        "status": "retired"
+      },
+      {
+        "version": "27",
+        "release_date": "2013-05-21",
+        "status": "retired"
+      },
+      {
+        "version": "28",
+        "release_date": "2013-07-09",
+        "status": "retired"
+      },
+      {
+        "version": "29",
+        "release_date": "2013-08-20",
+        "status": "retired"
+      },
+      {
+        "version": "30",
+        "release_date": "2013-10-01",
+        "status": "retired"
+      },
+      {
+        "version": "31",
+        "release_date": "2013-11-12",
+        "status": "retired"
+      },
+      {
+        "version": "32",
+        "release_date": "2014-01-14",
+        "status": "retired"
+      },
+      {
+        "version": "33",
+        "release_date": "2014-02-20",
+        "status": "retired"
+      },
+      {
+        "version": "34",
+        "release_date": "2014-04-08",
+        "status": "retired"
+      },
+      {
+        "version": "35",
+        "release_date": "2014-05-20",
+        "status": "retired"
+      },
+      {
+        "version": "36",
+        "release_date": "2014-07-16",
+        "status": "retired"
+      },
+      {
+        "version": "37",
+        "release_date": "2014-08-26",
+        "status": "retired"
+      },
+      {
+        "version": "38",
+        "release_date": "2014-10-07",
+        "status": "retired"
+      },
+      {
+        "version": "39",
+        "release_date": "2014-11-18",
+        "status": "retired"
+      },
+      {
+        "version": "40",
+        "release_date": "2015-01-21",
+        "status": "retired"
+      },
+      {
+        "version": "41",
+        "release_date": "2015-03-03",
+        "status": "retired"
+      },
+      {
+        "version": "42",
+        "release_date": "2015-04-14",
+        "status": "retired"
+      },
+      {
+        "version": "43",
+        "release_date": "2015-05-19",
+        "status": "retired"
+      },
+      {
+        "version": "44",
+        "release_date": "2015-07-21",
+        "status": "retired"
+      },
+      {
+        "version": "45",
+        "release_date": "2015-09-01",
+        "status": "retired"
+      },
+      {
+        "version": "46",
+        "release_date": "2015-10-13",
+        "status": "retired"
+      },
+      {
+        "version": "47",
+        "release_date": "2015-12-01",
+        "status": "retired"
+      },
+      {
+        "version": "48",
+        "release_date": "2016-01-20",
+        "status": "retired"
+      },
+      {
+        "version": "49",
+        "release_date": "2016-03-02",
+        "status": "retired"
+      },
+      {
+        "version": "50",
+        "release_date": "2016-04-13",
+        "status": "retired"
+      },
+      {
+        "version": "51",
+        "release_date": "2016-05-25",
+        "status": "retired"
+      },
+      {
+        "version": "52",
+        "release_date": "2016-07-20",
+        "status": "retired"
+      },
+      {
+        "version": "53",
+        "release_date": "2016-08-31",
+        "status": "retired"
+      },
+      {
+        "version": "54",
+        "release_date": "2016-10-12",
+        "status": "retired"
+      },
+      {
+        "version": "55",
+        "release_date": "2016-12-01",
+        "status": "retired"
+      },
+      {
+        "version": "56",
+        "release_date": "2017-01-25",
+        "status": "retired"
+      },
+      {
+        "version": "57",
+        "release_date": "2017-03-09",
+        "status": "retired"
+      },
+      {
+        "version": "58",
+        "release_date": "2017-04-19",
+        "status": "retired"
+      },
+      {
+        "version": "59",
+        "release_date": "2017-06-05",
+        "status": "retired"
+      },
+      {
+        "version": "60",
+        "release_date": "2017-07-25",
+        "status": "retired"
+      },
+      {
+        "version": "61",
+        "release_date": "2017-09-05",
+        "status": "current"
+      },
+      {
+        "version": "62",
+        "status": "beta"
+      },
+      {
+        "version": "63",
+        "status": "nightly"
+      }
+    ]
+  },
   "firefox": {
     "releases": [
       {

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -253,6 +253,48 @@
       }
     }
   },
+  "edge": {
+    "releases": {
+      "12": {
+        "release_date": "2015-07-15",
+        "status": "retired"
+      },
+      "13": {
+        "release_date": "2015-11-05",
+        "status": "retired"
+      },
+      "14": {
+        "release_date": "2016-08-02",
+        "status": "retired"
+      },
+      "15": {
+        "release_date": "2017-04-11",
+        "status": "current"
+      },
+      "16": {
+        "status": "nightly"
+      }
+    }
+  },
+  "edge_mobile": {
+    "releases": {
+      "12": {
+        "status": "retired"
+      },
+      "13": {
+        "status": "retired"
+      },
+      "14": {
+        "status": "retired"
+      },
+      "15": {
+        "status": "current"
+      },
+      "16": {
+        "status": "nightly"
+      }
+    }
+  },
   "firefox": {
     "releases": {
       "1": {

--- a/browsers/browsers.schema.json
+++ b/browsers/browsers.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+
+  "definitions": {
+
+    "browser_statement": {
+      "type": "object",
+      "properties": {
+        "releases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/release_statement"
+          }
+        }
+      },
+      "required": ["releases"],
+      "additionalProperties": false
+    },
+
+    "release_statement": {
+      "type": "object",
+      "properties": {
+        "version": { "type": "string" },
+        "release_date": { "type": "string", "format": "date" },
+        "release_notes": { "type": "string", "format": "uri" },
+        "status": { "type": "string", "enum": ["retired", "current", "beta", "nightly", "esr", "planned"] }
+      },
+      "required": ["version"],
+      "additionalProperties": false
+    }
+
+  },
+
+  "type": "object",
+    "properties": {
+      "webview_android": { "$ref": "#/definitions/browser_statement" },
+      "chrome": { "$ref": "#/definitions/browser_statement" },
+      "chrome_android": { "$ref": "#/definitions/browser_statement" },
+      "edge": { "$ref": "#/definitions/browser_statement" },
+      "edge_mobile": { "$ref": "#/definitions/browser_statement" },
+      "firefox": { "$ref": "#/definitions/browser_statement" },
+      "firefox_android": { "$ref": "#/definitions/browser_statement" },
+      "ie_mobile": { "$ref": "#/definitions/browser_statement" },
+      "ie": { "$ref": "#/definitions/browser_statement" },
+      "nodejs": { "$ref": "#/definitions/browser_statement" },
+      "opera": { "$ref": "#/definitions/browser_statement" },
+      "opera_android": { "$ref": "#/definitions/browser_statement" },
+      "safari": { "$ref": "#/definitions/browser_statement" },
+      "safari_ios": { "$ref": "#/definitions/browser_statement" }
+    },
+    "additionalProperties": false
+}

--- a/browsers/browsers.schema.json
+++ b/browsers/browsers.schema.json
@@ -7,10 +7,8 @@
       "type": "object",
       "properties": {
         "releases": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/release_statement"
-          }
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/release_statement" }
         }
       },
       "required": ["releases"],
@@ -20,13 +18,14 @@
     "release_statement": {
       "type": "object",
       "properties": {
-        "version": { "type": "string" },
         "release_date": { "type": "string", "format": "date" },
         "release_notes": { "type": "string", "format": "uri" },
-        "status": { "type": "string", "enum": ["retired", "current", "beta", "nightly", "esr", "planned"] }
+        "status": {
+          "type": "string",
+          "enum": ["retired", "current", "beta", "nightly", "esr", "planned"]
+        }
       },
-      "required": ["version"],
-      "additionalProperties": false
+      "required": ["status"]
     }
 
   },

--- a/index.js
+++ b/index.js
@@ -39,4 +39,4 @@ module.exports = load(
   'webextensions'
 );
 
-module.exports.browsers = require('browsers/browsers.json');
+module.exports.browsers = require('./browsers/browsers.json');

--- a/index.js
+++ b/index.js
@@ -38,3 +38,5 @@ module.exports = load(
   'javascript',
   'webextensions'
 );
+
+module.exports.browsers = require('browsers/browsers.json');

--- a/test/lint.js
+++ b/test/lint.js
@@ -48,9 +48,7 @@ if (process.argv[2]) {
 }
 
 console.log('browsers/browsers.json');
-testStyle(__dirname + '/../browsers/browsers.json');
-testSchema(__dirname + '/../browsers/browsers.schema.json', __dirname + '/../browsers/browsers.json');
-
+testSchema('./../browsers/browsers.json', './../browsers/browsers.schema.json');
 
 if (hasErrors) {
   process.exit(1);

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,90 +1,9 @@
 var fs = require('fs');
 var path = require('path');
-var Ajv = require('ajv');
-var ajv = new Ajv({ allErrors: true });
-var hasErrors = false;
-
-function jsonDiff(actual, expected) {
-  var actualLines = actual.split(/\n/);
-  var expectedLines = expected.split(/\n/);
-
-  for (var i = 0; i < actualLines.length; i++) {
-    if (actualLines[i] !== expectedLines[i]) {
-      return [
-        '#' + i + '\x1b[0m',
-        '    Actual:   ' + actualLines[i],
-        '    Expected: ' + expectedLines[i]
-      ].join('\n');
-    }
-  }
-}
-
-function checkStyle(filename) {
-  var actual = fs.readFileSync(filename, 'utf-8').trim();
-  var expected = JSON.stringify(JSON.parse(actual), null, 2);
-
-  var platform = require("os").platform;
-  if (platform() == "win32") { // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, "");
-    expected = expected.replace(/\r/g, "");
-  }
-
-  if (actual === expected) {
-    console.log('\x1b[32m  Style – OK \x1b[0m');
-  } else {
-    hasErrors = true;
-    console.log('\x1b[31m  Style – Error on line ' + jsonDiff(actual, expected));
-  }
-
-  let bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);
-  if (bugzillaMatch) {
-    // use https://bugzil.la/1000000 instead
-    hasErrors = true;
-    console.log('\x1b[33m  Style – Use shortenable URL (%s → https://bugzil.la/%s).\x1b[0m', bugzillaMatch[0],
-      bugzillaMatch[1]);
-  }
-
-  let crbugMatch = actual.match(String.raw`https?://bugs\.chromium\.org/p/chromium/issues/detail\?id=(\d+)`);
-  if (crbugMatch) {
-    // use https://crbug.com/100000 instead
-    hasErrors = true;
-    console.log('\x1b[33m  Style – Use shortenable URL (%s → https://crbug.com/%s).\x1b[0m', crbugMatch[0],
-      crbugMatch[1]);
-  }
-
-  let mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`)
-  if (mdnUrlMatch) {
-    hasErrors = true;
-    console.log(
-      '\x1b[33m  Style – Use non-localized MDN URL (%s → https://developer.mozilla.org/%s).\x1b[0m',
-      mdnUrlMatch[0],
-      mdnUrlMatch[2]);
-  }
-
-  if (actual.includes("href=\\\"")) {
-    hasErrors = true;
-    console.log('\x1b[33m  Style – Found \\\" but expected \' for <a href>.\x1b[0m');
-  }}
-
-function checkSchema(dataFilename) {
-  var schemaFilename = '../compat-data.schema.json';
-  var valid = ajv.validate(
-    require(schemaFilename),
-    require(dataFilename)
-  );
-
-  if (valid) {
-    console.log('\x1b[32m  JSON schema – OK \x1b[0m');
-  } else {
-    hasErrors = true;
-    console.log('\x1b[31m  JSON schema – ' + ajv.errors.length + ' error(s)\x1b[0m');
-    console.log('   ' + ajv.errorsText(ajv.errors, {
-      separator: '\n    ',
-      dataVar: 'item'
-    }));
-  }
-}
-
+var {testStyle} = require('./test-style');
+var {testSchema} = require('./test-schema');
+var {testVersions} = require('./test-versions');
+var hasErrors, hasStyleErrors, hasSchemaErrors, hasVersionErrors = false;
 
 function load(...files) {
   for (let file of files) {
@@ -95,8 +14,12 @@ function load(...files) {
     if (fs.statSync(file).isFile()) {
       if (path.extname(file) === '.json') {
         console.log(file.replace(path.resolve(__dirname, '..') + path.sep, ''));
-        checkStyle(file)
-        checkSchema(file);
+        hasStyleErrors = testStyle(file);
+        hasSchemaErrors = testSchema(file);
+        hasVersionErrors =  testVersions(file);
+        if (hasStyleErrors || hasSchemaErrors || hasVersionErrors) {
+          hasErrors = true;
+        }
       }
 
       continue;
@@ -123,6 +46,11 @@ if (process.argv[2]) {
     'webextensions'
   );
 }
+
+console.log('browsers/browsers.json');
+testStyle(__dirname + '/../browsers/browsers.json');
+testSchema(__dirname + '/../browsers/browsers.schema.json', __dirname + '/../browsers/browsers.json');
+
 
 if (hasErrors) {
   process.exit(1);

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -1,0 +1,23 @@
+var Ajv = require('ajv');
+var ajv = new Ajv({ allErrors: true });
+
+function testSchema(dataFilename, schemaFilename = '../compat-data.schema.json') {
+  var valid = ajv.validate(
+    require(schemaFilename),
+    require(dataFilename)
+  );
+
+  if (valid) {
+    console.log('\x1b[32m  JSON schema – OK \x1b[0m');
+    return false;
+  } else {
+    console.log('\x1b[31m  JSON schema – ' + ajv.errors.length + ' error(s)\x1b[0m');
+    console.log('   ' + ajv.errorsText(ajv.errors, {
+      separator: '\n    ',
+      dataVar: 'item'
+    }));
+    return true;
+  }
+}
+
+module.exports.testSchema = testSchema;

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -1,0 +1,70 @@
+var fs = require('fs');
+var path = require('path');
+var hasErrors = false;
+
+function jsonDiff(actual, expected) {
+  var actualLines = actual.split(/\n/);
+  var expectedLines = expected.split(/\n/);
+
+  for (var i = 0; i < actualLines.length; i++) {
+    if (actualLines[i] !== expectedLines[i]) {
+      return [
+        '#' + i + '\x1b[0m',
+        '    Actual:   ' + actualLines[i],
+        '    Expected: ' + expectedLines[i]
+      ].join('\n');
+    }
+  }
+}
+
+function testStyle(filename) {
+  var actual = fs.readFileSync(filename, 'utf-8').trim();
+  var expected = JSON.stringify(JSON.parse(actual), null, 2);
+
+  var platform = require("os").platform;
+  if (platform() == "win32") { // prevent false positives from git.core.autocrlf on Windows
+    actual = actual.replace(/\r/g, "");
+    expected = expected.replace(/\r/g, "");
+  }
+
+  if (actual === expected) {
+    console.log('\x1b[32m  Style – OK \x1b[0m');
+  } else {
+    hasErrors = true;
+    console.log('\x1b[31m  Style – Error on line ' + jsonDiff(actual, expected));
+  }
+
+  let bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);
+  if (bugzillaMatch) {
+    // use https://bugzil.la/1000000 instead
+    hasErrors = true;
+    console.log('\x1b[33m  Style – Use shortenable URL (%s → https://bugzil.la/%s).\x1b[0m', bugzillaMatch[0],
+      bugzillaMatch[1]);
+  }
+
+  let crbugMatch = actual.match(String.raw`https?://bugs\.chromium\.org/p/chromium/issues/detail\?id=(\d+)`);
+  if (crbugMatch) {
+    // use https://crbug.com/100000 instead
+    hasErrors = true;
+    console.log('\x1b[33m  Style – Use shortenable URL (%s → https://crbug.com/%s).\x1b[0m', crbugMatch[0],
+      crbugMatch[1]);
+  }
+
+  let mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`)
+  if (mdnUrlMatch) {
+    hasErrors = true;
+    console.log(
+      '\x1b[33m  Style – Use non-localized MDN URL (%s → https://developer.mozilla.org/%s).\x1b[0m',
+      mdnUrlMatch[0],
+      mdnUrlMatch[2]);
+  }
+
+  if (actual.includes("href=\\\"")) {
+    hasErrors = true;
+    console.log('\x1b[33m  Style – Found \\\" but expected \' for <a href>.\x1b[0m');
+  }
+
+  return hasErrors;
+}
+
+module.exports.testStyle = testStyle;

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -22,7 +22,7 @@ function testStyle(filename) {
   var expected = JSON.stringify(JSON.parse(actual), null, 2);
 
   var platform = require("os").platform;
-  if (platform() == "win32") { // prevent false positives from git.core.autocrlf on Windows
+  if (platform() === "win32") { // prevent false positives from git.core.autocrlf on Windows
     actual = actual.replace(/\r/g, "");
     expected = expected.replace(/\r/g, "");
   }

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -1,0 +1,56 @@
+var browsers = require('./../browsers/browsers.json');
+
+var validBrowserVersions = {};
+for (let browser of Object.keys(browsers)) {
+  validBrowserVersions[browser] = [];
+  for (let release of browsers[browser].releases) {
+     validBrowserVersions[browser].push(release.version);
+  }
+}
+
+
+function testVersions(dataFilename) {
+  var hasErrors = false;
+  var data = require(dataFilename);
+
+  function checkVersions(supportData) {
+    var browsersToCheck = Object.keys(supportData);
+    for (let browser of browsersToCheck) {
+      if (validBrowserVersions[browser]) {
+        if (typeof supportData[browser].version_added === "string" &&
+            !validBrowserVersions[browser].includes(supportData[browser].version_added)) {
+          console.log('\x1b[31m  version_added: "' + supportData[browser].version_added + '" is not a valid version number for ' + browser);
+          hasErrors = true;
+        }
+        if (typeof supportData[browser].version_removed === "string" &&
+            !validBrowserVersions[browser].includes(supportData[browser].version_removed)) {
+          console.log('\x1b[31m  version_removed: "' + supportData[browser].version_removed + '" is not a valid version number for ' + browser);
+          hasErrors = true;
+        }
+      }
+    }
+  }
+
+  function findSupport(data) {
+    for (var prop in data) {
+      if (prop === 'support') {
+        checkVersions(data[prop]);
+      }
+      var sub = data[prop];
+      if (typeof(sub) == "object") {
+        findSupport(sub);
+      }
+    }
+  }
+  findSupport(data);
+
+  if (hasErrors) {
+    console.log('\x1b[31m  Browser version error(s)\x1b[0m');
+    return true;
+  } else {
+    console.log('\x1b[32m  Browser versions – OK \x1b[0m');
+    return false;
+  }
+}
+
+module.exports.testVersions = testVersions;

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -2,10 +2,7 @@ var browsers = require('./../browsers/browsers.json');
 
 var validBrowserVersions = {};
 for (let browser of Object.keys(browsers)) {
-  validBrowserVersions[browser] = [];
-  for (let release of browsers[browser].releases) {
-     validBrowserVersions[browser].push(release.version);
-  }
+  validBrowserVersions[browser] = Object.keys(browsers[browser].releases);
 }
 
 

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -34,7 +34,7 @@ function testVersions(dataFilename) {
         checkVersions(data[prop]);
       }
       var sub = data[prop];
-      if (typeof(sub) == "object") {
+      if (typeof(sub) === "object") {
         findSupport(sub);
       }
     }


### PR DESCRIPTION
This PR does a few things:

* Add data about browsers
* Export browser data as part of the package (we want the compat.ejs macro to be able use this data, too)
* Split testing into different files for schema, style, versions (I think it is more readable this way)
* Validate browsers.json data against an own browsers json schema.
* Validate version_added/version_remove against valid releases from the browsers.json data.

I did not yet fix the data. Travis shows you how the current data throws errors https://travis-ci.org/mdn/browser-compat-data/builds/282374070

* Regarding the browser data there is the question if we want firefox_android's first version to be "4" or if we would allow "1". Maemo is cited as "1" and I think it is something different than what we have today. In that case, most of our "1" firefox_android would become "4". https://en.wikipedia.org/wiki/Firefox_for_Android#Release_history