### PR TITLE
Add margin CSS properties compat data

### DIFF
--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "margin-block-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-end",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "margin-block-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-start",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -95,6 +95,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -74,7 +74,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6",

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "margin-bottom": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-bottom",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -1,0 +1,89 @@
+{
+  "css": {
+    "properties": {
+      "margin-inline-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-end",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "alternative_name": "-webkit-padding-end",
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "alternative_name": "-moz-padding-end",
+                "version_added": "3"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "alternative_name": "-moz-padding-end",
+                "version_added": "3"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "alternative_name": "-webkit-padding-end",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-end",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": true
             },
             "chrome": {
               "alternative_name": "-webkit-padding-end",
@@ -64,17 +64,17 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "alternative_name": "-webkit-padding-end",
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-start",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": true
             },
             "chrome": {
               "alternative_name": "-webkit-padding-start",
@@ -64,17 +64,17 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "alternative_name": "-webkit-padding-start",
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -1,0 +1,89 @@
+{
+  "css": {
+    "properties": {
+      "margin-inline-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-start",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "alternative_name": "-webkit-padding-start",
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "alternative_name": "-moz-padding-start",
+                "version_added": "3"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "alternative_name": "-moz-padding-start",
+                "version_added": "3"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "alternative_name": "-webkit-padding-start",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -95,6 +95,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -74,7 +74,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6",

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "margin-left": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-left",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -95,6 +95,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -74,7 +74,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6",

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "margin-right": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-right",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -95,6 +95,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -74,7 +74,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6",

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "margin-top": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-top",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -24,7 +24,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -95,6 +95,11 @@
               "safari_ios": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "margin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "1"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -74,7 +74,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6",


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [`margin`](https://developer.mozilla.org/docs/Web/CSS/margin)
* [`margin-block-end`](https://developer.mozilla.org/docs/Web/CSS/margin-block-end)
* [`margin-block-start`](https://developer.mozilla.org/docs/Web/CSS/margin-block-start)
* [`margin-bottom`](https://developer.mozilla.org/docs/Web/CSS/margin-bottom)
* [`margin-left`](https://developer.mozilla.org/docs/Web/CSS/margin-left)
* [`margin-right`](https://developer.mozilla.org/docs/Web/CSS/margin-right)
* [`margin-top`](https://developer.mozilla.org/docs/Web/CSS/margin-top)
* [`margin-inline-end`](https://developer.mozilla.org/docs/Web/CSS/margin-inline-end)
* [`margin-inline-start`](https://developer.mozilla.org/docs/Web/CSS/margin-inline-start)
