### PR TITLE
Note limitations of RemovalOptions.since in Firefoxes

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1350,9 +1350,15 @@
                   "version_added": false
                 },
                 "firefox": {
+                  "notes": [
+                    "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>."
+                  ],
                   "version_added": "53"
                 },
                 "firefox_android": {
+                  "notes": [
+                    "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>."
+                  ],
                   "version_added": "56"
                 },
                 "opera": {


### PR DESCRIPTION
[`RemovalOptions.since`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/RemovalOptions) doesn't support all the data types that can be removed.