### PR TITLE
Remove empty note from const

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -404,16 +404,14 @@
               "version_added": "36",
               "notes": [
                 "Prior to Firefox 13, <code>const</code> is implemented, but re-assignment is not failing.",
-                "Prior to Firefox 46, a <code>TypeError</code> was thrown on redeclaration instead of a <code>SyntaxError</code>.",
-                ""
+                "Prior to Firefox 46, a <code>TypeError</code> was thrown on redeclaration instead of a <code>SyntaxError</code>."
               ]
             },
             "firefox_android": {
               "version_added": "36",
               "notes": [
                 "Prior to Firefox 13, <code>const</code> is implemented, but re-assignment is not failing.",
-                "Prior to Firefox 46, a <code>TypeError</code> was thrown on redeclaration instead of a <code>SyntaxError</code>.",
-                ""
+                "Prior to Firefox 46, a <code>TypeError</code> was thrown on redeclaration instead of a <code>SyntaxError</code>."
               ]
             },
             "ie": {


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const