### PR TITLE
Add @font-feature-values at-rule

### DIFF
--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -71,6 +71,509 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "annotation": {
+          "__compat": {
+            "description": "<code>@annotation</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#@annotation",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "character-variant": {
+          "__compat": {
+            "description": "<code>@character-variant</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#@character-variant",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "historical-forms": {
+          "__compat": {
+            "description": "<code>@historical-forms</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ornaments": {
+          "__compat": {
+            "description": "<code>@ornaments</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#@ornaments",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "styleset": {
+          "__compat": {
+            "description": "<code>@styleset</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#@styleset",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "stylistic": {
+          "__compat": {
+            "description": "<code>@stylistic</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#@stylistic",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "swash": {
+          "__compat": {
+            "description": "<code>@swash</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#@swash",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -7,19 +7,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -48,22 +48,22 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9.3"
             }
           },
           "status": {

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -3,6 +3,7 @@
     "at-rules": {
       "font-feature-values": {
         "__compat": {
+          "description": "<code>@font-feature-values</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values",
           "support": {
             "webview_android": {

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -1,0 +1,77 @@
+{
+  "css": {
+    "at-rules": {
+      "font-feature-values": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "24",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.font-features.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the [`@font-feature-values`](https://developer.mozilla.org/docs/Web/CSS/@font-feature-values) at-rule, though there's not a lot of data here and a cursory search didn't turn up anything I could add.