### PR TITLE
Add data for 2 new browserSettings settings

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1323,6 +1323,48 @@
               }
             }
           }
+        },
+        "homepageOverride": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": "57"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "newTabPageOverride": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": "57"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       },
       "commands": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1322308 adds support for two new settings, `homepageOverride` and `newTabPageOverride`:

https://hg.mozilla.org/mozilla-central/diff/9ea423e0e3e1/toolkit/components/extensions/schemas/browser_settings.json

I haven't written the docs pages yet.