### PR TITLE
Note earlier error behavior of contextualIdentities APIs

### DIFF
--- a/webextensions/javascript-apis.json
+++ b/webextensions/javascript-apis.json
@@ -1919,9 +1919,15 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
+                ],
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
+                ],
                 "version_added": "53"
               },
               "opera": {
@@ -1940,9 +1946,17 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
+                ],
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
+                ],
                 "version_added": "53"
               },
               "opera": {
@@ -2024,9 +2038,15 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
+                ],
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
+                ],
                 "version_added": "53"
               },
               "opera": {
@@ -2045,9 +2065,17 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
+                ],
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
+                ],
                 "version_added": "53"
               },
               "opera": {
@@ -2066,9 +2094,17 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
+                ],
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
+                ],
                 "version_added": "53"
               },
               "opera": {


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1395659#c18

I want to document the current error behavior (rejecting) and compat-note the old behavior (resolving).