### PR TITLE
Add data for theme_icons

### DIFF
--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -111,26 +111,44 @@
             }
           }
         },
-        "default_title": {
+        "browser_style": {
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "55",
-                "notes": [
-                  "Browser actions are presented as menu items, and the title is the menu item's label."
-                ]
+                "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
+              }
+            }
+          }
+        },
+        "default_area": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }
@@ -184,28 +202,31 @@
             }
           }
         },
-        "browser_style": {
+        "default_title": {
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": true
               },
               "firefox": {
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "55",
+                "notes": [
+                  "Browser actions are presented as menu items, and the title is the menu item's label."
+                ]
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
         },
-        "default_area": {
+        "theme_icons": {
           "__compat": {
             "support": {
               "chrome": {
@@ -215,7 +236,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "54"
+                "version_added": "56"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1329242 adds a new property in Firefox 56 to [`browser_action`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/browser_action), called `theme_icons`:

https://hg.mozilla.org/mozilla-central/diff/70384deed6a0/browser/components/extensions/schemas/browser_action.json

I also alphabetized the subfeatures.