### PR TITLE
Fix webkit preference notes for Firefox and Firefox for Android

### DIFF
--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -39,8 +39,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "From Firefox 44 to 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -39,8 +39,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "From Firefox 44 to 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -39,8 +39,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "From Firefox 44 to 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -39,8 +39,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "From Firefox 44 to 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -34,8 +34,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "version_added": "18",
@@ -54,8 +62,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "version_added": "18",

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -43,8 +43,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               }
             ],
             "ie": [

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -26,8 +26,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               }
             ],
             "firefox_android": [
@@ -36,8 +44,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               }
             ],
             "ie": {

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -37,8 +37,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "version_added": "18",
@@ -60,8 +68,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "version_added": "18",

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -54,8 +54,16 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49",
-                "notes": "For Firefox 48, the <code>-webkit-</code> prefix was available with the <code>layout.css.prefixes.webkit</code> preference. Starting with Firefox 49, the preference defaults to <code>true</code>."
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               },
               {
                 "version_added": "18",


### PR DESCRIPTION
This PR cleans up some inconsistency in the way the `layout.css.prefixes.webkit` preference is included as well as makes the data more structured. It's broken out (and partly expanded) from PR #419.