### PR TITLE
Rename frames to steps

### DIFF
--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -155,24 +155,21 @@
             "deprecated": false
           }
         },
-        "frames": {
+        "steps": {
           "__compat": {
-            "description": "frames()",
+            "description": "steps()",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "chrome_android": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -181,8 +178,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -154,42 +154,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "steps": {
-          "__compat": {
-            "description": "steps()",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -134,27 +134,24 @@
             "deprecated": false
           }
         },
-        "frames_timing_function": {
+        "steps": {
           "__compat": {
-            "description": "<code>frames</code> timing function",
+            "description": "<code>steps()</code>",
             "support": {
               "webview_android": {
                 "version_added": false
               },
               "chrome": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "chrome_android": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -163,12 +160,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "opera_android": {
-                "version_added": false,
-                "notes": "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>under discussion</a>, so it is disabled in browser release versions until a final decision is reached. It is enabled in Nightly/Canary only."
+                "version_added": false
               },
               "safari": {
                 "version_added": false

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -133,51 +133,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "steps": {
-          "__compat": {
-            "description": "<code>steps()</code>",
-            "support": {
-              "webview_android": {
-                "version_added": false
-              },
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
The CSS Working Group has concluded [its discussion on the name](https://github.com/w3c/csswg-drafts/issues/1301#issuecomment-319710740), so this PR renames `frames()` to `steps()` and removes outdated notes that the name is still under discussion. This makes things more consistent with the discussion on #533.