### PR TITLE
Add more font- CSS properties

### DIFF
--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -1,0 +1,87 @@
+{
+  "css": {
+    "properties": {
+      "font-language-override": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-language-override",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-language-override",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -57,22 +57,22 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -19,10 +19,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -1,0 +1,72 @@
+{
+  "css": {
+    "properties": {
+      "font-size-adjust": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "43",
+              "flag": {
+                "type": "preference",
+                "name": "Enable experimental Web Platform features"
+              }
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "3",
+                "notes": "Before Firefox 40, <code>font-size-adjust: 0</code> was incorrectly interpreted as <code>font-size-adjust: none</code> (<a href='https://bugzil.la/1144885'>bug 1144885</a>)."
+              },
+              {
+                "version_added": "1",
+                "notes": "Before Firefox 3, <code>font-size-adjust</code> was supported on Windows only."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "30",
+              "flag": {
+                "type": "preference",
+                "name": "Enable experimental Web Platform features"
+              }
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -1,0 +1,114 @@
+{
+  "css": {
+    "properties": {
+      "font-size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "rem_values": {
+          "__compat": {
+            "description": "Rem values",
+            "support": {
+              "webview_android": {
+                "version_added": "4.1"
+              },
+              "chrome": {
+                "version_added": "31"
+              },
+              "chrome_android": {
+                "version_added": "42"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "31",
+                "notes": [
+                  "Before Firefox 57, animations using em units are not affected by changes to the <code>font-size</code> of the animated element's parent (<a href='https://bugzil.la/1254424'>bug 1254424</a>).",
+                  "Before Firefox 57, some language settings' inherited <code>font-size</code> is smaller than expected (<a href='https://bugzil.la/1391341'>bug 1391341</a>)"
+                ]
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "partial_implementation": true,
+                  "version_added": "9",
+                  "version_removed": "10"
+                }
+              ],
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": "12"
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "4.1"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -15,10 +15,10 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -65,7 +65,7 @@
                 "version_added": "42"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": "12"
@@ -78,7 +78,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "31"
               },
               "ie": [
                 {
@@ -103,7 +103,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "4.1"
+                "version_added": true
               }
             }
           }

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -74,7 +74,7 @@
                 "version_added": "31",
                 "notes": [
                   "Before Firefox 57, animations using em units are not affected by changes to the <code>font-size</code> of the animated element's parent (<a href='https://bugzil.la/1254424'>bug 1254424</a>).",
-                  "Before Firefox 57, some language settings' inherited <code>font-size</code> is smaller than expected (<a href='https://bugzil.la/1391341'>bug 1391341</a>)"
+                  "Before Firefox 57, some language settings' inherited <code>font-size</code> is smaller than expected (<a href='https://bugzil.la/1391341'>bug 1391341</a>)."
                 ]
               },
               "firefox_android": {

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -15,10 +15,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "9"
@@ -39,10 +39,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "font-stretch": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-stretch",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "48"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "9"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -12,13 +12,13 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1",

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "properties": {
+      "font-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-style",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Before Firefox 44, <code>oblique</code> was not distinguished from <code>italic</code>."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "Before Firefox 44, <code>oblique</code> was not distinguished from <code>italic</code>."
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds five more `font-` CSS properties:

* [`font-style`](https://developer.mozilla.org/docs/Web/CSS/font-style)
* [`font-stretch`](https://developer.mozilla.org/docs/Web/CSS/font-stretch)
* [`font-size-adjust`](https://developer.mozilla.org/docs/Web/CSS/font-size-adjust)
* [`font-size`](https://developer.mozilla.org/docs/Web/CSS/font-size)
* [`font-language-override`](https://developer.mozilla.org/docs/Web/CSS/font-language-override)
