### PR TITLE
Add at-rule @keyframes compat data

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -53,16 +53,33 @@
             },
             "opera": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1",
+                "version_removed": "15"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
               },
               {
                 "prefix": "-o-",
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "15"
               }
             ],
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "12",
+                "version_removed": "15"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -49,7 +49,7 @@
               "version_added": "10"
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "opera": [
               {

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -125,6 +125,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -32,6 +32,19 @@
                 "version_added": "16"
               },
               {
+                "version_added": "49",
+                "prefix": "-webkit-"
+              },
+              {
+                "version_added": "44",
+                "prefix": "-webkit-",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              },
+              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -39,6 +52,19 @@
             "firefox_android": [
               {
                 "version_added": "16"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
+              },
+              {
+                "version_added": "44",
+                "prefix": "-webkit-",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "prefix": "-moz-",

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -72,9 +72,15 @@
                 "version_added": "4"
               }
             ],
-            "safari_ios": {
-              "version_added": null
-            }
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -1,0 +1,134 @@
+{
+  "css": {
+    "at-rules": {
+      "@keyframes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@keyframes",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "5"
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "12.10"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "12"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4"
+              }
+            ],
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "ignore_important_declarations": {
+          "__compat": {
+            "description": "Ignore <code>!important</code> declarations",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "19"
+              },
+              "firefox_android": {
+                "version_added": "19"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -5,10 +5,15 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@keyframes",
           "support": {
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "chrome": [
               {
                 "version_added": "43"
@@ -18,9 +23,15 @@
                 "version_added": true
               }
             ],
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "edge": {
               "version_added": true
             },


### PR DESCRIPTION
This PR adds one at-rule, [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes). Since it's the first of it's kind, I figured I should open a PR for this one alone.