### PR TITLE
Invalidate stringly typed versions

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -18,8 +18,8 @@
           "required": ["type", "name"]
         },
         "partial_implementation": { "type": "boolean" },
-        "version_added": { "type": ["string", "boolean", "null"] },
-        "version_removed": { "type": ["string", "boolean", "null"] },
+        "version_added": { "$ref": "#/definitions/version_value" },
+        "version_removed": { "$ref": "#/definitions/version_value" },
         "notes": {
           "anyOf": [
             {
@@ -109,6 +109,13 @@
         "^(?!__compat|.*\\.).+$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
+    },
+
+    "version_value": {
+      "allOf": [
+        { "type": ["string", "boolean", "null"] },
+        { "not": { "enum": ["true", "false", "null"] } }
+      ]
     }
   },
 

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -502,10 +502,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "false"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "false"
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
It's currently possible to enter values for `version_added` and `version_removed` like `"true"` instead of `true` or `"null"` instead of `null`. This PR changes the schema to make `"true"`, `"false"`, and `"null"` unacceptable values for versions.