### PR TITLE
Mark browser.downloads.getFileIcon() as supported from firefox 48

### DIFF
--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -908,7 +908,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
This PR should fix #322 regarding the addition of `browser.downloads.getFileIcon()` in Firefox 48 (https://bugzilla.mozilla.org/show_bug.cgi?id=1245606)