### PR TITLE
Note support for and limitations of storage.managed in Firefox 57

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -8676,7 +8676,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "notes": [
+                  "Platform-specific storage backends, such as Windows registry keys, are not supported.",
+                  "Enforcement of extension-provided storage schemas is not supported.",
+                  "The <code>onChanged</code> event is not supported."
+                ],
+                "version_added": "57"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1386427 added basic support for the [`storage.managed`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage/managed) API in Firefox 57, desktop only.

Limitations of this basic support are noted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1386427#c19. 