### PR TITLE
Firefox for Android 57 supports runtime.openOptionsPage

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -7296,7 +7296,7 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "opera": {
                 "version_added": "29"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1364945 means Firefox for Android supports [runtime.openOptionsPage](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/openOptionsPage) from version 57.