### PR TITLE
Change in `frame-ancestors` support - Bug 1380755

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -589,10 +589,11 @@
               },
               "firefox": {
                 "version_added": "33",
-                "notes": "Before Firefox 58, this would be ignored in <code>Content-Security-Policy-Report-Only</code>"
+                "notes": "Before Firefox 58, <code>frame-ancestors</code> is ignored in <code>Content-Security-Policy-Report-Only</code>."
               },
               "firefox_android": {
-                "version_added": "33"
+                "version_added": "33",
+                "notes": "Before Firefox for Android 58, <code>frame-ancestors</code> is ignored in <code>Content-Security-Policy-Report-Only</code>."
               },
               "ie": {
                 "version_added": false

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -588,7 +588,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "33"
+                "version_added": "33",
+                "notes": "Before Firefox 58, this would be ignored in <code>Content-Security-Policy-Report-Only</code>"
               },
               "firefox_android": {
                 "version_added": "33"


### PR DESCRIPTION
Before Firefox 58 `frame-ancestors` would explicitly be ignored when used in `Content-Security-Policy-Report-Only`.