### PR TITLE
Fix occurrences of non existent firefox android versions

### DIFF
--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4",

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -125,7 +125,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "9"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -125,7 +125,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "9"

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
@@ -74,7 +74,7 @@
                 "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -22,7 +22,7 @@
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
             },
             "ie": {

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5"

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -22,7 +22,7 @@
               "notes": "Firefox also supports the following non-standard CSS properties to set the border sides to multiple colors: <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a>"
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Firefox also supports the following non-standard CSS properties to set the border sides to multiple colors: <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a>"
             },
             "ie": {

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -18,7 +18,7 @@
               "version_added": "13"
             },
             "firefox_android": {
-              "version_added": "13"
+              "version_added": "14"
             },
             "ie": {
               "version_added": "11"

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -22,7 +22,7 @@
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a> CSS property that sets the bottom border to multiple colors."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a> CSS property that sets the bottom border to multiple colors."
             },
             "ie": {

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -22,7 +22,7 @@
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
             },
             "ie": {

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-spacing.json
+++ b/css/properties/border-spacing.json
@@ -18,7 +18,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"

--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -22,7 +22,7 @@
               "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50."
             },
             "ie": {

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -22,7 +22,7 @@
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a> CSS property that sets the top border to multiple colors."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a> CSS property that sets the top border to multiple colors."
             },
             "ie": {

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-top.json
+++ b/css/properties/border-top.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -18,7 +18,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5",

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"

--- a/css/properties/left.json
+++ b/css/properties/left.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5.5"

--- a/css/properties/right.json
+++ b/css/properties/right.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5.5"

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5",

--- a/html/elements/abbr.json
+++ b/html/elements/abbr.json
@@ -25,7 +25,7 @@
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "ie": {

--- a/html/elements/abbr.json
+++ b/html/elements/abbr.json
@@ -25,8 +25,7 @@
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
+              "version_added": "4"
             },
             "ie": {
               "version_added": "7"

--- a/html/elements/address.json
+++ b/html/elements/address.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -273,7 +273,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -373,7 +373,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -473,7 +473,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -623,7 +623,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -673,7 +673,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -723,7 +723,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -773,7 +773,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -25,7 +25,7 @@
               "notes": "For Firefox to play audio, the server must serve the file using the correct MIME type."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "For Firefox to play audio, the server must serve the file using the correct MIME type."
             },
             "ie": {
@@ -75,7 +75,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -175,7 +175,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -275,7 +275,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -503,7 +503,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -225,7 +225,7 @@
                 "version_added": "11"
               },
               "firefox_android": {
-                "version_added": "11"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "9"
@@ -325,7 +325,7 @@
                 "version_added": "11"
               },
               "firefox_android": {
-                "version_added": "11"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": null

--- a/html/elements/b.json
+++ b/html/elements/b.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true,
@@ -74,7 +74,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/blink.json
+++ b/html/elements/blink.json
@@ -25,7 +25,7 @@
               "version_removed": "22"
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "version_removed": "22"
             },
             "ie": {

--- a/html/elements/blockquote.json
+++ b/html/elements/blockquote.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/br.json
+++ b/html/elements/br.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -29,7 +29,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "1.5",
+              "version_added": "4",
               "notes": [
                 "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
                 "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
@@ -89,7 +89,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "1.5",
+                "version_added": "4",
                 "notes": [
                   "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
                   "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",
@@ -145,7 +145,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -200,7 +200,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "1.5",
+                "version_added": "4",
                 "notes": [
                   "Before Firefox 5, the canvas width and height were signed integers instead of unsigned integers.",
                   "Prior to Firefox 6, a &lt;canvas&gt; element with a zero width or height would be rendered as if it had default dimensions.",

--- a/html/elements/caption.json
+++ b/html/elements/caption.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/cite.json
+++ b/html/elements/cite.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/code.json
+++ b/html/elements/code.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -279,7 +279,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -381,7 +381,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -279,7 +279,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -381,7 +381,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/dd.json
+++ b/html/elements/dd.json
@@ -25,7 +25,7 @@
               "notes": "Before Firefox 4, this element was implemented using the <code>HTMLSpanElement</code> interface instead of <code>HTMLElement</code>."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Before Firefox 4, this element was implemented using the <code>HTMLSpanElement</code> interface instead of <code>HTMLElement</code>."
             },
             "ie": {
@@ -75,7 +75,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/dd.json
+++ b/html/elements/dd.json
@@ -25,8 +25,7 @@
               "notes": "Before Firefox 4, this element was implemented using the <code>HTMLSpanElement</code> interface instead of <code>HTMLElement</code>."
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": "Before Firefox 4, this element was implemented using the <code>HTMLSpanElement</code> interface instead of <code>HTMLElement</code>."
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/del.json
+++ b/html/elements/del.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/dfn.json
+++ b/html/elements/dfn.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/div.json
+++ b/html/elements/div.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/dl.json
+++ b/html/elements/dl.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/dt.json
+++ b/html/elements/dt.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/em.json
+++ b/html/elements/em.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/h2.json
+++ b/html/elements/h2.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/h3.json
+++ b/html/elements/h3.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/h4.json
+++ b/html/elements/h4.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/h5.json
+++ b/html/elements/h5.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/h6.json
+++ b/html/elements/h6.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -223,7 +223,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -273,7 +273,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -73,7 +73,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/i.json
+++ b/html/elements/i.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/ins.json
+++ b/html/elements/ins.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/kbd.json
+++ b/html/elements/kbd.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/keygen.json
+++ b/html/elements/keygen.json
@@ -27,7 +27,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/html/elements/li.json
+++ b/html/elements/li.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -223,7 +223,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -273,7 +273,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -373,7 +373,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -573,7 +573,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -825,7 +825,7 @@
                   "version_added": "3"
                 },
                 "firefox_android": {
-                  "version_added": "1"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": null
@@ -1026,7 +1026,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1128,7 +1128,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1178,7 +1178,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1228,7 +1228,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/map.json
+++ b/html/elements/map.json
@@ -28,7 +28,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -77,7 +77,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "2"
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "2"
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "2"
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "2"
@@ -223,7 +223,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "2"
@@ -273,7 +273,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "3"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": null
@@ -323,7 +323,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "3"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": null
@@ -373,7 +373,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "2"
@@ -423,7 +423,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "2"
@@ -473,7 +473,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "3"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "4"
@@ -523,7 +523,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "3"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": null
@@ -573,7 +573,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "2"

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -222,7 +222,7 @@
                   "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": true
@@ -272,7 +272,7 @@
                   "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": true
@@ -322,7 +322,7 @@
                   "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": true
@@ -372,7 +372,7 @@
                   "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": true
@@ -422,7 +422,7 @@
                   "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": true
@@ -473,7 +473,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -522,7 +522,7 @@
                   "version_added": "1"
                 },
                 "firefox_android": {
-                  "version_added": "1"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": true

--- a/html/elements/noscript.json
+++ b/html/elements/noscript.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -223,7 +223,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -273,7 +273,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -323,7 +323,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -373,7 +373,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -423,7 +423,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -473,7 +473,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -523,7 +523,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -573,7 +573,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -623,7 +623,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -673,7 +673,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -773,7 +773,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -823,7 +823,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/ol.json
+++ b/html/elements/ol.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -223,7 +223,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/option.json
+++ b/html/elements/option.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -128,7 +128,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "1",
+                "version_added": "4",
                 "notes": "Firefox doesn't display the value of the <code>label</code> attribute as option text if element's content is empty. See <a href='https://bugzil.la/40545'>bug 40545</a>."
               },
               "ie": {
@@ -179,7 +179,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -229,7 +229,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/p.json
+++ b/html/elements/p.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/param.json
+++ b/html/elements/param.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -223,7 +223,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/pre.json
+++ b/html/elements/pre.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -74,7 +74,7 @@
                 "version_removed": "29"
               },
               "firefox_android": {
-                "version_added": "1",
+                "version_added": "4",
                 "version_removed": "29"
               },
               "ie": {
@@ -131,7 +131,7 @@
                 "notes": "Since Firefox 29, specifying the <code>width</code> attribute has no layout effect."
               },
               "firefox_android": {
-                "version_added": "1",
+                "version_added": "4",
                 "notes": "Since Firefox 29, specifying the <code>width</code> attribute has no layout effect."
               },
               "ie": {
@@ -188,7 +188,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": null

--- a/html/elements/q.json
+++ b/html/elements/q.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/s.json
+++ b/html/elements/s.json
@@ -25,7 +25,7 @@
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "ie": {

--- a/html/elements/s.json
+++ b/html/elements/s.json
@@ -25,8 +25,7 @@
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/samp.json
+++ b/html/elements/samp.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -25,7 +25,7 @@
               "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
             },
             "ie": {
@@ -75,7 +75,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -177,7 +177,7 @@
                 "notes": "Since Firefox 3.6, the <code>defer</code> attribute is ignored on scripts that don't have the <code>src</code> attribute. However, in Firefox 3.5 even inline scripts are deferred if the <code>defer</code> attribute is set."
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10",
@@ -279,7 +279,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -439,7 +439,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -489,7 +489,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -539,7 +539,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -25,8 +25,7 @@
               "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -124,7 +124,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": false

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -31,7 +31,7 @@
               "notes": "Historically, Firefox has allowed keyboard and mouse events to bubble up from the <code>&lt;option&gt;</code> element to the parent <code>&lt;select&gt;</code> element, although this behavior is inconsistent across many browsers. For better Web compatibility (and for technical reasons), when Firefox is in multi-process mode the <code>&lt;select&gt;</code> element is displayed as a drop-down list. The behavior is unchanged if the <code>&lt;select&gt;</code> is presented inline and it has either the multiple attribute defined or a size attribute set to more than 1. Rather than watching <code>&lt;option&gt;</code> elements for events, you should watch for change events on <code>&lt;select&gt;</code>. See <a href='https://bugzil.la/1090602'>bug 1090602</a> for details."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Firefox for Android, by default, sets a <code>background-image</code> gradient on all <code>&lt;select multiple&gt;</code> elements. This can be disabled using <code>background-image: none</code>."
             },
             "ie": {
@@ -83,7 +83,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -133,7 +133,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -183,7 +183,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -233,7 +233,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -283,7 +283,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -383,7 +383,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/small.json
+++ b/html/elements/small.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -25,7 +25,7 @@
               "notes": "Until Firefox 15, Firefox picked the first source element that has a type matching the MIME-type of a supported media format; see <a href='https://bugzil.la/449363'>bug 449363</a> for details."
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Until Firefox 15, Firefox picked the first source element that has a type matching the MIME-type of a supported media format; see <a href='https://bugzil.la/449363'>bug 449363</a> for details."
             },
             "ie": {
@@ -195,7 +195,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -315,7 +315,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/html/elements/spacer.json
+++ b/html/elements/spacer.json
@@ -25,8 +25,7 @@
               "version_removed": "4"
             },
             "firefox_android": {
-              "version_added": "4",
-              "version_removed": "4"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/html/elements/spacer.json
+++ b/html/elements/spacer.json
@@ -25,7 +25,7 @@
               "version_removed": "4"
             },
             "firefox_android": {
-              "version_added": "1",
+              "version_added": "4",
               "version_removed": "4"
             },
             "ie": {

--- a/html/elements/span.json
+++ b/html/elements/span.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/strong.json
+++ b/html/elements/strong.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"
@@ -74,7 +74,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "3"
@@ -125,7 +125,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "3"
@@ -176,7 +176,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "3"

--- a/html/elements/sub.json
+++ b/html/elements/sub.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/sup.json
+++ b/html/elements/sup.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -173,7 +173,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -223,7 +223,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -273,7 +273,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -323,7 +323,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -373,7 +373,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -423,7 +423,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -473,7 +473,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -175,7 +175,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -379,7 +379,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -429,7 +429,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -479,7 +479,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -580,7 +580,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -682,7 +682,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -175,7 +175,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -379,7 +379,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -429,7 +429,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -479,7 +479,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -580,7 +580,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -682,7 +682,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/title.json
+++ b/html/elements/title.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "1"

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/u.json
+++ b/html/elements/u.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/ul.json
+++ b/html/elements/ul.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -123,7 +123,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/var.json
+++ b/html/elements/var.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -224,7 +224,7 @@
                 "version_added": "12"
               },
               "firefox_android": {
-                "version_added": "12"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": null
@@ -324,7 +324,7 @@
                 "version_added": "11"
               },
               "firefox_android": {
-                "version_added": "11"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "9"
@@ -374,7 +374,7 @@
                 "version_added": "11"
               },
               "firefox_android": {
-                "version_added": "11"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "10"

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -73,7 +73,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -174,7 +174,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -274,7 +274,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -474,7 +474,7 @@
                 "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -574,7 +574,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -624,7 +624,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/html/elements/wbr.json
+++ b/html/elements/wbr.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5.5",

--- a/http/headers/access-control-allow-credentials.json
+++ b/http/headers/access-control-allow-credentials.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-allow-origin.json
+++ b/http/headers/access-control-allow-origin.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-max-age.json
+++ b/http/headers/access-control-max-age.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-request-headers.json
+++ b/http/headers/access-control-request-headers.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/access-control-request-method.json
+++ b/http/headers/access-control-request-method.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -125,7 +125,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -77,7 +77,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -239,7 +239,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -347,7 +347,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -401,7 +401,7 @@
                 "version_added": "25"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -455,7 +455,7 @@
                 "version_added": "25"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -509,7 +509,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -671,7 +671,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -779,7 +779,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -995,7 +995,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1158,7 +1158,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -1266,7 +1266,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -1320,7 +1320,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1374,7 +1374,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1428,7 +1428,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -1482,7 +1482,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -1536,7 +1536,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1590,7 +1590,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1644,7 +1644,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -1698,7 +1698,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"
@@ -2077,7 +2077,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5.5"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -294,7 +294,7 @@
                 "notes": "The non-standard <code>ArrayBuffer.slice()</code> method has been removed in Firefox 53 (but the standardized version <code>ArrayBuffer.prototype.slice()</code> is kept."
               },
               "firefox_android": {
-                "version_added": "12",
+                "version_added": "14",
                 "notes": "The non-standard <code>ArrayBuffer.slice()</code> method has been removed in Firefox 53 (but the standardized version <code>ArrayBuffer.prototype.slice()</code> is kept."
               },
               "ie": {

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -185,7 +185,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "8"
@@ -725,7 +725,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -239,7 +239,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": null

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -24,7 +24,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"
@@ -77,7 +77,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "8"
@@ -131,7 +131,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "8"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -24,7 +24,7 @@
               "version_added": "13"
             },
             "firefox_android": {
-              "version_added": "13"
+              "version_added": "14"
             },
             "ie": {
               "version_added": "11"
@@ -77,7 +77,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": false
@@ -347,7 +347,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"
@@ -509,7 +509,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"
@@ -563,7 +563,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"
@@ -671,7 +671,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"
@@ -725,7 +725,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1004,7 +1004,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1217,7 +1217,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -24,7 +24,7 @@
               "version_added": "13"
             },
             "firefox_android": {
-              "version_added": "13"
+              "version_added": "14"
             },
             "ie": {
               "version_added": "11"
@@ -77,7 +77,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": false
@@ -293,7 +293,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"
@@ -401,7 +401,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"
@@ -563,7 +563,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"
@@ -617,7 +617,7 @@
                 "version_added": "13"
               },
               "firefox_android": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "ie": {
                 "version_added": "11"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -351,7 +351,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -405,7 +405,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -459,7 +459,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -513,7 +513,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -1327,7 +1327,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -1493,7 +1493,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -1601,7 +1601,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -1817,7 +1817,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -2033,7 +2033,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -1007,7 +1007,7 @@
               "version_added": "2"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1115,7 +1115,7 @@
               "version_added": "2"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -25,7 +25,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "1"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -919,7 +919,7 @@
               "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Versions 1, 1.5, 3 (and 2, 3.5, 3.6, but there were no occurrences) -> Version 4
Versions 11, 12, 13 -> Version 14.

Also fixed in the notes (removal of a few relevent notes).

One occurrence of version_added == version_removed after the changed, fixed to "version_added": false

Directories: test/* and webextensions/* not done