### PR TITLE
Webrequest 57

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -12073,6 +12073,27 @@
             }
           }
         },
+        "filterResponseData": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": "57"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "handlerBehaviorChanged": {
           "__compat": {
             "support": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -12173,9 +12173,15 @@
                     "version_added": true
                   },
                   "firefox": {
+                    "notes": [
+                      "Before version 57, on a proxied connection, the <code>challenger.host</code> property contains the hostname for the requested URL rather than the hostname for the proxy."
+                    ],
                     "version_added": "54"
                   },
                   "firefox_android": {
+                    "notes": [
+                      "Before version 57, on a proxied connection, the <code>challenger.host</code> property contains the hostname for the requested URL rather than the hostname for the proxy."
+                    ],
                     "version_added": "54"
                   },
                   "opera": {


### PR DESCRIPTION
This PR contains updates for a couple of DDNs:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1255894 adds a Firefoxes-only method, `filterResponseData()`: https://hg.mozilla.org/mozilla-central/diff/3599cdb1a849/toolkit/components/extensions/schemas/web_request.json

* https://bugzilla.mozilla.org/show_bug.cgi?id=1388289 fixes a previously undocumented bug in [`webRequest.onAuthRequired`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/onAuthRequired). This PR adds a note about the bug.