### PR TITLE
Note non-support for since in remove{LocalStorage, Cache}

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -406,9 +406,15 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "<code>removalOptions.since</code> is not supported."
+                ],
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "<code>removalOptions.since</code> is not supported."
+                ],
                 "version_added": "57"
               },
               "opera": {
@@ -514,9 +520,15 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": [
+                  "<code>removalOptions.since</code> is not supported."
+                ],
                 "version_added": "57"
               },
               "firefox_android": {
+                "notes": [
+                  "<code>removalOptions.since</code> is not supported."
+                ],
                 "version_added": "57"
               },
               "opera": {


### PR DESCRIPTION
[`removeLocalStorage`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/removeLocalStorage) and [`removeCache`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/removeCache) don't support `since`: https://bugzilla.mozilla.org/show_bug.cgi?id=1355576.

(neither do `removeIndexedDB` or `removeServiceWorkers`, but we don't support these yet AFAIK.)