### PR TITLE
Browsing data 57

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1159,10 +1159,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "57"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "57"
                 },
                 "opera": {
                   "version_added": true
@@ -1487,6 +1487,27 @@
               },
               "firefox_android": {
                 "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "removeLocalStorage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": "57"
               },
               "opera": {
                 "version_added": true

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1002,22 +1002,255 @@
       },
       "browsingData": {
         "DataTypeSet": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "version_added": "56"
-              },
-              "opera": {
-                "version_added": true
+          "cache": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "cookies": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "downloads": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "fileSystems": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "formData": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "history": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "indexedDB": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "localStorage": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "passwords": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "pluginData": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "serverBoundCertificates": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "serviceWorkers": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
               }
             }
           }
@@ -1140,12 +1373,14 @@
               },
               "firefox": {
                 "notes": [
-                  "Firefox does not support removal of: 'fileSystems', 'indexedDB', 'localStorage', or 'serverBoundCertificates'.",
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
+                  "Specifying <code>dataTypes.history</code> will also remove download history."
                 ],
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "Specifying <code>dataTypes.history</code> will also remove download history."
+                ],
                 "version_added": "57"
               },
               "opera": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1399,9 +1399,6 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
                 "version_added": "53"
               },
               "firefox_android": {
@@ -1423,9 +1420,6 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
                 "version_added": "53"
               },
               "firefox_android": {
@@ -1447,9 +1441,6 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
                 "version_added": "53"
               },
               "firefox_android": {
@@ -1471,9 +1462,6 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
                 "version_added": "53"
               },
               "firefox_android": {
@@ -1495,9 +1483,6 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
                 "version_added": "53"
               },
               "firefox_android": {
@@ -1519,9 +1504,6 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
                 "version_added": "53"
               },
               "firefox_android": {
@@ -1543,9 +1525,6 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "'removalOptions' does not support 'protectedWeb' or 'extension' as values of 'originTypes'."
-                ],
                 "version_added": "53"
               },
               "firefox_android": {


### PR DESCRIPTION
This PR addresses 2 DDNs relating to the [browsingData](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData) API:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1401688, for which we need to note that in Firefox removing history also removes downloads history

* https://bugzilla.mozilla.org/show_bug.cgi?id=1355576, which adds support for removing localStorage

I've split these into separate commits, to make it easier to review.

I've also refactored the `browsingData` data, to list support for the different data types as subfeatures of `browsingData.DataTypeSet`, rather than as [a note in the `remove` function](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/remove#Browser_compatibility).

I also removed the other note there, about `removalOptions`, because it's also noted in [`browsingData.RemovalOptions`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/RemovalOptions#Browser_compatibility) and is therefore redundant.