### PR TITLE
Add data for clipboard API

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1430,6 +1430,29 @@
           }
         }
       },
+      "clipboard": {
+        "setImageData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": "57"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
       "commands": {
         "Command": {
           "__compat": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1356543 adds support for a clipboard API. In Firefox/Firefox for Android 57 it has just one function, `setImageData`:

http://searchfox.org/mozilla-central/source/toolkit/components/extensions/schemas/clipboard.json
