### PR TITLE
Add CSS list-style properties

### DIFF
--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "list-style-image": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/list-style-image",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/list-style-position.json
+++ b/css/properties/list-style-position.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "list-style-position": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/list-style-position",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "list-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/list-style",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This one is a little bit of a work in progress. To start, I've added the following properties:

* [`list-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style)
* [`list-style-image`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-image)
* [`list-style-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-position)

I'd like to add [`list-style-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type) as well, but it's quite complicated. Specifically, there's several groups of languages represented in the wiki compat data table. They're not really identifiable groups however—just somewhat arbitrary lists of values. That seems a bit haphazard for our schema. I'd love to hear your thoughts on how best to represent them as features.