### PR TITLE
Add data for BookmarkTreeNodeType

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -170,6 +170,48 @@
                 "version_added": true
               }
             }
+          },
+          "type": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "BookmarkTreeNodeType": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
           }
         },
         "BookmarkTreeNodeUnmodifiable": {
@@ -210,6 +252,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1293853 adds support for a new type, `BookmarkTreeNodeType`, which is added as the `type` property to [`CreateDetails`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/bookmarks/CreateDetails) and [`BookmarkTreeNode`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode):

https://hg.mozilla.org/mozilla-central/diff/89c9b17b0cfc/browser/components/extensions/schemas/bookmarks.json

I haven't updated the docs pages yet.
