### PR TITLE
Add remaining font-variant-* CSS properties

### DIFF
--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -27,10 +27,10 @@
               "version_added": "34"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -61,7 +61,7 @@
               }
             ],
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "ie_mobile": {
               "version_added": null
@@ -78,14 +78,24 @@
             "opera_android": {
               "version_added": "21"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "7"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "7"
-            }
+            "safari": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -1,0 +1,99 @@
+{
+  "css": {
+    "properties": {
+      "font-variant-ligatures": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "34"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "31"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "34"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "21"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "19"
+              }
+            ],
+            "opera_android": {
+              "version_added": "21"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "font-variant-numeric": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric",
+          "support": {
+            "webview_android": {
+              "version_added": "52"
+            },
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "39"
+            },
+            "opera_android": {
+              "version_added": "39"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -15,10 +15,10 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -49,10 +49,10 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "39"
@@ -61,10 +61,10 @@
               "version_added": "39"
             },
             "safari": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-position",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -49,22 +49,22 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -1,0 +1,79 @@
+{
+  "css": {
+    "properties": {
+      "font-variant-position": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-position",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following CSS properties (the last of the `font-variant-` properties):

* [`font-variant-ligatures`](https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures)
* [`font-variant-numeric`](https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric)
* [`font-variant-position`](https://developer.mozilla.org/docs/Web/CSS/font-variant-position)
