### PR TITLE
Add some font CSS properties compat data

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -1,0 +1,114 @@
+{
+  "css": {
+    "properties": {
+      "font-family": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "system_ui": {
+          "__compat": {
+            "description": "<code>system-ui</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": false
+                },
+                {
+                  "alternative_name": "-apple-system",
+                  "version_added": "43",
+                  "notes": "Supported on macOS only."
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "alternative_name": "-apple-system",
+                "version_added": true,
+                "notes": "Supported since macOS 10.11."
+              },
+              "safari_ios": {
+                "alternative_name": "-apple-system",
+                "version_added": true,
+                "notes": "Supported since iOS 9."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -105,6 +105,11 @@
                 "version_added": true,
                 "notes": "Supported since iOS 9."
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -97,7 +97,7 @@
               },
               "safari": {
                 "alternative_name": "-apple-system",
-                "version_added": true,
+                "version_added": "9",
                 "notes": "Supported since macOS 10.11."
               },
               "safari_ios": {

--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -30,7 +30,6 @@
               {
                 "version_added": "34",
                 "notes": [
-                  "Starting with Firefox 34, the version prefixed with <code>-moz-</code> is only kept for backward compatibility purpose. It is controlled by the <code>layout.css.prefixes.font-features</code>, defaulting to <code>true</code>. The prefixed property will be removed in the future.",
                   "The <a href='http://mpeg.chiariglione.org/standards/mpeg-4/open-font-format/text-isoiec-cd-14496-22-3rd-edition' >ISO/IEC CD 14496-22 3rd edition</a> suggests using the <code>ssty</code> feature to provide glyph variants more suitable for use in scripts (for example primes used as superscripts). Starting with Firefox 29, this is done automatically by the <a href='https://developer.mozilla.org/docs/Web/MathML'>MathML</a> rendering engine. The ISO/IEC CD 14496-22 3rd edition also suggests applying the <code>dtls</code> feature to letters when placing mathematical accents to get dotless forms (for example dotless i, j with a hat). Starting with Firefox 35, this is done automatically by the MathML rendering engine. You can override the default values determined by the MathML rendering engine with CSS."
                 ]
               },
@@ -44,7 +43,6 @@
               {
                 "version_added": "34",
                 "notes": [
-                  "Starting with Firefox 34, the version prefixed with <code>-moz-</code> is only kept for backward compatibility purpose. It is controlled by the <code>layout.css.prefixes.font-features</code>, defaulting to <code>true</code>. The prefixed property will be removed in the future.",
                   "The <a href='http://mpeg.chiariglione.org/standards/mpeg-4/open-font-format/text-isoiec-cd-14496-22-3rd-edition' >ISO/IEC CD 14496-22 3rd edition</a> suggests using the <code>ssty</code> feature to provide glyph variants more suitable for use in scripts (for example primes used as superscripts). Starting with Firefox 29, this is done automatically by the <a href='https://developer.mozilla.org/docs/Web/MathML'>MathML</a> rendering engine. The ISO/IEC CD 14496-22 3rd edition also suggests applying the <code>dtls</code> feature to letters when placing mathematical accents to get dotless forms (for example dotless i, j with a hat). Starting with Firefox 35, this is done automatically by the MathML rendering engine. You can override the default values determined by the MathML rendering engine with CSS."
                 ]
               },

--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -1,0 +1,100 @@
+{
+  "css": {
+    "properties": {
+      "font-feature-settings": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-feature-settings",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": [
+              {
+                "version_added": "48"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "16"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "48"
+            },
+            "edge": {
+              "version_added": "40.15063.0.0"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "34",
+                "notes": [
+                  "Starting with Firefox 34, the version prefixed with <code>-moz-</code> is only kept for backward compatibility purpose. It is controlled by the <code>layout.css.prefixes.font-features</code>, defaulting to <code>true</code>. The prefixed property will be removed in the future.",
+                  "The <a href='http://mpeg.chiariglione.org/standards/mpeg-4/open-font-format/text-isoiec-cd-14496-22-3rd-edition' >ISO/IEC CD 14496-22 3rd edition</a> suggests using the <code>ssty</code> feature to provide glyph variants more suitable for use in scripts (for example primes used as superscripts). Starting with Firefox 29, this is done automatically by the <a href='https://developer.mozilla.org/docs/Web/MathML'>MathML</a> rendering engine. The ISO/IEC CD 14496-22 3rd edition also suggests applying the <code>dtls</code> feature to letters when placing mathematical accents to get dotless forms (for example dotless i, j with a hat). Starting with Firefox 35, this is done automatically by the MathML rendering engine. You can override the default values determined by the MathML rendering engine with CSS."
+                ]
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "From Firefox 4 to Firefox 14 (inclusive), Firefox supported an older, slightly different syntax. See <a href='http://hacks.mozilla.org/2010/11/firefox-4-font-feature-support/'>OpenType Font Feature support in Firefox 4</a>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34",
+                "notes": [
+                  "Starting with Firefox 34, the version prefixed with <code>-moz-</code> is only kept for backward compatibility purpose. It is controlled by the <code>layout.css.prefixes.font-features</code>, defaulting to <code>true</code>. The prefixed property will be removed in the future.",
+                  "The <a href='http://mpeg.chiariglione.org/standards/mpeg-4/open-font-format/text-isoiec-cd-14496-22-3rd-edition' >ISO/IEC CD 14496-22 3rd edition</a> suggests using the <code>ssty</code> feature to provide glyph variants more suitable for use in scripts (for example primes used as superscripts). Starting with Firefox 29, this is done automatically by the <a href='https://developer.mozilla.org/docs/Web/MathML'>MathML</a> rendering engine. The ISO/IEC CD 14496-22 3rd edition also suggests applying the <code>dtls</code> feature to letters when placing mathematical accents to get dotless forms (for example dotless i, j with a hat). Starting with Firefox 35, this is done automatically by the MathML rendering engine. You can override the default values determined by the MathML rendering engine with CSS."
+                ]
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "From Firefox 4 to Firefox 14 (inclusive), Firefox supported an older, slightly different syntax. See <a href='http://hacks.mozilla.org/2010/11/firefox-4-font-feature-support/'>OpenType Font Feature support in Firefox 4</a>."
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "4",
+                "version_removed": "6"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9.3"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "3.2",
+                "version_removed": "6.1"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -21,7 +21,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "40.15063.0.0"
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": true
@@ -35,7 +35,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4",
+                "version_added": "15",
                 "notes": "From Firefox 4 to Firefox 14 (inclusive), Firefox supported an older, slightly different syntax. See <a href='http://hacks.mozilla.org/2010/11/firefox-4-font-feature-support/'>OpenType Font Feature support in Firefox 4</a>."
               }
             ],
@@ -48,7 +48,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4",
+                "version_added": "15",
                 "notes": "From Firefox 4 to Firefox 14 (inclusive), Firefox supported an older, slightly different syntax. See <a href='http://hacks.mozilla.org/2010/11/firefox-4-font-feature-support/'>OpenType Font Feature support in Firefox 4</a>."
               }
             ],

--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -58,12 +58,17 @@
             "ie_mobile": {
               "version_added": null
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
+            "opera": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "opera_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "safari": [
               {

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -27,7 +27,7 @@
               },
               {
                 "version_added": "24",
-                "version_removed": true,
+                "version_removed": "34",
                 "flag": {
                   "type": "preference",
                   "name": "layout.css.font-features.enabled",
@@ -41,7 +41,7 @@
               },
               {
                 "version_added": "24",
-                "version_removed": true,
+                "version_removed": "34",
                 "flag": {
                   "type": "preference",
                   "name": "layout.css.font-features.enabled",
@@ -53,7 +53,7 @@
               "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -1,0 +1,80 @@
+{
+  "css": {
+    "properties": {
+      "font-kerning": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-kerning",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "24",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "24",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -1,0 +1,149 @@
+{
+  "css": {
+    "properties": {
+      "font": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "system_fonts": {
+          "__compat": {
+            "description": "System fonts",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "6"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        },
+        "font_stretch_support": {
+          "__compat": {
+            "description": "Support for <code>font-stretch</code> values",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "43"
+              },
+              "firefox_android": {
+                "version_added": "43"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -94,6 +94,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -140,6 +145,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -24,25 +24,25 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
OK, let's try out a few `font` CSS properties. This PR adds the following properties:

* [font](https://developer.mozilla.org/docs/Web/CSS/font)
* [font-family](https://developer.mozilla.org/docs/Web/CSS/font-family)
* [font-feature-settings](https://developer.mozilla.org/docs/Web/CSS/font-feature-settings)
* [ｆｏｎｔ－ｋｅｒｎｉｎｇ](https://developer.mozilla.org/docs/Web/CSS/font-kerning)
