### PR TITLE
Add loadReplace; refactor tabs.update data

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -9915,133 +9915,198 @@
               }
             }
           },
-          "pinned": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": true
+          "updateProperties": {
+            "active": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
-            }
-          },
-          "muted": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "45"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "32"
+            },
+            "autoDiscardable": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "54"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "41"
+                  }
                 }
               }
-            }
-          },
-          "highlighted": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
+            },
+            "highlighted": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
-            }
-          },
-          "selected": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
-            }
-          },
-          "openerTabId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "18"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "15"
+            },
+            "loadReplace": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
                 }
               }
-            }
-          },
-          "autoDiscardable": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "54"
+            },
+            "muted": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "45"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "32"
+                  }
+                }
+              }
+            },
+            "openerTabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              }
+            },
+            "pinned": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "selected": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "41"
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1397383 adds a `loadReplace` option to the `updateProperties` argument given to [`tabs.update`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/update):

https://hg.mozilla.org/mozilla-central/diff/442345c31f98/browser/components/extensions/schemas/tabs.json

This PR adds that, and also splits out all the other bits of `updateProperties`. Some were already split out, but I've now put them explicitly under `updateProperties`.

I'm liking the new more flexible schema :).
