### PR TITLE
Bug 1083470: Remove 'for each in' in Firefox 57

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -914,10 +914,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "1.5"
+              "version_added": "1.5",
+              "version_removed": "57"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "57"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
DDN bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1083470