### PR TITLE
Add CSS transition properties

### DIFF
--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -5,34 +5,49 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-delay",
           "support": {
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "2.1"
-            },
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "edge": [
+            "webview_android": [
               {
                 "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.1"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": true
               }
             ],
-            "edge_mobile": [
+            "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -42,6 +57,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -60,6 +79,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -82,9 +105,13 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
                 "version_added": "11.6",
-                "version_removed": "12.5"
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -92,19 +119,33 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
                 "version_added": "10",
-                "version_removed": "12.5"
+                "version_removed": "15"
               }
             ],
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "3"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "3.2"
-            }
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -1,0 +1,118 @@
+{
+  "css": {
+    "properties": {
+      "transition-delay": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-delay",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.6",
+                "version_removed": "12.5"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10",
+                "version_removed": "12.5"
+              }
+            ],
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -1,0 +1,123 @@
+{
+  "css": {
+    "properties": {
+      "transition-duration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-duration",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "2.1"
+            },
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10",
+                "version_removed": "12.5"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10",
+                "version_removed": "12.5"
+              }
+            ],
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -5,39 +5,49 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-duration",
           "support": {
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "2.1"
-            },
-            "chrome": [
+            "webview_android": [
               {
                 "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.1"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "26"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "edge": [
+            "chrome_android": [
               {
-                "version_added": true
+                "version_added": "26"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": true
               }
             ],
-            "edge_mobile": [
+            "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -47,6 +57,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -65,6 +79,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -87,9 +105,13 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
                 "version_added": "10",
-                "version_removed": "12.5"
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -97,19 +119,33 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
                 "version_added": "10",
-                "version_removed": "12.5"
+                "version_removed": "15"
               }
             ],
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "3"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "3.2"
-            }
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -5,19 +5,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-property",
           "support": {
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "edge": [
+            "webview_android": [
               {
                 "version_added": true
               },
@@ -26,13 +14,40 @@
                 "version_added": true
               }
             ],
-            "edge_mobile": [
+            "chrome": [
               {
-                "version_added": true
+                "version_added": "26"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -42,6 +57,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -60,6 +79,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -82,22 +105,36 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
                 "version_added": "11.6",
-                "version_removed": "12.5"
+                "version_removed": "15"
               }
             ],
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": true
-            }
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -110,13 +147,13 @@
             "description": "<code>IDENT</code> value",
             "support": {
               "webview_android": {
-                "version_added": null
+                "version_added": true
               },
               "chrome": {
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null
@@ -128,7 +165,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": true
@@ -137,10 +174,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": false

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -1,0 +1,162 @@
+{
+  "css": {
+    "properties": {
+      "transition-property": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-property",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.6",
+                "version_removed": "12.5"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "IDENT_value": {
+          "__compat": {
+            "description": "<code>IDENT</code> value",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -112,7 +112,7 @@
         },
         "frames": {
           "__compat": {
-            "description": "<code>frames()</code>",
+            "description": "<code>steps()</code>",
             "support": {
               "webview_android": {
                 "version_added": false

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -5,10 +5,15 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-timing-function",
           "support": {
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "chrome": [
               {
                 "version_added": "26"
@@ -18,26 +23,31 @@
                 "version_added": true
               }
             ],
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "edge": [
+            "chrome_android": [
               {
-                "version_added": true
+                "version_added": "26"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": true
               }
             ],
-            "edge_mobile": [
+            "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -47,6 +57,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -65,6 +79,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -87,22 +105,36 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
                 "version_added": "11.6",
-                "version_removed": "12.5"
+                "version_removed": "15"
               }
             ],
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": true
-            }
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -141,57 +141,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "frames": {
-          "__compat": {
-            "description": "<code>steps()</code>",
-            "support": {
-              "webview_android": {
-                "version_added": false
-              },
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -1,0 +1,167 @@
+{
+  "css": {
+    "properties": {
+      "transition-timing-function": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-timing-function",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.6",
+                "version_removed": "12.5"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "frames": {
+          "__compat": {
+            "description": "<code>frames()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -183,7 +183,7 @@
           },
           "frames": {
             "__compat": {
-              "description": "<code>frames()</code>",
+              "description": "<code>steps()</code>",
               "support": {
                 "webview_android": {
                   "version_added": null

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -5,10 +5,15 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition",
           "support": {
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "2.1"
-            },
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.1"
+              }
+            ],
             "chrome": [
               {
                 "version_added": "26"
@@ -18,25 +23,31 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": [
+            "chrome_android": [
               {
-                "version_added": true
+                "version_added": "26"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": true
               }
             ],
-            "edge_mobile": [
+            "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -51,6 +62,10 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
               },
               {
                 "prefix": "-webkit-",
@@ -76,6 +91,10 @@
                 "version_added": "4"
               },
               {
+                "version_added": "49",
+                "prefix": "-webkit-"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "44",
                 "flag": {
@@ -96,9 +115,13 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
                 "version_added": "10.1",
-                "version_removed": "12.5"
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -106,9 +129,13 @@
                 "version_added": "12.1"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
                 "prefix": "-o-",
-                "version_added": "10",
-                "version_removed": "12.5"
+                "version_added": "10.1",
+                "version_removed": "15"
               }
             ],
             "safari": [
@@ -120,10 +147,15 @@
                 "version_added": "3"
               }
             ],
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "3.2"
-            }
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -1,0 +1,229 @@
+{
+  "css": {
+    "properties": {
+      "transition": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "2.1"
+            },
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": "10"
+            },
+            "opera": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10.1",
+                "version_removed": "12.5"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10",
+                "version_removed": "12.5"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "6.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "gradients": {
+          "__compat": {
+            "description": "Gradients",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "frames": {
+            "__compat": {
+              "description": "<code>frames()</code>",
+              "support": {
+                "webview_android": {
+                  "version_added": null
+                },
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "ie_mobile": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -212,57 +212,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "frames": {
-            "__compat": {
-              "description": "<code>steps()</code>",
-              "support": {
-                "webview_android": {
-                  "version_added": null
-                },
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -41,7 +41,12 @@
             ],
             "firefox": [
               {
-                "version_added": "16"
+                "version_added": "16",
+                "notes": [
+                  "Before Firefox 57, transitions do not work when transitioning from a <a href='https://developer.mozilla.org/docs/Web/CSS/text-shadow'><code>text-shadow</code></a> with a color specified to a <code>text-shadow</code> without a color specified (see <A href='https://bugzil.la/726550'>bug 726550</a>).",
+                  "Before Firefox 57, cancelling a filling animation (for example, with <code>animation-fill-mode: forwards</code> set) can trigger a transition set on the same element, although only once (see <a href='https://bugzil.la/1192592'>bug 1192592</a> and <a href='https://bug1192592.bmoattachments.org/attachment.cgi?id=8843824'>these test cases</a> for more information).",
+                  "Before Firefox 57, the <a href='https://developer.mozilla.org/docs/Web/CSS/background-position'><code>background-position</code></a> property can't be transitioned between two values containing different numbers of <a href='https://developer.mozilla.org/docs/Web/CSS/position_value' t><code>&lt;position&gt;</code></a> values, for example <code>background-position: 10px 10px;</code> and <code>background-position: 20px 20px, 30px 30px;</code> (see <a href='https://bugzil.la/1390446'>bug 1390446</a>)."
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -59,7 +64,12 @@
             ],
             "firefox_android": [
               {
-                "version_added": "16"
+                "version_added": "16",
+                "notes": [
+                  "Before Firefox 57, transitions do not work when transitioning from a <a href='https://developer.mozilla.org/docs/Web/CSS/text-shadow'><code>text-shadow</code></a> with a color specified to a <code>text-shadow</code> without a color specified (see <A href='https://bugzil.la/726550'>bug 726550</a>).",
+                  "Before Firefox 57, cancelling a filling animation (for example, with <code>animation-fill-mode: forwards</code> set) can trigger a transition set on the same element, although only once (see <a href='https://bugzil.la/1192592'>bug 1192592</a> and <a href='https://bug1192592.bmoattachments.org/attachment.cgi?id=8843824'>these test cases</a> for more information).",
+                  "Before Firefox 57, the <a href='https://developer.mozilla.org/docs/Web/CSS/background-position'><code>background-position</code></a> property can't be transitioned between two values containing different numbers of <a href='https://developer.mozilla.org/docs/Web/CSS/position_value' t><code>&lt;position&gt;</code></a> values, for example <code>background-position: 10px 10px;</code> and <code>background-position: 20px 20px, 30px 30px;</code> (see <a href='https://bugzil.la/1390446'>bug 1390446</a>)."
+                ]
               },
               {
                 "prefix": "-moz-",


### PR DESCRIPTION
This adds the following CSS properties:

* [`transition-delay`](https://developer.mozilla.org/docs/Web/CSS/transition-delay)
* [`transition-duration`](https://developer.mozilla.org/docs/Web/CSS/transition-duration)
* [`transition-property`](https://developer.mozilla.org/docs/Web/CSS/transition-property)
* [`transition-timing-function`](https://developer.mozilla.org/docs/Web/CSS/transition-timing-function)
* [`transition`](https://developer.mozilla.org/docs/Web/CSS/transition)

One issue here I was unable to resolve was `frames()`, which is being renamed `steps()`. I had a few ideas of how to handle it and I wasn't happy with any of them:

* Include separate entries for `frames()` and `steps()`, since someone might want to know whether the former was supported before the introduction of the latter
* Rename `frames()` to `steps()` and pretend the former never existed
* Make the description longer (e.g., something like `<code>steps()</code> (formerly known as <code>frames()</code>)`
* Suggest an addition to the schema for a `notes` property for features, to handle cases like this

Open to suggestions on this. 😄 