### PR TITLE
Abortable fetch support in EdgeHTML16

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -14,10 +14,10 @@
             "version_added": false
           },
           "edge": {
-            "version_added": false
+            "version_added": "16"
           },
           "edge_mobile": {
-            "version_added": false
+            "version_added": "16"
           },
           "firefox": {
             "version_added": "57"
@@ -65,10 +65,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "57"
@@ -116,10 +116,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "57"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "57"

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -14,10 +14,10 @@
             "version_added": false
           },
           "edge": {
-            "version_added": false
+            "version_added": "16"
           },
           "edge_mobile": {
-            "version_added": false
+            "version_added": "16"
           },
           "firefox": {
             "version_added": "57"
@@ -64,10 +64,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "57"
@@ -115,10 +115,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "57"


### PR DESCRIPTION
AbortSignal / AbortController shipped this week with EdgeHTML 16 ([Windows 10 Fall Creators Update](https://blogs.windows.com/windowsexperience/2017/10/17/windows-10-fall-creators-update-and-mixed-reality-headsets-available-today-announcing-surface-book-2/)). Here are the compat table updates.