### PR TITLE
Add line-height CSS property

### DIFF
--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "line-height": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-height",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the [`line-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height) property (which didn't seem to fit with anything else, thus the standalone PR).