### PR TITLE
Tabs 57

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -9094,7 +9094,7 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "57"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -9549,7 +9549,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": false
+                    "version_added": "57"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -10665,6 +10665,27 @@
                 }
               }
             },
+            "openerTabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
             "pinned": {
               "__compat": {
                 "support": {
@@ -11139,7 +11160,7 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": false
+                    "version_added": "57"
                   },
                   "firefox_android": {
                     "version_added": false

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -10353,7 +10353,7 @@
               },
               "edge": {
                 "notes": [
-                  "The 'panel', 'app', 'devtools' and 'popup' values for 'WindowType' are not supported."
+                  "The <code>panel</code>, <code>app</code>, <code>devtools</code> and <code>popup</code> values for <code>WindowType</code> are not supported."
                 ],
                 "version_added": true
               },
@@ -10368,241 +10368,348 @@
               }
             }
           },
-          "url": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "45",
-                  "notes": [
-                    "Fails if the extension doesn't have the 'tabs' permission.",
-                    "Before Firefox 56, moz-extension:// URLs were not allowed."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "54",
-                  "notes": [
-                    "Fails if the extension doesn't have the 'tabs' permission.",
-                    "Before Firefox 56, moz-extension:// URLs were not allowed."
-                  ]
-                },
-                "opera": {
-                  "version_added": true
+          "queryInfo": {
+            "active": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
-            }
-          },
-          "pinned": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": true
+            },
+            "audible": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "45"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "32"
+                  }
                 }
               }
-            }
-          },
-          "highlighted": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": true
+            },
+            "autoDiscardable": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "54"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "41"
+                  }
                 }
               }
-            }
-          },
-          "index": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "18"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "15"
+            },
+            "cookieStoreId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
                 }
               }
-            }
-          },
-          "currentWindow": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "19"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "15"
+            },
+            "currentWindow": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "19"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
                 }
               }
-            }
-          },
-          "lastFocusedWindow": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "19"
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "15"
+            },
+            "discarded": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "54"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "41"
+                  }
                 }
               }
-            }
-          },
-          "audible": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "45"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "32"
+            },
+            "highlighted": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
-            }
-          },
-          "muted": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "45"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "32"
+            },
+            "index": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
                 }
               }
-            }
-          },
-          "cookieStoreId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
+            },
+            "lastFocusedWindow": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "19"
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
                 }
               }
-            }
-          },
-          "discarded": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "54"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "41"
+            },
+            "muted": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "45"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": "32"
+                  }
                 }
               }
-            }
-          },
-          "autoDiscardable": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "54"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "41"
+            },
+            "pinned": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "status": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "title": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45",
+                    "notes": [
+                      "Fails if the extension doesn't have the <code>tabs</code> permission.",
+                      "Before Firefox 56, moz-extension:// URLs were not allowed."
+                    ]
+                  },
+                  "firefox_android": {
+                    "version_added": "54",
+                    "notes": [
+                      "Fails if the extension doesn't have the <code>tabs</code> permission.",
+                      "Before Firefox 56, moz-extension:// URLs were not allowed."
+                    ]
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "windowId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "windowType": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -8810,22 +8810,192 @@
           }
         },
         "Tab": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "45"
-              },
-              "firefox_android": {
-                "version_added": "54"
-              },
-              "opera": {
-                "version_added": true
+          "active": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "audible": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "45"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "32"
+                }
+              }
+            }
+          },
+          "autoDiscardable": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "41"
+                }
+              }
+            }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "discarded": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "54"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": "57"
+                },
+                "opera": {
+                  "version_added": "41"
+                }
+              }
+            }
+          },
+          "favIconUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "height": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "31"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "18"
+                }
+              }
+            }
+          },
+          "highlighted": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "id": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
               }
             }
           },
@@ -8851,14 +9021,98 @@
               }
             }
           },
