### PR TITLE
Add basic support bcd for Window interface

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "Window": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "1"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": true
+          },
+          "ie_mobile": {
+            "version_added": true
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Yhe Window interface has more than 100 methods and properties. Most BCD doesn't exist on MDN, or as partial tables on the members themselves.

To ease review, and minimize the time between the research/copy of BCD and the addtion of the table on MDN, I'm breaking the work in small PR>

This one is the basic support of Window, that is the basic support of DOM (although Window is technically part of HTML, it has been added at a time where the separation between DOM and HTML was unclear).