### PR TITLE
Remove trailing ".0" in version numbers

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "33.0"
+            "version_added": "33"
           },
           "firefox_android": {
             "version_added": null
@@ -70,7 +70,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "33.0"
+              "version_added": "33"
             },
             "firefox_android": {
               "version_added": null
@@ -121,7 +121,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "33.0"
+              "version_added": "33"
             },
             "firefox_android": {
               "version_added": null
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "33.0"
+              "version_added": "33"
             },
             "firefox_android": {
               "version_added": null

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "33.0"
+            "version_added": "33"
           },
           "firefox_android": {
             "version_added": null

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "49.0"
+            "version_added": "49"
           },
           "firefox_android": {
             "version_added": null

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "30.0"
+            "version_added": "30"
           },
           "firefox_android": {
             "version_added": null

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": false
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -223,7 +223,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -325,7 +325,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -376,7 +376,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -427,7 +427,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "30.0"
+            "version_added": "30"
           },
           "firefox_android": {
             "version_added": null

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "28.0"
+            "version_added": "28"
           },
           "firefox_android": {
             "version_added": null

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "50.0"
+            "version_added": "50"
           },
           "firefox_android": {
             "version_added": null

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "17.0"
+            "version_added": "17"
           },
           "firefox_android": {
             "version_added": null

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "24.0"
+            "version_added": "24"
           },
           "firefox_android": {
             "version_added": null

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "10.0"
+            "version_added": "10"
           },
           "firefox_android": {
             "version_added": null

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "6.0"
+            "version_added": "6"
           },
           "firefox_android": {
             "version_added": null

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "24.0"
+            "version_added": "24"
           },
           "firefox_android": {
             "version_added": null

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "29.0"
+            "version_added": "29"
           },
           "firefox_android": {
             "version_added": null

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "30.0"
+            "version_added": "30"
           },
           "firefox_android": {
             "version_added": null

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "25.0"
+            "version_added": "25"
           },
           "firefox_android": {
             "version_added": null
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25.0"
+              "version_added": "25"
             },
             "firefox_android": {
               "version_added": null
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25.0"
+              "version_added": "25"
             },
             "firefox_android": {
               "version_added": null
@@ -172,7 +172,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25.0"
+              "version_added": "25"
             },
             "firefox_android": {
               "version_added": null
@@ -223,7 +223,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25.0"
+              "version_added": "25"
             },
             "firefox_android": {
               "version_added": null

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "30.0"
+            "version_added": "30"
           },
           "firefox_android": {
             "version_added": null
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "30.0"
+              "version_added": "30"
             },
             "firefox_android": {
               "version_added": null

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -20,10 +20,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "53.0"
+            "version_added": "53"
           },
           "firefox_android": {
-            "version_added": "53.0"
+            "version_added": "53"
           },
           "ie": {
             "version_added": null
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "53.0"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "53.0"
+              "version_added": "53"
             },
             "ie": {
               "version_added": null

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "18.0"
+            "version_added": "18"
           },
           "firefox_android": {
             "version_added": null

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": null

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "30.0"
+            "version_added": "30"
           },
           "firefox_android": {
             "version_added": null

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "18.0"
+            "version_added": "18"
           },
           "firefox_android": {
             "version_added": null

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -22,11 +22,11 @@
           "firefox": [
             {
               "prefix": "MOZ_",
-              "version_added": "15.0",
-              "version_removed": "21.0"
+              "version_added": "15",
+              "version_removed": "21"
             },
             {
-              "version_added": "22.0"
+              "version_added": "22"
             }
           ],
           "firefox_android": {

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -22,7 +22,7 @@
           "firefox": [
             {
               "version_added": true,
-              "version_removed": "53.0",
+              "version_removed": "53",
               "flag": {
                 "type": "preference",
                 "name": "webgl.enable-debug-renderer-info",
@@ -30,7 +30,7 @@
               }
             },
             {
-              "version_added": "53.0"
+              "version_added": "53"
             }
           ],
           "firefox_android": {

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "30.0",
+            "version_added": "30",
             "flag": {
               "type": "preference",
               "name": "webgl.enable-privileged-extensions",
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "30.0",
+              "version_added": "30",
               "flag": {
                 "type": "preference",
                 "name": "webgl.enable-privileged-extensions",

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -23,10 +23,10 @@
             {
               "prefix": "MOZ_",
               "version_added": true,
-              "version_removed": "22.0"
+              "version_removed": "22"
             },
             {
-              "version_added": "22.0"
+              "version_added": "22"
             }
           ],
           "firefox_android": {

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -23,7 +23,7 @@
             {
               "prefix": "MOZ_",
               "version_added": true,
-              "version_removed": "28.0",
+              "version_removed": "28",
               "flag": {
                 "type": "preference",
                 "name": "webgl.enable-draft-extensions",
@@ -31,7 +31,7 @@
               }
             },
             {
-              "version_added": "28.0"
+              "version_added": "28"
             }
           ],
           "firefox_android": {
@@ -85,7 +85,7 @@
               {
                 "prefix": "MOZ_",
                 "version_added": true,
-                "version_removed": "28.0",
+                "version_removed": "28",
                 "flag": {
                   "type": "preference",
                   "name": "webgl.enable-draft-extensions",
@@ -93,7 +93,7 @@
                 }
               },
               {
-                "version_added": "28.0"
+                "version_added": "28"
               }
             ],
             "firefox_android": {

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -22,11 +22,11 @@
           "firefox": [
             {
               "prefix": "MOZ_",
-              "version_added": "19.0",
-              "version_removed": "22.0"
+              "version_added": "19",
+              "version_removed": "22"
             },
             {
-              "version_added": "22.0"
+              "version_added": "22"
             }
           ],
           "firefox_android": {
@@ -79,11 +79,11 @@
             "firefox": [
               {
                 "prefix": "MOZ_",
-                "version_added": "19.0",
-                "version_removed": "22.0"
+                "version_added": "19",
+                "version_removed": "22"
               },
               {
-                "version_added": "22.0"
+                "version_added": "22"
               }
             ],
             "firefox_android": {
@@ -137,11 +137,11 @@
             "firefox": [
               {
                 "prefix": "MOZ_",
-                "version_added": "19.0",
-                "version_removed": "22.0"
+                "version_added": "19",
+                "version_removed": "22"
               },
               {
-                "version_added": "22.0"
+                "version_added": "22"
               }
             ],
             "firefox_android": {

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": false
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -223,7 +223,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -325,7 +325,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -376,7 +376,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -427,7 +427,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -478,7 +478,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -529,7 +529,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -580,7 +580,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -631,7 +631,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -682,7 +682,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -733,7 +733,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -784,7 +784,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -835,7 +835,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -886,7 +886,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -937,7 +937,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -988,7 +988,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1039,7 +1039,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1090,7 +1090,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1141,7 +1141,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1192,7 +1192,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1243,7 +1243,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1294,7 +1294,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1345,7 +1345,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1396,7 +1396,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1447,7 +1447,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1498,7 +1498,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1549,7 +1549,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1600,7 +1600,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1651,7 +1651,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1702,7 +1702,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1753,7 +1753,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1804,7 +1804,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1855,7 +1855,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1906,7 +1906,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -1957,7 +1957,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2008,7 +2008,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2059,7 +2059,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2110,7 +2110,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2161,7 +2161,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2212,7 +2212,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2263,7 +2263,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2314,7 +2314,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2365,7 +2365,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2416,7 +2416,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2467,7 +2467,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2518,7 +2518,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2569,7 +2569,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2620,7 +2620,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2671,7 +2671,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2722,7 +2722,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2773,7 +2773,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2824,7 +2824,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2875,7 +2875,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2926,7 +2926,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -2977,7 +2977,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3028,7 +3028,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3079,7 +3079,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3130,7 +3130,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3181,7 +3181,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3232,7 +3232,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3283,7 +3283,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3334,7 +3334,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3385,7 +3385,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3436,7 +3436,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3487,7 +3487,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3538,7 +3538,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3589,7 +3589,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3640,7 +3640,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3691,7 +3691,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3742,7 +3742,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3793,7 +3793,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3844,7 +3844,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3895,7 +3895,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3946,7 +3946,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -3997,7 +3997,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4048,7 +4048,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4099,7 +4099,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4150,7 +4150,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4201,7 +4201,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4252,7 +4252,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4303,7 +4303,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4354,7 +4354,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4405,7 +4405,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4456,7 +4456,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4507,7 +4507,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4558,7 +4558,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4609,7 +4609,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4660,7 +4660,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4711,7 +4711,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4762,7 +4762,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4813,7 +4813,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4864,7 +4864,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4915,7 +4915,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -4966,7 +4966,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -5017,7 +5017,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false
@@ -5068,7 +5068,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51.0"
+              "version_added": "51"
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",
@@ -126,7 +126,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -177,7 +177,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -228,7 +228,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",

--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": false

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -26,7 +26,7 @@
             ]
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",
@@ -138,7 +138,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -189,7 +189,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -240,7 +240,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -291,7 +291,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -340,10 +340,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -392,7 +392,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -441,10 +441,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -493,7 +493,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -544,7 +544,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -593,10 +593,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -645,7 +645,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -696,7 +696,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -745,10 +745,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -797,7 +797,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -846,10 +846,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -898,7 +898,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -949,7 +949,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1000,7 +1000,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1049,10 +1049,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -1101,7 +1101,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1150,10 +1150,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -1202,7 +1202,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1251,7 +1251,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "44.0",
+                "version_added": "44",
                 "flag": {
                   "type": "preference",
                   "name": "gfx.offscreencanvas.enabled",
@@ -1308,7 +1308,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1357,10 +1357,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -1409,7 +1409,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1460,7 +1460,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1511,7 +1511,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1562,7 +1562,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1613,7 +1613,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1664,7 +1664,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",
@@ -1720,7 +1720,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1771,7 +1771,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1820,10 +1820,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -1872,7 +1872,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -1921,10 +1921,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -1973,7 +1973,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2024,7 +2024,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2075,7 +2075,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2126,7 +2126,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2177,7 +2177,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2228,7 +2228,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2279,7 +2279,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2330,7 +2330,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2381,7 +2381,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2432,7 +2432,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2483,7 +2483,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2534,7 +2534,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2585,7 +2585,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2636,7 +2636,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2687,7 +2687,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2738,7 +2738,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2789,7 +2789,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2840,7 +2840,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2891,7 +2891,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2942,7 +2942,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -2993,7 +2993,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3044,7 +3044,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3095,7 +3095,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3146,7 +3146,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3197,7 +3197,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3248,7 +3248,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3299,7 +3299,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3350,7 +3350,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3401,7 +3401,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3452,7 +3452,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3501,10 +3501,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -3553,7 +3553,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3602,10 +3602,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -3654,7 +3654,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3705,7 +3705,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3754,10 +3754,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -3806,7 +3806,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3857,7 +3857,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3908,7 +3908,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -3959,7 +3959,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4010,7 +4010,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4059,10 +4059,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -4111,7 +4111,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4162,7 +4162,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4213,7 +4213,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4264,7 +4264,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4313,10 +4313,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -4365,7 +4365,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4416,7 +4416,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4467,7 +4467,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4516,10 +4516,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -4568,7 +4568,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4617,10 +4617,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -4669,7 +4669,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4720,7 +4720,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4771,7 +4771,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4822,7 +4822,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4873,7 +4873,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4924,7 +4924,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -4973,10 +4973,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -5025,7 +5025,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5074,10 +5074,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -5126,7 +5126,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5177,7 +5177,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5226,10 +5226,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -5278,7 +5278,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5329,7 +5329,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5380,7 +5380,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5431,7 +5431,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5482,7 +5482,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5531,10 +5531,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -5583,7 +5583,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5634,7 +5634,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5685,7 +5685,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5736,7 +5736,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5787,7 +5787,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5889,7 +5889,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5940,7 +5940,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -5989,10 +5989,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -6041,7 +6041,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6092,7 +6092,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6141,10 +6141,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -6193,7 +6193,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6242,10 +6242,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -6294,7 +6294,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6345,7 +6345,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6396,7 +6396,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6447,7 +6447,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6498,7 +6498,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6549,7 +6549,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6600,7 +6600,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6651,7 +6651,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6702,7 +6702,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6753,7 +6753,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6802,10 +6802,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -6854,7 +6854,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -6903,10 +6903,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -6955,7 +6955,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7004,10 +7004,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -7056,7 +7056,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7105,10 +7105,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -7157,7 +7157,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7208,7 +7208,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7259,7 +7259,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7310,7 +7310,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7361,7 +7361,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7412,7 +7412,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7463,7 +7463,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7514,7 +7514,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7565,7 +7565,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7616,7 +7616,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7667,7 +7667,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7718,7 +7718,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7769,7 +7769,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7820,7 +7820,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7871,7 +7871,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7922,7 +7922,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -7973,7 +7973,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8022,10 +8022,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -8074,7 +8074,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8123,10 +8123,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -8175,7 +8175,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8224,10 +8224,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": "51.0"
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false
@@ -8276,7 +8276,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8327,7 +8327,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8378,7 +8378,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8429,7 +8429,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8480,7 +8480,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8531,7 +8531,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8582,7 +8582,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8633,7 +8633,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8684,7 +8684,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8735,7 +8735,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8786,7 +8786,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true
@@ -8837,7 +8837,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": false

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",
@@ -127,7 +127,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -178,7 +178,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -229,7 +229,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": false

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",

--- a/api/WebGLTransformFeedback.json
+++ b/api/WebGLTransformFeedback.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": false

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4.0"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44.0",
+              "version_added": "44",
               "flag": {
                 "type": "preference",
                 "name": "gfx.offscreencanvas.enabled",

--- a/api/WebGLVertexArrayObject.json
+++ b/api/WebGLVertexArrayObject.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51.0"
+            "version_added": "51"
           },
           "firefox_android": {
             "version_added": false

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "25.0"
+            "version_added": "25"
           },
           "firefox_android": {
             "version_added": null

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "4"
@@ -36,10 +36,10 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "3.2"
@@ -59,7 +59,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -77,7 +77,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -86,7 +86,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "safari": {
                 "version_added": "1.3"
@@ -110,7 +110,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -128,7 +128,7 @@
                 "version_added": "25"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -140,7 +140,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "5.0"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": null

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -9,7 +9,7 @@
               "version_added": "4.1"
             },
             "chrome": {
-              "version_added": "1.0",
+              "version_added": "1",
               "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "chrome_android": {
@@ -22,14 +22,14 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0",
+              "version_added": "4",
               "notes": "Gecko supported, from version 1.1 to version 1.9.2, corresponding to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
             },
             "firefox_android": {
-              "version_added": "14.0"
+              "version_added": "14"
             },
             "ie": {
-              "version_added": "9.0",
+              "version_added": "9",
               "notes": "In IE 7 and IE 8 of Internet Explorer, this property always behaved like <code>background-clip: padding</code> when <code>overflow</code> was <code>hidden</code>, <code>auto</code>, or <code>scroll</code>."
             },
             "ie_mobile": {
@@ -42,7 +42,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "3.0",
+              "version_added": "3",
               "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "safari_ios": {
@@ -63,7 +63,7 @@
                 "version_added": "4.1"
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -75,14 +75,14 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "4.0",
+                "version_added": "4",
                 "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
               },
               "firefox_android": {
-                "version_added": "14.0"
+                "version_added": "14"
               },
               "ie": {
-                "version_added": "9.0",
+                "version_added": "9",
                 "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>"
               },
               "ie_mobile": {
@@ -95,7 +95,7 @@
                 "version_added": "12.1"
               },
               "safari": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "safari_ios": {
                 "version_added": true
@@ -137,11 +137,11 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "49.0",
+                "version_added": "49",
                 "notes": "In Firefox 48, it was not activated by default and its support could be activated by setting <code>layout.css.background-clip-text.enabled</code> pref to <code>true</code>."
               },
               "firefox_android": {
-                "version_added": "49.0",
+                "version_added": "49",
                 "notes": "In Firefox 48, it was not activated by default and its support could be activated by setting <code>layout.css.background-clip-text.enabled</code> pref to <code>true</code>."
               },
               "ie": {

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -21,13 +21,13 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
-              "version_added": "4.0",
+              "version_added": "4",
               "notes": "In Internet Explorer 8 and 9, there is a bug where a computed <code>background-color</code> of <code>transparent</code> causes <code>click</code> events to not get fired on overlaid elements."
             },
             "ie_mobile": {
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": true
@@ -57,13 +57,13 @@
             "description": "Alpha channel for hex values",
             "support": {
               "webview_android": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "chrome": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "chrome_android": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "edge": {
                 "version_added": false

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0",
+              "version_added": "1",
               "notes": [
                 "If the <code>browser.display.use_document_colors</code> user preference in <code>about:config</code> is set to <code>false</code>, background images will not be displayed."
               ]
@@ -42,7 +42,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": true
@@ -62,7 +62,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -80,7 +80,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -113,7 +113,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0",
+                "version_added": "1",
                 "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               },
               "chrome_android": {
@@ -149,7 +149,7 @@
                 "notes": "Some versions support only experimental gradients prefixed with <code>-o</code>."
               },
               "safari": {
-                "version_added": "4.0",
+                "version_added": "4",
                 "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               },
               "safari_ios": {
@@ -172,7 +172,7 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": "8.0"
+                "version_added": "8"
               },
               "chrome_android": {
                 "version_added": true
@@ -184,13 +184,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "4.0"
+                "version_added": "4"
               },
               "firefox_android": {
                 "version_added": true
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -202,11 +202,11 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "5.0",
+                "version_added": "5",
                 "notes": "Support of SVG in CSS background is incomplete."
               },
               "safari_ios": {
-                "version_added": "5.0",
+                "version_added": "5",
                 "notes": "Support of SVG in CSS background is incomplete."
               }
             },

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -9,7 +9,7 @@
               "version_added": "4.1"
             },
             "chrome": {
-              "version_added": "1.0",
+              "version_added": "1",
               "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "chrome_android": {
@@ -22,17 +22,17 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0",
+              "version_added": "4",
               "notes": [
                 "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>.",
                 "Since Firefox 49, also supports the <code>-webkit</code> prefixed version of the property."
               ]
             },
             "firefox_android": {
-              "version_added": "14.0"
+              "version_added": "14"
             },
             "ie": {
-              "version_added": "9.0",
+              "version_added": "9",
               "notes": "In IE 7 and before, Internet explorer was behaving as if <code>background-origin: border-box</code> was set. In Internet Explorer 8, as if <code>background-origin: padding-box</code>, the regular default value, was set."
             },
             "ie_mobile": {
@@ -45,7 +45,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "3.0",
+              "version_added": "3",
               "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "safari_ios": {
@@ -66,7 +66,7 @@
                 "version_added": "4.1"
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -78,14 +78,14 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "4.0",
+                "version_added": "4",
                 "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
               },
               "firefox_android": {
-                "version_added": "14.0"
+                "version_added": "14"
               },
               "ie": {
-                "version_added": "9.0",
+                "version_added": "9",
                 "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>."
               },
               "ie_mobile": {
@@ -98,7 +98,7 @@
                 "version_added": "12.1"
               },
               "safari": {
-                "version_added": "3.0",
+                "version_added": "3",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               },
               "safari_ios": {

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "49.0"
+              "version_added": "49"
             },
             "firefox_android": {
-              "version_added": "49.0"
+              "version_added": "49"
             },
             "ie": {
               "version_added": "6"
@@ -71,13 +71,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "firefox_android": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": null

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "49.0"
+              "version_added": "49"
             },
             "firefox_android": {
-              "version_added": "49.0"
+              "version_added": "49"
             },
             "ie": {
               "version_added": "6"
@@ -71,13 +71,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "firefox_android": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": null

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": true
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": true
@@ -59,7 +59,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -77,7 +77,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -110,7 +110,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "25.0"
+                "version_added": "25"
               },
               "chrome_android": {
                 "version_added": true
@@ -122,13 +122,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "13.0"
+                "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13.0"
+                "version_added": "13"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -140,7 +140,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "7.0"
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": true

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -9,7 +9,7 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": null
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "4"
@@ -39,7 +39,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": null
@@ -59,7 +59,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": null
@@ -122,13 +122,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "13.0"
+                "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13.0"
+                "version_added": "13"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": null
@@ -173,13 +173,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "firefox_android": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": null

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -11,11 +11,11 @@
             "chrome": [
               {
                 "prefix": "-webkit-",
-                "version_added": "1.0",
+                "version_added": "1",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               },
               {
-                "version_added": "3.0",
+                "version_added": "3",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               }
             ],
@@ -38,24 +38,24 @@
                 "version_added": "49"
               },
               {
-                "version_added": "4.0"
+                "version_added": "4"
               }
             ],
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": "1.0"
+                "version_added": "1"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
               },
               {
-                "version_added": "4.0"
+                "version_added": "4"
               }
             ],
             "ie": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "ie_mobile": {
               "version_added": true
@@ -76,7 +76,7 @@
             "safari": [
               {
                 "prefix": "-webkit-",
-                "version_added": "3.0",
+                "version_added": "3",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               },
               {
@@ -101,7 +101,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "chrome_android": {
                 "version_added": null
@@ -122,10 +122,10 @@
                 "version_added": "9"
               },
               "ie_mobile": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "opera": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "opera_android": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": "44.0"
+                "version_added": "44"
               },
               "chrome_android": {
                 "version_added": null
@@ -164,19 +164,19 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "8.0"
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8.0"
+                "version_added": "8"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": null
               },
               "opera": {
-                "version_added": "31.0"
+                "version_added": "31"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -9,7 +9,7 @@
               "version_added": "2.1"
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": null
@@ -21,25 +21,25 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "4"
             },
             "ie_mobile": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "5.0"
+              "version_added": "5"
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "3.2"
@@ -59,7 +59,7 @@
                 "version_added": "2.1"
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": null
@@ -74,13 +74,13 @@
                 "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": "9"
               },
               "ie_mobile": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "opera": {
                 "version_added": "10.5"
@@ -107,10 +107,10 @@
             "description": "SVG image as background",
             "support": {
               "webview_android": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "chrome": {
-                "version_added": "31.0"
+                "version_added": "31"
               },
               "chrome_android": {
                 "version_added": null
@@ -122,19 +122,19 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "firefox_android": {
-                "version_added": "4.0"
+                "version_added": "4"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "opera": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "opera_android": {
                 "version_added": true
@@ -158,10 +158,10 @@
             "description": "Values of <code>background-size</code> longhand",
             "support": {
               "webview_android": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "chrome": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "chrome_android": {
                 "version_added": null
@@ -173,19 +173,19 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "firefox_android": {
-                "version_added": "18.0"
+                "version_added": "18"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "opera": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "opera_android": {
                 "version_added": true
@@ -194,7 +194,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "4.0"
+                "version_added": "4"
               }
             },
             "status": {
@@ -209,10 +209,10 @@
             "description": "Values of <code>background-origin</code> longhand",
             "support": {
               "webview_android": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "chrome": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "chrome_android": {
                 "version_added": null
@@ -224,19 +224,19 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "22.0"
+                "version_added": "22"
               },
               "firefox_android": {
-                "version_added": "22.0"
+                "version_added": "22"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "opera": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "opera_android": {
                 "version_added": false
@@ -245,7 +245,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "4.0"
+                "version_added": "4"
               }
             },
             "status": {
@@ -260,10 +260,10 @@
             "description": "Values of <code>background-clip</code> longhand",
             "support": {
               "webview_android": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "chrome": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "chrome_android": {
                 "version_added": null
@@ -275,19 +275,19 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "22.0"
+                "version_added": "22"
               },
               "firefox_android": {
-                "version_added": "22.0"
+                "version_added": "22"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
-                "version_added": "10.0"
+                "version_added": "10"
               },
               "opera": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "opera_android": {
                 "version_added": false
@@ -296,7 +296,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "4.0"
+                "version_added": "4"
               }
             },
             "status": {

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -10,8 +10,8 @@
             },
             "chrome": [
               {
-                "version_added": "35.0",
-                "version_removed": "47.0",
+                "version_added": "35",
+                "version_removed": "47",
                 "flag": {
                   "type": "preference",
                   "name": "Enable Experimental Web Platform Features",
@@ -19,13 +19,13 @@
                 }
               },
               {
-                "version_added": "47.0"
+                "version_added": "47"
               }
             ],
             "chrome_android": [
               {
-                "version_added": "35.0",
-                "version_removed": "47.0",
+                "version_added": "35",
+                "version_removed": "47",
                 "flag": {
                   "type": "preference",
                   "name": "Enable Experimental Web Platform Features",
@@ -33,7 +33,7 @@
                 }
               },
               {
-                "version_added": "47.0"
+                "version_added": "47"
               }
             ],
             "edge": {
@@ -45,21 +45,21 @@
             "firefox": [
               {
                 "prefix": "-moz-",
-                "version_added": "12.0",
-                "version_removed": "53.0"
+                "version_added": "12",
+                "version_removed": "53"
               },
               {
-                "version_added": "49.0"
+                "version_added": "49"
               }
             ],
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": "12.0",
-                "version_removed": "53.0"
+                "version_added": "12",
+                "version_removed": "53"
               },
               {
-                "version_added": "49.0"
+                "version_added": "49"
               }
             ],
             "ie": {

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -29,7 +29,7 @@
                 "version_added": true
               },
               {
-                "version_added": "50.0"
+                "version_added": "50"
               }
             ],
             "firefox_android": [
@@ -38,7 +38,7 @@
                 "version_added": true
               },
               {
-                "version_added": "50.0"
+                "version_added": "50"
               }
             ],
             "ie": {

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": true,
@@ -71,10 +71,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -121,10 +121,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "4.0"
+                  "version_added": "4"
                 },
                 "firefox_android": {
-                  "version_added": "4.0"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": true

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": true
@@ -58,7 +58,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -70,10 +70,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -70,10 +70,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/keygen.json
+++ b/html/elements/keygen.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "3.0"
+              "version_added": "3"
             },
             "opera_android": {
               "version_added": null

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": true
@@ -58,7 +58,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -70,10 +70,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -108,7 +108,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": "25.0"
+                "version_added": "25"
               },
               "chrome_android": {
                 "version_added": true
@@ -120,10 +120,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "18.0"
+                "version_added": "18"
               },
               "firefox_android": {
-                "version_added": "18.0"
+                "version_added": "18"
               },
               "ie": {
                 "version_added": false
@@ -132,7 +132,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "15.0"
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null
@@ -208,7 +208,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -220,10 +220,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -258,7 +258,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -270,10 +270,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -305,13 +305,13 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "45.0"
+                "version_added": "45"
               },
               "chrome": {
-                "version_added": "45.0"
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": "45.0"
+                "version_added": "45"
               },
               "edge": {
                 "version_added": false
@@ -358,7 +358,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -370,10 +370,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -426,10 +426,10 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": "4.0"
+                "version_added": "4"
               },
               "ie_mobile": {
-                "version_added": "4.0"
+                "version_added": "4"
               },
               "opera": {
                 "version_added": false
@@ -455,13 +455,13 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "56.0"
+                "version_added": "56"
               },
               "chrome": {
-                "version_added": "56.0"
+                "version_added": "56"
               },
               "chrome_android": {
-                "version_added": "56.0"
+                "version_added": "56"
               },
               "edge": {
                 "version_added": null
@@ -482,10 +482,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "43.0"
+                "version_added": "43"
               },
               "opera_android": {
-                "version_added": "43.0"
+                "version_added": "43"
               },
               "safari": {
                 "version_added": null
@@ -505,13 +505,13 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "58.0"
+                "version_added": "58"
               },
               "chrome": {
-                "version_added": "58.0"
+                "version_added": "58"
               },
               "chrome_android": {
-                "version_added": "58.0"
+                "version_added": "58"
               },
               "edge": {
                 "version_added": false
@@ -520,10 +520,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "50.0"
+                "version_added": "50"
               },
               "firefox_android": {
-                "version_added": "50.0"
+                "version_added": "50"
               },
               "ie": {
                 "version_added": null
@@ -558,7 +558,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -570,10 +570,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -620,10 +620,10 @@
                   "version_added": null
                 },
                 "firefox": {
-                  "version_added": "3.0"
+                  "version_added": "3"
                 },
                 "firefox_android": {
-                  "version_added": "4.0"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": null
@@ -755,13 +755,13 @@
             "__compat": {
               "support": {
                 "webview_android": {
-                  "version_added": "46.0"
+                  "version_added": "46"
                 },
                 "chrome": {
-                  "version_added": "46.0"
+                  "version_added": "46"
                 },
                 "chrome_android": {
-                  "version_added": "42.0"
+                  "version_added": "42"
                 },
                 "edge": {
                   "version_added": false
@@ -774,7 +774,7 @@
                   "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
                 },
                 "firefox_android": {
-                  "version_added": "39.0",
+                  "version_added": "39",
                   "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
                 },
                 "ie": {
@@ -807,10 +807,10 @@
             "__compat": {
               "support": {
                 "webview_android": {
-                  "version_added": "46.0"
+                  "version_added": "46"
                 },
                 "chrome": {
-                  "version_added": "46.0"
+                  "version_added": "46"
                 },
                 "chrome_android": {
                   "version_added": true
@@ -822,10 +822,10 @@
                   "version_added": null
                 },
                 "firefox": {
-                  "version_added": "3.0"
+                  "version_added": "3"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "ie": {
                   "version_added": null
@@ -857,13 +857,13 @@
             "__compat": {
               "support": {
                 "webview_android": {
-                  "version_added": "50.0"
+                  "version_added": "50"
                 },
                 "chrome": {
-                  "version_added": "50.0"
+                  "version_added": "50"
                 },
                 "chrome_android": {
-                  "version_added": "50.0"
+                  "version_added": "50"
                 },
                 "edge": {
                   "version_added": null
@@ -907,13 +907,13 @@
             "__compat": {
               "support": {
                 "webview_android": {
-                  "version_added": "49.0"
+                  "version_added": "49"
                 },
                 "chrome": {
-                  "version_added": "49.0"
+                  "version_added": "49"
                 },
                 "chrome_android": {
-                  "version_added": "49.0"
+                  "version_added": "49"
                 },
                 "edge": {
                   "version_added": null
@@ -922,10 +922,10 @@
                   "version_added": null
                 },
                 "firefox": {
-                  "version_added": "52.0"
+                  "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": "52.0"
+                  "version_added": "52"
                 },
                 "ie": {
                   "version_added": null
@@ -934,10 +934,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": "36.0"
+                  "version_added": "36"
                 },
                 "opera_android": {
-                  "version_added": "32.0"
+                  "version_added": "32"
                 },
                 "safari": {
                   "version_added": null
@@ -957,7 +957,7 @@
             "__compat": {
               "support": {
                 "webview_android": {
-                  "version_added": "39.0"
+                  "version_added": "39"
                 },
                 "chrome": {
                   "version_added": false
@@ -1011,7 +1011,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -1023,10 +1023,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -1113,7 +1113,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -1125,10 +1125,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -1163,7 +1163,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -1175,10 +1175,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -1213,7 +1213,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -1225,10 +1225,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -201,7 +201,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "8.0",
+                "version_added": "8",
                 "notes": [
                   "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
                   "The <code>&lt;menuitem&gt;</code> element requires a closing tag."

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": true
@@ -70,10 +70,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -120,10 +120,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -170,10 +170,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -219,10 +219,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "ie": {
                   "version_added": true
@@ -269,10 +269,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "ie": {
                   "version_added": true
@@ -319,10 +319,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "ie": {
                   "version_added": true
@@ -369,10 +369,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "ie": {
                   "version_added": true
@@ -419,10 +419,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "ie": {
                   "version_added": true
@@ -470,10 +470,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": true
@@ -519,10 +519,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1.0"
+                  "version_added": "1"
                 },
                 "ie": {
                   "version_added": true
@@ -558,7 +558,7 @@
                   "version_added": null
                 },
                 "chrome": {
-                  "version_added": "17.0",
+                  "version_added": "17",
                   "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
                 },
                 "chrome_android": {
@@ -571,11 +571,11 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "36.0",
+                  "version_added": "36",
                   "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
                 },
                 "firefox_android": {
-                  "version_added": "36.0",
+                  "version_added": "36",
                   "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
                 },
                 "ie": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -177,7 +177,7 @@
                 "notes": "Since Firefox 3.6, the <code>defer</code> attribute is ignored on scripts that don't have the <code>src</code> attribute. However, in Firefox 3.5 even inline scripts are deferred if the <code>defer</code> attribute is set."
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
                 "version_added": "10",

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/style",
           "support": {
             "webview_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "edge": {
               "version_added": true
@@ -21,29 +21,29 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
-              "version_added": "3.0"
+              "version_added": "3"
             },
             "ie_mobile": {
-              "version_added": "9.0",
+              "version_added": "9",
               "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6.0"
+              "version_added": "6"
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "1.0"
+              "version_added": "1"
             }
           },
           "status": {
@@ -56,13 +56,13 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "edge": {
                 "version_added": true
@@ -71,29 +71,29 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "ie_mobile": {
-                "version_added": "9.0",
+                "version_added": "9",
                 "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
               },
               "opera": {
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "6.0"
+                "version_added": "6"
               },
               "safari": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "1.0"
+                "version_added": "1"
               }
             },
             "status": {
@@ -107,13 +107,13 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "edge": {
                 "version_added": true
@@ -122,29 +122,29 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "ie_mobile": {
-                "version_added": "9.0",
+                "version_added": "9",
                 "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
               },
               "opera": {
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "6.0"
+                "version_added": "6"
               },
               "safari": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "1.0"
+                "version_added": "1"
               }
             },
             "status": {
@@ -158,13 +158,13 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "edge": {
                 "version_added": true
@@ -173,29 +173,29 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "ie_mobile": {
-                "version_added": "9.0",
+                "version_added": "9",
                 "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
               },
               "opera": {
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "6.0"
+                "version_added": "6"
               },
               "safari": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "1.0"
+                "version_added": "1"
               }
             },
             "status": {
@@ -212,8 +212,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": "19.0",
-                "version_removed": "35.0",
+                "version_added": "19",
+                "version_removed": "35",
                 "flag": {
                   "type": "preference",
                   "name": "Enable &lt;style scoped&gt;",
@@ -230,10 +230,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "firefox_android": {
-                "version_added": "21.0"
+                "version_added": "21"
               },
               "ie": {
                 "version_added": false

--- a/html/elements/title.json
+++ b/html/elements/title.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -21,25 +21,25 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie_mobile": {
               "version_added": true
             },
             "opera": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "opera_android": {
               "version_added": true
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": true

--- a/http/headers/access-control-allow-credentials.json
+++ b/http/headers/access-control-allow-credentials.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-allow-origin.json
+++ b/http/headers/access-control-allow-origin.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-max-age.json
+++ b/http/headers/access-control-max-age.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-request-headers.json
+++ b/http/headers/access-control-request-headers.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-request-method.json
+++ b/http/headers/access-control-request-method.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -71,7 +71,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "firefox_android": {
                 "version_added": false

--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "44.0"
+                "version_added": "44"
               },
               "firefox_android": {
-                "version_added": "44.0"
+                "version_added": "44"
               },
               "ie": {
                 "version_added": false
@@ -83,7 +83,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "36.0"
+                "version_added": "36"
               },
               "opera_android": {
                 "version_added": false

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "23.0"
+              "version_added": "23"
             },
             "firefox_android": {
-              "version_added": "23.0"
+              "version_added": "23"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -23,11 +23,11 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "23.0",
+                "version_added": "23",
                 "notes": "Implemented as X-Content-Security-Policy header in Firefox 4."
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": "10",
@@ -77,10 +77,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "45.0"
+                  "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "45.0"
+                  "version_added": "45"
                 },
                 "ie": {
                   "version_added": false
@@ -128,10 +128,10 @@
                   "version_added": null
                 },
                 "firefox": {
-                  "version_added": "50.0"
+                  "version_added": "50"
                 },
                 "firefox_android": {
-                  "version_added": "50.0"
+                  "version_added": "50"
                 },
                 "ie": {
                   "version_added": false
@@ -180,10 +180,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "35.0"
+                "version_added": "35"
               },
               "firefox_android": {
-                "version_added": "35.0"
+                "version_added": "35"
               },
               "ie": {
                 "version_added": false
@@ -231,10 +231,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "48.0"
+                "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48.0"
+                "version_added": "48"
               },
               "ie": {
                 "version_added": false
@@ -282,10 +282,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "45.0"
+                "version_added": "45"
               },
               "firefox_android": {
-                "version_added": "45.0"
+                "version_added": "45"
               },
               "ie": {
                 "version_added": false
@@ -333,11 +333,11 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0",
+                "version_added": "23",
                 "notes": "Prior to Firefox 50, ping attributes of &lt;a&gt; elements weren't covered by connect-src."
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -385,10 +385,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -486,10 +486,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -537,10 +537,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "36.0"
+                "version_added": "36"
               },
               "firefox_android": {
-                "version_added": "36.0"
+                "version_added": "36"
               },
               "ie": {
                 "version_added": false
@@ -588,10 +588,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "33.0"
+                "version_added": "33"
               },
               "firefox_android": {
-                "version_added": "33.0"
+                "version_added": "33"
               },
               "ie": {
                 "version_added": false
@@ -639,10 +639,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -690,10 +690,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -741,10 +741,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "41.0"
+                "version_added": "41"
               },
               "firefox_android": {
-                "version_added": "41.0"
+                "version_added": "41"
               },
               "ie": {
                 "version_added": false
@@ -792,10 +792,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -893,10 +893,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -999,11 +999,11 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "37.0",
+                "version_added": "37",
                 "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
               },
               "firefox_android": {
-                "version_added": "37.0",
+                "version_added": "37",
                 "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
               },
               "ie": {
@@ -1154,10 +1154,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -1205,10 +1205,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "firefox_android": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "ie": {
                 "version_added": false
@@ -1256,10 +1256,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "50.0"
+                "version_added": "50"
               },
               "firefox_android": {
-                "version_added": "50.0"
+                "version_added": "50"
               },
               "ie": {
                 "version_added": "10"
@@ -1307,10 +1307,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -1403,7 +1403,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "firefox_android": {
                 "version_added": false
@@ -1454,10 +1454,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "firefox_android": {
-                "version_added": "23.0"
+                "version_added": "23"
               },
               "ie": {
                 "version_added": false
@@ -1506,10 +1506,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "42.0"
+                "version_added": "42"
               },
               "firefox_android": {
-                "version_added": "42.0"
+                "version_added": "42"
               },
               "ie": {
                 "version_added": false

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -22,10 +22,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "35.0"
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "35.0"
+              "version_added": "35"
             },
             "ie": {
               "version_added": null

--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Referrer-Policy",
           "support": {
             "webview_android": {
-              "version_added": "56.0"
+              "version_added": "56"
             },
             "chrome": {
-              "version_added": "56.0"
+              "version_added": "56"
             },
             "chrome_android": {
               "version_added": false
@@ -21,10 +21,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "50.0"
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": "50.0"
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "firefox_android": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "ie": {
                 "version_added": false
@@ -122,10 +122,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "firefox_android": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "ie": {
                 "version_added": false
@@ -173,10 +173,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "firefox_android": {
-                "version_added": "52.0"
+                "version_added": "52"
               },
               "ie": {
                 "version_added": false

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -77,7 +77,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": "8.0"
+                "version_added": "8"
               },
               "ie_mobile": {
                 "version_added": true
@@ -110,7 +110,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -122,13 +122,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "1.0"
+                "version_added": "1"
               },
               "ie": {
-                "version_added": "9.0"
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -140,7 +140,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "5.0"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "iOS 4"

--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -29,19 +29,19 @@
             "firefox": [
               {
                 "prefix": "X-",
-                "version_added": "27.0"
+                "version_added": "27"
               },
               {
-                "version_added": "55.0"
+                "version_added": "55"
               }
             ],
             "firefox_android": [
               {
                 "prefix": "X-",
-                "version_added": "27.0"
+                "version_added": "27"
               },
               {
-                "version_added": "55.0"
+                "version_added": "55"
               }
             ],
             "ie": {

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -9,7 +9,7 @@
               "version_added": "4.4"
             },
             "chrome": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "chrome_android": {
               "version_added": "18"

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -22,10 +22,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "48.0"
+              "version_added": "48"
             },
             "firefox_android": {
-              "version_added": "48.0"
+              "version_added": "48"
             },
             "ie": {
               "version_added": false

--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -27,7 +27,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": "8.0"
+              "version_added": "8"
             },
             "ie_mobile": {
               "version_added": true

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "chrome_android": {
               "version_added": true
@@ -27,7 +27,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "8.0"
+              "version_added": "8"
             },
             "ie_mobile": {
               "version_added": true
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "4.0"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": true
@@ -77,7 +77,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": "8.0"
+                "version_added": "8"
               },
               "ie_mobile": {
                 "version_added": null

--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -27,7 +27,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "8.0"
+              "version_added": "8"
             },
             "ie_mobile": {
               "version_added": null

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -854,7 +854,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -10,10 +10,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -22,7 +22,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0",
+                "version_added": "29",
                 "notes": "Constructor requires a new operator since version 37."
               },
               "firefox_android": {
@@ -50,7 +50,7 @@
                 "notes": "Constructor requires a new operator since version 10."
               },
               "safari_ios": {
-                "version_added": "8.0",
+                "version_added": "8",
                 "notes": "Constructor requires a new operator since version 10."
               }
             },
@@ -69,10 +69,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -81,7 +81,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0"
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "29"
@@ -105,7 +105,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {
@@ -123,10 +123,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -135,7 +135,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0"
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "29"
@@ -159,7 +159,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {
@@ -177,10 +177,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -189,7 +189,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0"
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "29"
@@ -213,7 +213,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {
@@ -231,10 +231,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -243,7 +243,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0"
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "29"
@@ -267,7 +267,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {
@@ -285,10 +285,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -297,7 +297,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0"
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "29"
@@ -321,7 +321,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {
@@ -339,10 +339,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -351,7 +351,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0"
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "29"
@@ -375,7 +375,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {
@@ -393,10 +393,10 @@
                 "version_added": "4.4.4"
               },
               "chrome": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": "32.0"
+                "version_added": "32"
               },
               "edge": {
                 "version_added": true
@@ -405,7 +405,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "29.0"
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "29"
@@ -429,7 +429,7 @@
                 "version_added": "7.1"
               },
               "safari_ios": {
-                "version_added": "8.0"
+                "version_added": "8"
               }
             },
             "status": {


### PR DESCRIPTION
We decided to remove all ".0" at the end of version numbers. In the (near) future, we will check for this with the linter (and more).

This removes all the trailing ".0". It can be merged without waiting for the linter, it will even make it additionnal requested changes more readable.