-          "highlighted": {
+          "index": {
             "__compat": {
               "support": {
                 "chrome": {
                   "version_added": true
                 },
                 "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "lastAccessed": {
+            "__compat": {
+              "support": {
+                "chrome": {
                   "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "56"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "mutedInfo": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "46"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": "33"
+                }
+              }
+            }
+          },
+          "openerTabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "pinned": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": "45"
@@ -8898,132 +9152,6 @@
               }
             }
           },
-          "width, height": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "31"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "18"
-                }
-              }
-            }
-          },
-          "audible": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "45"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "32"
-                }
-              }
-            }
-          },
-          "mutedInfo": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "46"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": {
-                  "version_added": "33"
-                }
-              }
-            }
-          },
-          "lastAccessed": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "56"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
-          "cookieStoreId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
-          "openerTabId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "18"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "15"
-                }
-              }
-            }
-          },
           "sessionId": {
             "__compat": {
               "support": {
@@ -9045,44 +9173,107 @@
               }
             }
           },
-          "discarded": {
+          "status": {
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "54"
+                  "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "firefox": {
-                  "version_added": "57"
+                  "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "57"
+                  "version_added": "54"
                 },
                 "opera": {
-                  "version_added": "41"
+                  "version_added": true
                 }
               }
             }
           },
-          "autoDiscardable": {
+          "title": {
             "__compat": {
               "support": {
                 "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
                   "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "width": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "31"
                 },
                 "edge": {
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "54"
                 },
                 "opera": {
-                  "version_added": "41"
+                  "version_added": "18"
+                }
+              }
+            }
+          },
+          "windowId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": {
+                  "version_added": true
                 }
               }
             }

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -9620,9 +9620,15 @@
                     "version_added": true
                   },
                   "firefox": {
+                    "notes": [
+                      "Before version 57, extensions were not allowed to open 'view-source:' pages."
+                    ],
                     "version_added": "45"
                   },
                   "firefox_android": {
+                    "notes": [
+                      "Before version 57, extensions were not allowed to open 'view-source:' pages."
+                    ],
                     "version_added": "54"
                   },
                   "opera": {

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -10484,10 +10484,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": false
+                    "version_added": "57"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "57"
                   },
                   "opera": {
                     "version_added": "41"

--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -9462,10 +9462,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true,
-                "notes": [
-                  "If the `url` has the `ms-browser-extension://` protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading."
-                ]
+                "version_added": true
               },
               "firefox": {
                 "version_added": "45"
@@ -9478,91 +9475,180 @@
               }
             }
           },
-          "pinned": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
+          "createProperties": {
+            "active": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
-            }
-          },
-          "cookieStoreId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
+            },
+            "cookieStoreId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
                 }
               }
-            }
-          },
-          "selected": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
+            },
+            "index": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
-            }
-          },
-          "openerTabId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "18"
+            },
+            "openerTabId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "18"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  }
+                }
+              }
+            },
+            "pinned": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "selected": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "15"
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "notes": [
+                      "If the <code>url</code> has the 'ms-browser-extension://' protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading."
+                    ],
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "windowId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
                 }
               }
             }


### PR DESCRIPTION
This PR adds data from 3 DDNs:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1238314 adds support for `openerTabId` in [`tabs.Tab`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/Tab), [`tabs.query`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/query), [`tabs.update`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/update), and [`tabs.create`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/create), in Firefox 57 (desktop only I think).

* https://bugzilla.mozilla.org/show_bug.cgi?id=1377733 adds support for `discarded` in [`tabs.Tab`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/Tab) and [`tabs.query`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/query) for both Firefoxes 57. One of these was noted in a previous PR: https://github.com/mdn/browser-compat-data/pull/377, but the other one was missed.

* https://bugzilla.mozilla.org/show_bug.cgi?id=1261289 enabled Firefoxes 57 and higher to open view-source URLs.

While I was in there I also refactored some of the `tabs` data, splitting out implicit data into subfeatures, alphabetizing, and nesting it properly.

I've used separate commits for the refactorings and each of the DDNs, which should hopefully make this easier to review.

