### PR TITLE
Add data for proxyInfo; split out all 'details' properties

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -11348,6 +11348,323 @@
                 }
               }
             }
+          },
+          "details": {
+            "challenger": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "isProxy": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "realm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "responseHeaders": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "scheme": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusCode": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusLine": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
           }
         },
         "onBeforeRedirect": {
@@ -11370,23 +11687,340 @@
               }
             }
           },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+          "details": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "fromCache": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "ip": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "redirectUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "responseHeaders": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusCode": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusLine": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -11427,65 +12061,256 @@
               }
             }
           },
-          "requestBody": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "53"
-                },
-                "firefox_android": {
-                  "version_added": "53"
-                },
-                "opera": {
-                  "version_added": true
+          "details": {
+            "frameAncestors": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "58"
+                  },
+                  "firefox_android": {
+                    "version_added": "58"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
                 }
               }
-            }
-          },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+            },
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
-            }
-          },
-          "frameAncestors": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "58"
-                },
-                "firefox_android": {
-                  "version_added": "58"
-                },
-                "opera": {
-                  "version_added": false
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "requestBody": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53"
+                  },
+                  "firefox_android": {
+                    "version_added": "53"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -11526,23 +12351,235 @@
               }
             }
           },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+          "details": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "requestHeaders": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "53"
+                  },
+                  "firefox_android": {
+                    "version_added": "53"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -11568,23 +12605,319 @@
               }
             }
           },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+          "details": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "fromCache": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "ip": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "responseHeaders": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusCode": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusLine": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -11610,23 +12943,277 @@
               }
             }
           },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+          "details": {
+            "error": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "fromCache": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "ip": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -11669,23 +13256,277 @@
               }
             }
           },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+          "details": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "responseHeaders": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusCode": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusLine": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -11711,23 +13552,319 @@
               }
             }
           },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+          "details": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "fromCache": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "ip": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "responseHeaders": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusCode": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "statusLine": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }
@@ -11753,23 +13890,235 @@
               }
             }
           },
-          "originUrl": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
+          "details": {
+            "frameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "method": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "parentFrameId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "proxyInfo": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": "57"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "requestId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "requestHeaders": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "tabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "timeStamp": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "type": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1373646 adds a `proxyInfo` property to the `details` object that gets passed in to [webRequest](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest) listeners.

This PR adds that under a new `details` subfeature.

It also moves other things, like `originUrl`, under `details`, where before we put them directly under the listener. I think this should make it clearer exactly which bit of the API something like `originUrl` is attached to, and this only became possible since we had the more flexible schema.

For good measure, this PR also explicitly enumerates *all* the properties of `details`, rather than bundling implicit support into the higher-level `__compat`.
