### PR TITLE
Add data for browserSettings.imageAnimationBehavior

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1408,6 +1408,27 @@
             }
           }
         },
+        "imageAnimationBehavior": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": "57"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "newTabPageOverride": {
           "__compat": {
             "support": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1364972 adds a new property to the [`browserSettings`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserSettings) API, `imageAnimationBehavior`:

https://hg.mozilla.org/mozilla-central/diff/39a2a87fc100/toolkit/components/extensions/schemas/browser_settings.json