### PR TITLE
Updates to the theme key for Firefox 57

### DIFF
--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -2075,7 +2075,7 @@
             }
           }
         },
-        "color": {
+        "colors": {
           "accentcolor": {
             "__compat": {
               "support": {
@@ -2181,27 +2181,6 @@
               }
             }
           },
-          "toolbar_text": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "57"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
           "toolbar_field": {
             "__compat": {
               "support": {
@@ -2224,6 +2203,27 @@
             }
           },
           "toolbar_field_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "toolbar_text": {
             "__compat": {
               "support": {
                 "chrome": {

--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -2164,7 +2164,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": false

--- a/webextensions/manifest-keys.json
+++ b/webextensions/manifest-keys.json
@@ -2074,6 +2074,176 @@
               "version_added": false
             }
           }
+        },
+        "color": {
+          "accentcolor": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "frame": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "tab_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "textcolor": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "toolbar": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "toolbar_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "toolbar_field": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "toolbar_field_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
         }
       },
       "version": {


### PR DESCRIPTION
Updates to [`theme.color`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/theme) for Firefox 57.

DDNs:

https://bugzilla.mozilla.org/show_bug.cgi?id=1347182: adds `theme.color.toolbar`, which is also supported in Chrome

https://bugzilla.mozilla.org/show_bug.cgi?id=1389465: adds `theme.color.toolbar_field` and `theme.color.toolbar_field_text`.

https://bugzilla.mozilla.org/show_bug.cgi?id=1387582: adds `theme.color.toolbar_text`.

To describe support, I split `color` out as a subfeature of `theme`, and enumerated all its properties as subfeatures, too. Some but not all of these are supported by Chrome as well as Firefox.
