### PR TITLE
Add more font- CSS properties

### DIFF
--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -1,0 +1,68 @@
+{
+  "css": {
+    "properties": {
+      "font-synthesis": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "33",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -38,22 +38,22 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9.1"
             }
           },
           "status": {

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "font-variant-alternates": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -49,22 +49,22 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "font-variant-caps": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-caps",
+          "support": {
+            "webview_android": {
+              "version_added": "52"
+            },
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "39"
+            },
+            "opera_android": {
+              "version_added": "39"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -15,10 +15,10 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -49,10 +49,10 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "39"
@@ -61,10 +61,10 @@
               "version_added": "39"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/font-variant-east-asian.json
+++ b/css/properties/font-variant-east-asian.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "font-variant-east-asian": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-variant-east-asian.json
+++ b/css/properties/font-variant-east-asian.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "63"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -49,22 +49,22 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "50"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -1,0 +1,283 @@
+{
+  "css": {
+    "properties": {
+      "font-variant": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "uppercase_eszett": {
+          "__compat": {
+            "description": "<code>ß</code> → <code>SS</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "turkic_is": {
+          "__compat": {
+            "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "14"
+              },
+              "firefox_android": {
+                "version_added": "14"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "greek_accented_characters": {
+          "__compat": {
+            "description": "Greek accented characters",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "css_fonts_shorthand": {
+          "__compat": {
+            "description": "CSS Fonts Module Level 3 shorthand",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "33",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "33",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following CSS properties:

* [`font-synthesis`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis)
* [`font-variant`](https://developer.mozilla.org/docs/Web/CSS/font-variant)
* [`font-variant-alternates`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates)
* [`font-variant-caps`](https://developer.mozilla.org/docs/Web/CSS/font-variant-caps)
* [`font-variant-east-asian`](https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian)

There's quite a bit of missing data, so I decided another small PR was in order.