### PR TITLE
Fix test and webextension data to not contain '.0' versions

### DIFF
--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -6,18 +6,18 @@
           "description": "Tests for various notes",
           "support": {
             "webview_android": {
-              "version_added": "4.1",
+              "version_added": "4",
               "notes": [
                 "First note",
                 "Second note"
               ]
             },
             "chrome": {
-              "version_added": "1.0",
+              "version_added": "1",
               "notes": [
                 "A note"
               ],
-              "version_removed": "3.0"
+              "version_removed": "3"
             },
             "chrome_android": {
               "version_added": true,
@@ -31,27 +31,27 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0",
+              "version_added": "4",
               "version_removed": true
             },
             "firefox_android": {
-              "version_added": "14.0"
+              "version_added": "14"
             },
             "ie": {
-              "version_added": "9.0",
+              "version_added": "9",
               "version_removed": null
             },
             "ie_mobile": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "opera": {
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": "12.1"
+              "version_added": "12"
             },
             "safari": {
-              "version_added": "3.0",
+              "version_added": "3",
               "notes": "The same note twice should only be displayed once and have one anchor number"
             },
             "safari_ios": {
@@ -70,10 +70,10 @@
         "__compat": {
           "support": {
             "webview_android": {
-              "version_added": "4.1"
+              "version_added": "4"
             },
             "chrome": {
-              "version_added": "1.0",
+              "version_added": "1",
               "notes": [
                 "A note"
               ]
@@ -89,29 +89,29 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "4.0",
+              "version_added": "4",
               "notes": [
                 "First note",
                 "Second note"
               ]
             },
             "firefox_android": {
-              "version_added": "14.0"
+              "version_added": "14"
             },
             "ie": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "ie_mobile": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "opera": {
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": "12.1"
+              "version_added": "12"
             },
             "safari": {
-              "version_added": "3.0"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": true
@@ -128,12 +128,12 @@
             "description": "This is a sub feature with complex support statements",
             "support": {
               "webview_android": {
-                "version_added": "4.1"
+                "version_added": "4"
               },
               "chrome": [
                 {
-                  "version_added": "35.0",
-                  "version_removed": "47.0",
+                  "version_added": "35",
+                  "version_removed": "47",
                   "flag": {
                     "type": "preference",
                     "name": "Enable Experimental Web Platform Features",
@@ -141,14 +141,14 @@
                   }
                 },
                 {
-                  "version_added": "47.0",
+                  "version_added": "47",
                   "notes": "A note but no array"
                 }
               ],
               "chrome_android": [
                 {
-                  "version_added": "35.0",
-                  "version_removed": "47.0",
+                  "version_added": "35",
+                  "version_removed": "47",
                   "notes": [
                     "First note for a flag",
                     "Second note for a flag"
@@ -160,14 +160,14 @@
                   }
                 },
                 {
-                  "version_added": "47.0"
+                  "version_added": "47"
                 }
               ],
               "edge": [
                 {
                   "alternative_name": "chocolateCookie",
                   "version_added": true,
-                  "version_removed": "12.0"
+                  "version_removed": "12"
                 },
                 {
                   "version_added": "12"
@@ -180,49 +180,49 @@
               "firefox": [
                 {
                   "prefix": "-moz-",
-                  "version_added": "12.0",
-                  "version_removed": "53.0",
+                  "version_added": "12",
+                  "version_removed": "53",
                   "notes": "A note but no array for a support statement with -moz- prefix"
                 },
                 {
-                  "version_added": "49.0"
+                  "version_added": "49"
                 }
               ],
               "firefox_android": [
                 {
                   "prefix": "-moz-",
-                  "version_added": "12.0",
-                  "version_removed": "53.0",
+                  "version_added": "12",
+                  "version_removed": "53",
                   "notes": [
                     "First note",
                     "Second note"
                   ]
                 },
                 {
-                  "version_added": "49.0",
+                  "version_added": "49",
                   "notes": [
                     "A single note in an array"
                   ]
                 }
               ],
               "ie": {
-                "version_added": "9.0",
+                "version_added": "9",
                 "version_removed": true
               },
               "ie_mobile": {
-                "version_added": "7.1",
+                "version_added": "7",
                 "version_removed": null
               },
               "opera": {
                 "version_added": true,
-                "version_removed": "10.5"
+                "version_removed": "10"
               },
               "opera_android": {
-                "version_added": "12.1",
+                "version_added": "12",
                 "version_removed": false
               },
               "safari": {
-                "version_added": "3.0"
+                "version_added": "3"
               },
               "safari_ios": {
                 "version_added": true
@@ -240,10 +240,10 @@
             "description": "No status block and only a few browsers",
             "support": {
               "firefox": {
-                "version_added": "49.0"
+                "version_added": "49"
               },
               "firefox_android": {
-                "version_added": "49.0"
+                "version_added": "49"
               }
             }
           }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -8130,10 +8130,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "45.0"
+                  "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48.0"
+                  "version_added": "48"
                 },
                 "opera": {
                   "version_added": "33"
@@ -8151,10 +8151,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "45.0"
+                  "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48.0"
+                  "version_added": "48"
                 },
                 "opera": {
                   "version_added": "33"
@@ -8193,10 +8193,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "45.0"
+                  "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48.0"
+                  "version_added": "48"
                 },
                 "opera": {
                   "version_added": "33"
@@ -8217,10 +8217,10 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "45.0"
+                  "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48.0"
+                  "version_added": "48"
                 },
                 "opera": {
                   "version_added": "33"


### PR DESCRIPTION
This will make https://github.com/mdn/browser-compat-data/pull/439 pass :) (for now)