### PR TITLE
Remove .0 in notes

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -23,7 +23,7 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "Gecko supported, from version 1.1 to version 1.9.2, corresponding to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+              "notes": "Gecko supported, from version 1.1 to version 1.9.2, corresponding to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
             },
             "firefox_android": {
               "version_added": "14"
@@ -76,7 +76,7 @@
               },
               "firefox": {
                 "version_added": "4",
-                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
               },
               "firefox_android": {
                 "version_added": "14"

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -23,7 +23,7 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "Gecko supported, from version 1.1 to version 1.9.2, corresponding to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+              "notes": "Firefox supported, from version 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
             },
             "firefox_android": {
               "version_added": "14"
@@ -76,7 +76,7 @@
               },
               "firefox": {
                 "version_added": "4",
-                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+                "notes": "Firefox supported, from version 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
               },
               "firefox_android": {
                 "version_added": "14"

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -24,7 +24,7 @@
             "firefox": {
               "version_added": "4",
               "notes": [
-                "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>.",
+                "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>.",
                 "Since Firefox 49, also supports the <code>-webkit</code> prefixed version of the property."
               ]
             },
@@ -79,7 +79,7 @@
               },
               "firefox": {
                 "version_added": "4",
-                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1.0 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
               },
               "firefox_android": {
                 "version_added": "14"

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -24,7 +24,7 @@
             "firefox": {
               "version_added": "4",
               "notes": [
-                "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>.",
+                "Firefox supported, from version 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>.",
                 "Since Firefox 49, also supports the <code>-webkit</code> prefixed version of the property."
               ]
             },
@@ -79,7 +79,7 @@
               },
               "firefox": {
                 "version_added": "4",
-                "notes": "Gecko supported, from version 1.1 to version 1.9.2, which corresponds to Firefox 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
+                "notes": "Firefox supported, from version 1 to 3.6 included, a different and prefixed syntax: <code>-moz-background-clip: padding | border</code>."
               },
               "firefox_android": {
                 "version_added": "14"


### PR DESCRIPTION
There are a few Firefox 1.0 scatterred in notes, this fix them (to Firefox 1). [tests/* and webextensions/* not covered]