### PR TITLE
adding BaseAudioContext

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1,0 +1,1705 @@
+{
+  "api": {
+    "BaseAudioContext": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext",
+        "support": {
+          "webview_android": {
+            "version_added": "55"
+          },
+          "chrome": {
+            "version_added": "55"
+          },
+          "chrome_android": {
+            "version_added": "55"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "53"
+          },
+          "firefox_android": {
+            "version_added": "53"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "ie_mobile": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "42"
+          },
+          "opera_android": {
+            "version_added": "42"
+          },
+          "safari": {
+            "version_added": false,
+            "notes": "Some members supported, but still with a webkit prefix, and on the <code>AudioContext</code> interface."
+          },
+          "safari_ios": {
+            "version_added": false,
+            "notes": "Some members supported, but still with a webkit prefix, and on the <code>AudioContext</code> interface."
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "currentTime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/currentTime",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "destination": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/destination",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "listener": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/listener",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sampleRate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "state": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/state",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onstatechange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/onstatechange",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createAnalyser": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createAnalyser",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createBiquadFilter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBiquadFilter",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBuffer",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createBufferSource": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBufferSource",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createChannelMerger": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelMerger",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createChannelSplitter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelSplitter",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createConstantSource": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConstantSource",
+          "support": {
+            "webview_android": {
+              "version_added": "56"
+            },
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createConvolver": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConvolver",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createDelay": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDelay",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createDynamicsCompressor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDynamicsCompressor",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createGain": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createGain",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createIIRFilter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createIIRFilter",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createOscillator": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createOscillator",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createPanner": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPanner",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createPeriodicWave": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPeriodicWave",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface. Before Chrome 59, the default values were not supported."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface. Before Chrome 59, the default values were not supported."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface. Before Chrome 59, the default values were not supported."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "Disable normalization constraints": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "createScriptProcessor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createScriptProcessor",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createStereoPanner": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createStereoPanner",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createWaveShaper": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createWaveShaper",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "decodeAudioData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/decodeAudioData",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Still available on the <code>AudioContext</code> interface with a <code>webkit</code> prefix."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "Promise-based syntax": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": "55",
+                "notes": "Previously available on the <code>AudioContext</code> interface."
+              },
+              "chrome": {
+                "version_added": "55",
+                "notes": "Previously available on the <code>AudioContext</code> interface."
+              },
+              "chrome_android": {
+                "version_added": "55",
+                "notes": "Previously available on the <code>AudioContext</code> interface."
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "53",
+                "notes": "Previously available on the <code>AudioContext</code> interface."
+              },
+              "firefox_android": {
+                "version_added": "53",
+                "notes": "Previously available on the <code>AudioContext</code> interface."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "42",
+                "notes": "Previously available on the <code>AudioContext</code> interface."
+              },
+              "opera_android": {
+                "version_added": "42",
+                "notes": "Previously available on the <code>AudioContext</code> interface."
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "resume": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/resume",
+          "support": {
+            "webview_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "chrome_android": {
+              "version_added": "55",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "opera_android": {
+              "version_added": "42",
+              "notes": "Previously available on the <code>AudioContext</code> interface."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Yes, I know it's a mixin, but I decided to just get it done anyway, as we can always edit it later.

One point of contention — a lot of these features used to hang off AudioContext, but were later moved to BaseAudioContext. I've dealt with this by adding notes to the data points in question, but I wasn't sure if 

a. This was the best way to deal with it, or
b. If anything else was needed. For example, It might possibly be helpful to state somewhere exactly what versions of browsers first supported them on AudioContext, and when the prefixes were dropped. BUT this would be a nightmare to represent, so thus far I haven't tried ;-)