### PR TITLE
Note browsingData.removeHistory behavior in Firefox

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -490,6 +490,9 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "This function also removes download history."
+                ],
                 "version_added": "53"
               },
               "firefox_android": {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1401688 - Firefox clears download history when you call [browsingData.removeHistory](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/removeHistory).