### PR TITLE
Add padding CSS properties compat data

### DIFF
--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "padding-block-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-end",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -12,13 +12,13 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "padding-block-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-start",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-bottom",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -24,25 +24,25 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "padding-bottom": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-bottom",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -1,0 +1,89 @@
+{
+  "css": {
+    "properties": {
+      "padding-inline-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-end",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "alternative_name": "-webkit-padding-end",
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "alternative_name": "-moz-padding-end",
+                "version_added": "3"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "alternative_name": "-moz-padding-end",
+                "version_added": "3"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "alternative_name": "-webkit-padding-end",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -6,14 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-end",
           "support": {
             "webview_android": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": true
             },
             "chrome": {
               "alternative_name": "-webkit-padding-end",
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": null
+              "alternative_name": "-webkit-padding-end",
+              "version_added": "2"
             },
             "edge": {
               "version_added": null
@@ -64,17 +66,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": "15"
             },
             "safari": {
               "alternative_name": "-webkit-padding-end",
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -6,20 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-start",
           "support": {
             "webview_android": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": true
             },
             "chrome": {
               "alternative_name": "-webkit-padding-start",
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": null
+              "alternative_name": "-webkit-padding-end",
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -64,17 +66,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": true
             },
             "safari": {
               "alternative_name": "-webkit-padding-start",
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "alternative_name": "-webkit-padding-end",
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -1,0 +1,89 @@
+{
+  "css": {
+    "properties": {
+      "padding-inline-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-start",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "alternative_name": "-webkit-padding-start",
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "alternative_name": "-moz-padding-start",
+                "version_added": "3"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "alternative_name": "-moz-padding-start",
+                "version_added": "3"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "alternative_name": "-webkit-padding-start",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-left",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -24,25 +24,25 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "padding-left": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-left",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "padding-right": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-right",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-right",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -24,25 +24,25 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-top",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -24,25 +24,25 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "padding-top": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-top",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -24,25 +24,25 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "padding": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [`padding`](https://developer.mozilla.org/docs/Web/CSS/padding)
* [`padding-left`](https://developer.mozilla.org/docs/Web/CSS/padding-left)
* [`padding-right`](https://developer.mozilla.org/docs/Web/CSS/padding-right)
* [`padding-bottom`](https://developer.mozilla.org/docs/Web/CSS/padding-bottom)
* [`padding-top`](https://developer.mozilla.org/docs/Web/CSS/padding-top)
* [`padding-block-end`](https://developer.mozilla.org/docs/Web/CSS/padding-block-end)
* [`padding-block-start`](https://developer.mozilla.org/docs/Web/CSS/padding-block-start)
* [`padding-inline-end`](https://developer.mozilla.org/docs/Web/CSS/padding-inline-end)
* [`padding-inline-start`](https://developer.mozilla.org/docs/Web/CSS/padding-inline-start)