### PR TITLE
Add @font-face CSS at-rule

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -127,7 +127,6 @@
                 },
                 {
                   "version_added": "35",
-                  "version_removed": "38",
                   "flag": {
                     "type": "preference",
                     "name": "gfx.downloadable_fonts.woff2.enabled",
@@ -141,7 +140,6 @@
                 },
                 {
                   "version_added": "35",
-                  "version_removed": "38",
                   "flag": {
                     "type": "preference",
                     "name": "gfx.downloadable_fonts.woff2.enabled",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -229,6 +229,7 @@
         "unicode_range": {
           "__compat": {
             "description": "<code>unicode-range</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/%40font-face/unicode-range",
             "support": {
               "webview_android": {
                 "version_added": null

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -15,10 +15,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -116,10 +116,10 @@
                 "version_added": "36"
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": [
                 {
@@ -160,10 +160,11 @@
                 "version_added": "23"
               },
               "safari": {
-                "version_added": false
+                "version_added": "10",
+                "notes": "Supported only on macOS 10.12 (Sierra) and later."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               }
             },
             "status": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -1,6 +1,6 @@
 {
   "css": {
-    "properties": {
+    "at-rules": {
       "font-face": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/at-rules/font-face",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -1,0 +1,283 @@
+{
+  "css": {
+    "properties": {
+      "font-face": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/at-rules/font-face",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "10"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "WOFF": {
+          "__compat": {
+            "description": "WOFF",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": {
+                "version_added": "6"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "11.1"
+              },
+              "opera_android": {
+                "version_added": "11"
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "WOFF_2": {
+          "__compat": {
+            "description": "WOFF 2",
+            "support": {
+              "webview_android": {
+                "version_added": "36"
+              },
+              "chrome": {
+                "version_added": "36"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "39"
+                },
+                {
+                  "version_added": "35",
+                  "version_removed": "38",
+                  "flag": {
+                    "type": "preference",
+                    "name": "gfx.downloadable_fonts.woff2.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "39"
+                },
+                {
+                  "version_added": "35",
+                  "version_removed": "38",
+                  "flag": {
+                    "type": "preference",
+                    "name": "gfx.downloadable_fonts.woff2.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "23"
+              },
+              "opera_android": {
+                "version_added": "23"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "SVG_fonts": {
+          "__compat": {
+            "description": "SVG fonts",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "unicode_range": {
+          "__compat": {
+            "description": "<code>unicode-range</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "36"
+              },
+              "firefox_android": {
+                "version_added": "36"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the [`@font-face`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) at-rule. This may be a work in progress, however.

On [the tracking spreadsheet](https://docs.google.com/spreadsheets/d/1ivgyPBr9Lj3Wvj5kyndT1rgGbX-pGggrxuMtrgcOmjM/edit#gid=1616230214), there are several descriptors related to `@font-face`, such as `unicode-range`. The wiki table includes `unicode-range` as a subfeature, but there's also a page for `unicode-range` with its own table. Duplication seems very likely to be wrong, so I'm guessing something needs to change (whether descriptor compat data should be subfeatures of the at-rule or not). Some guidance about what the change should be would be appreciated. Thanks!