### PR TITLE
Add compat data for @font-face descriptors

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -328,6 +328,58 @@
               "deprecated": false
             }
           }
+        },
+        "src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/src",
+            "description": "<code>src</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.2"
+              },
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "9"
+              },
+              "opera_android": {
+                "version_added": "12"
+              },
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": "3.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -281,25 +281,19 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "4.4"
+                "version_added": false
               },
-              "chrome": [
-                {
-                  "version_added": "48"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "16"
-                }
-              ],
+              "chrome": {
+                "version_added": false
+              },
               "chrome_android": {
-                "version_added": "48"
+                "version_added": false
               },
               "edge": {
-                "version_added": "15"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": [
                 {
@@ -328,43 +322,23 @@
                 }
               ],
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "ie_mobile": {
-                "version_added": null
+                "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "35"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "15"
-                }
-              ],
+              "opera": {
+                "version_added": false
+              },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
-              "safari": [
-                {
-                  "version_added": "9.1"
-                },
-                {
-                  "partial_implementation": true,
-                  "version_added": "4",
-                  "version_removed": "6"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "9.3"
-                },
-                {
-                  "partial_implementation": true,
-                  "version_added": "3.2",
-                  "version_removed": "6.1"
-                }
-              ]
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -225,114 +225,10 @@
             }
           }
         },
-        "unicode_range": {
-          "__compat": {
-            "description": "<code>unicode-range</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/%40font-face/unicode-range",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "36"
-              },
-              "firefox_android": {
-                "version_added": "36"
-              },
-              "ie": {
-                "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "font_family": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-family",
             "description": "<code>font-family</code>",
-            "support": {
-              "webview_android": {
-                "version_added": "2.2"
-              },
-              "chrome": {
-                "version_added": "4"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "3.5"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": "10"
-              },
-              "opera": {
-                "version_added": "9"
-              },
-              "opera_android": {
-                "version_added": "12"
-              },
-              "safari": {
-                "version_added": "3.1"
-              },
-              "safari_ios": {
-                "version_added": "3.1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "src": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/src",
-            "description": "<code>src</code>",
             "support": {
               "webview_android": {
                 "version_added": "2.2"
@@ -421,6 +317,110 @@
               },
               "safari": {
                 "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/src",
+            "description": "<code>src</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.2"
+              },
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "9"
+              },
+              "opera_android": {
+                "version_added": "12"
+              },
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": "3.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "unicode_range": {
+          "__compat": {
+            "description": "<code>unicode-range</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/%40font-face/unicode-range",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "36"
+              },
+              "firefox_android": {
+                "version_added": "36"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
               },
               "safari_ios": {
                 "version_added": true

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -276,6 +276,58 @@
               "deprecated": false
             }
           }
+        },
+        "font_family": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-family",
+            "description": "<code>font-family</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.2"
+              },
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "ie_mobile": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "9"
+              },
+              "opera_android": {
+                "version_added": "12"
+              },
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": "3.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -426,6 +426,57 @@
             }
           }
         },
+        "font_weight": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-weight",
+            "support": {
+              "webview_android": {
+                "version_added": "1"
+              },
+              "chrome": {
+                "version_added": "2"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "3"
+              },
+              "ie_mobile": {
+                "version_added": "6"
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "6"
+              },
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": {
+                "version_added": "3.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "src": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/src",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -277,6 +277,103 @@
             }
           }
         },
+        "font_feature_settings": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-feature-settings",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": [
+                {
+                  "version_added": "48"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "16"
+                }
+              ],
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "34",
+                  "notes": [
+                    "The <a href='http://mpeg.chiariglione.org/standards/mpeg-4/open-font-format/text-isoiec-cd-14496-22-3rd-edition' >ISO/IEC CD 14496-22 3rd edition</a> suggests using the <code>ssty</code> feature to provide glyph variants more suitable for use in scripts (for example primes used as superscripts). Starting with Firefox 29, this is done automatically by the <a href='https://developer.mozilla.org/docs/Web/MathML'>MathML</a> rendering engine. The ISO/IEC CD 14496-22 3rd edition also suggests applying the <code>dtls</code> feature to letters when placing mathematical accents to get dotless forms (for example dotless i, j with a hat). Starting with Firefox 35, this is done automatically by the MathML rendering engine. You can override the default values determined by the MathML rendering engine with CSS."
+                  ]
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "15",
+                  "notes": "From Firefox 4 to Firefox 14 (inclusive), Firefox supported an older, slightly different syntax. See <a href='http://hacks.mozilla.org/2010/11/firefox-4-font-feature-support/'>OpenType Font Feature support in Firefox 4</a>."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34",
+                  "notes": [
+                    "The <a href='http://mpeg.chiariglione.org/standards/mpeg-4/open-font-format/text-isoiec-cd-14496-22-3rd-edition' >ISO/IEC CD 14496-22 3rd edition</a> suggests using the <code>ssty</code> feature to provide glyph variants more suitable for use in scripts (for example primes used as superscripts). Starting with Firefox 29, this is done automatically by the <a href='https://developer.mozilla.org/docs/Web/MathML'>MathML</a> rendering engine. The ISO/IEC CD 14496-22 3rd edition also suggests applying the <code>dtls</code> feature to letters when placing mathematical accents to get dotless forms (for example dotless i, j with a hat). Starting with Firefox 35, this is done automatically by the MathML rendering engine. You can override the default values determined by the MathML rendering engine with CSS."
+                  ]
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "15",
+                  "notes": "From Firefox 4 to Firefox 14 (inclusive), Firefox supported an older, slightly different syntax. See <a href='http://hacks.mozilla.org/2010/11/firefox-4-font-feature-support/'>OpenType Font Feature support in Firefox 4</a>."
+                }
+              ],
+              "ie": {
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "35"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "15"
+                }
+              ],
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": [
+                {
+                  "version_added": "9.1"
+                },
+                {
+                  "partial_implementation": true,
+                  "version_added": "4",
+                  "version_removed": "6"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "9.3"
+                },
+                {
+                  "partial_implementation": true,
+                  "version_added": "3.2",
+                  "version_removed": "6.1"
+                }
+              ]
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "font_style": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-style",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -279,7 +279,6 @@
         },
         "font_feature_settings": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-feature-settings",
             "support": {
               "webview_android": {
                 "version_added": "4.4"
@@ -428,7 +427,6 @@
         },
         "font_weight": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-weight",
             "support": {
               "webview_android": {
                 "version_added": "1"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -403,43 +403,43 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "1"
+                "version_added": true
               },
               "chrome": {
-                "version_added": "2"
+                "version_added": "4"
               },
               "chrome_android": {
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "3.5"
               },
               "firefox_android": {
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "3"
+                "version_added": "4"
               },
               "ie_mobile": {
-                "version_added": "6"
+                "version_added": true
               },
               "opera": {
-                "version_added": "3.5"
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": "6"
+                "version_added": "10"
               },
               "safari": {
-                "version_added": "1.3"
+                "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": true
               }
             },
             "status": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -380,6 +380,58 @@
               "deprecated": false
             }
           }
+        },
+        "font_style": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-style",
+            "description": "<code>font-style</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "10"
+              },
+              "opera_android": {
+                "version_added": "10"
+              },
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This adds compat data for the following descriptors to `@font-face`:

* [`src`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src)
* [`font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family)
* [`font-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-style)