### PR TITLE
Add missing Firefox note to @keyframes

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -40,7 +40,8 @@
             },
             "firefox": [
               {
-                "version_added": "16"
+                "version_added": "16",
+                "notes": "<code>@keyframes</code> is unsupported in scoped stylesheets in Firefox (<a href='https://bugzil.la/830056'>bug 830056</a>)."
               },
               {
                 "version_added": "49",


### PR DESCRIPTION
This PR fixes #489. At least, I think it does (it's hard to see what exactly the note was attached to, from the wiki page history).