### PR TITLE
Add order CSS property compat data

### DIFF
--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -1,0 +1,194 @@
+{
+  "css": {
+    "properties": {
+      "order": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/order",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "18",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "20",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "18",
+                "version_removed": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "absolutely_positioned_flex_children": {
+          "__compat": {
+            "description": "Absolutely-positioned flex children",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "12.1"
+              },
+              "opera_android": {
+                "version_added": "12.1"
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the [`order`](https://developer.mozilla.org/docs/Web/CSS/order) CSS property (a missed flexbox property; see also #437).