### PR TITLE
Update let keyword notes

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1699,7 +1699,7 @@
             "firefox_android": {
               "version_added": "44",
               "notes": [
-                "Prior to Firefox 44, <code>let</code> is only available to code blocks in HTML wrapped in a <code>&lt;script type=\"application/javascript;version=1.7\"&gt;</code> block (or higher version) and has different semantics.",
+                "Prior to Firefox 44, <code>let</code> is only available to code blocks in HTML wrapped in a <code>&lt;script type=\"application/javascript;version=1.7\"&gt;</code> block (or higher version) and has different semantics (e.g. no temporal dead zone).",
                 "Prior to Firefox 46, a <code>TypeError</code> is thrown on redeclaration instead of a <code>SyntaxError</code>.",
                 "Firefox 54 adds support of <code>let</code> in workers."
               ]


### PR DESCRIPTION
The point "_Prior to Firefox 44, let is only available to code blocks in HTML wrapped in a <script type="application/javascript;version=1.7"> block (or higher version) and has different semantics"_ is repeated twice in the [let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) page. So making the points under `firefox` and `firefox_android` the same so that only one of them is displayed in the page.