### PR TITLE
Output the errors on stderr instead of stdout

### DIFF
--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -11,8 +11,9 @@ function testSchema(dataFilename, schemaFilename = '../compat-data.schema.json')
     console.log('\x1b[32m  JSON schema – OK \x1b[0m');
     return false;
   } else {
-    console.log('\x1b[31m  JSON schema – ' + ajv.errors.length + ' error(s)\x1b[0m');
-    console.log('   ' + ajv.errorsText(ajv.errors, {
+    console.error('\x1b[31m  File : ' + dataFilename);
+    console.error('\x1b[31m  JSON schema – ' + ajv.errors.length + ' error(s)\x1b[0m');
+    console.error('   ' + ajv.errorsText(ajv.errors, {
       separator: '\n    ',
       dataVar: 'item'
     }));

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -31,14 +31,15 @@ function testStyle(filename) {
     console.log('\x1b[32m  Style – OK \x1b[0m');
   } else {
     hasErrors = true;
-    console.log('\x1b[31m  Style – Error on line ' + jsonDiff(actual, expected));
+    console.error('\x1b[31m  File : ' + filename);
+    console.error('\x1b[31m  Style – Error on line ' + jsonDiff(actual, expected));
   }
 
   let bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);
   if (bugzillaMatch) {
     // use https://bugzil.la/1000000 instead
     hasErrors = true;
-    console.log('\x1b[33m  Style – Use shortenable URL (%s → https://bugzil.la/%s).\x1b[0m', bugzillaMatch[0],
+    console.error('\x1b[33m  Style – Use shortenable URL (%s → https://bugzil.la/%s).\x1b[0m', bugzillaMatch[0],
       bugzillaMatch[1]);
   }
 
@@ -46,14 +47,14 @@ function testStyle(filename) {
   if (crbugMatch) {
     // use https://crbug.com/100000 instead
     hasErrors = true;
-    console.log('\x1b[33m  Style – Use shortenable URL (%s → https://crbug.com/%s).\x1b[0m', crbugMatch[0],
+    console.error('\x1b[33m  Style – Use shortenable URL (%s → https://crbug.com/%s).\x1b[0m', crbugMatch[0],
       crbugMatch[1]);
   }
 
   let mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`)
   if (mdnUrlMatch) {
     hasErrors = true;
-    console.log(
+    console.error(
       '\x1b[33m  Style – Use non-localized MDN URL (%s → https://developer.mozilla.org/%s).\x1b[0m',
       mdnUrlMatch[0],
       mdnUrlMatch[2]);
@@ -61,7 +62,7 @@ function testStyle(filename) {
 
   if (actual.includes("href=\\\"")) {
     hasErrors = true;
-    console.log('\x1b[33m  Style – Found \\\" but expected \' for <a href>.\x1b[0m');
+    console.error('\x1b[33m  Style – Found \\\" but expected \' for <a href>.\x1b[0m');
   }
 
   return hasErrors;

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -16,12 +16,12 @@ function testVersions(dataFilename) {
       if (validBrowserVersions[browser]) {
         if (typeof supportData[browser].version_added === "string" &&
             !validBrowserVersions[browser].includes(supportData[browser].version_added)) {
-          console.log('\x1b[31m  version_added: "' + supportData[browser].version_added + '" is not a valid version number for ' + browser);
+          console.error('\x1b[31m  version_added: "' + supportData[browser].version_added + '" is not a valid version number for ' + browser);
           hasErrors = true;
         }
         if (typeof supportData[browser].version_removed === "string" &&
             !validBrowserVersions[browser].includes(supportData[browser].version_removed)) {
-          console.log('\x1b[31m  version_removed: "' + supportData[browser].version_removed + '" is not a valid version number for ' + browser);
+          console.error('\x1b[31m  version_removed: "' + supportData[browser].version_removed + '" is not a valid version number for ' + browser);
           hasErrors = true;
         }
       }
@@ -42,7 +42,8 @@ function testVersions(dataFilename) {
   findSupport(data);
 
   if (hasErrors) {
-    console.log('\x1b[31m  Browser version error(s)\x1b[0m');
+    console.error('\x1b[31m  File : ' + filename); 
+    console.error('\x1b[31m  Browser version error(s)\x1b[0m');
     return true;
   } else {
     console.log('\x1b[32m  Browser versions – OK \x1b[0m');


### PR DESCRIPTION
I saw the issue #371 regarding the linting process being a bit tedious to read to find the error in all the output.

So I looked at making the errors on the `stderr` rather than on `stdout`. This allows to filter the error output using the standard std redirections.

The usual output would still be obtained with `npm test` but a shorter output with only the error could be obtained using a std redirection like `npm test 1> /dev/null`.