### PR TITLE
Add ChannelSplitterNode

### DIFF
--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -1,0 +1,107 @@
+{
+  "api": {
+    "ChannelSplitterNode": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChannelSplitterNode",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "14"
+          },
+          "chrome_android": {
+            "version_added": "14"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "25"
+          },
+          "firefox_android": {
+            "version_added": "26"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "ie_mobile": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "15"
+          },
+          "safari": {
+            "version_added": "6"
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "ChannelSplitterNode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChannelSplitterNode/ChannelSplitterNode",
+          "description": "<code>ChannelSplitterNode()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": "55"
+            },
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -5,13 +5,16 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChannelSplitterNode",
         "support": {
           "webview_android": {
-            "version_added": true
+            "version_added": "14",
+            "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "chrome": {
-            "version_added": "14"
+            "version_added": "14",
+            "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "14",
+            "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "edge": {
             "version_added": true
@@ -32,10 +35,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "15",
+            "notes": "Starting in Opera 43, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "opera_android": {
-            "version_added": "15"
+            "version_added": "15",
+            "notes": "Starting in Opera 43, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "safari": {
             "version_added": "6"


### PR DESCRIPTION
I've got one thing here that I'm not sure about — on https://developer.mozilla.org/en-US/docs/Web/API/ChannelSplitterNode there is a note. How do you think I should add this?