### PR TITLE
Add font-variant-alternates function compat data

### DIFF
--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -368,6 +368,80 @@
               "deprecated": true
             }
           }
+        },
+        "stylistic": {
+          "__compat": {
+            "description": "<code>stylistic()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#stylistic()",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -146,6 +146,80 @@
               "deprecated": true
             }
           }
+        },
+        "character_variant": {
+          "__compat": {
+            "description": "<code>character-variant()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#character-variant()",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -72,6 +72,80 @@
             "standard_track": true,
             "deprecated": true
           }
+        },
+        "annotation": {
+          "__compat": {
+            "description": "<code>annotation()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#annotation()",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -294,6 +294,80 @@
               "deprecated": true
             }
           }
+        },
+        "styleset": {
+          "__compat": {
+            "description": "<code>styleset()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#styleset()",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -442,6 +442,80 @@
               "deprecated": true
             }
           }
+        },
+        "swash": {
+          "__compat": {
+            "description": "<code>swash()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#swash()",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -220,6 +220,80 @@
               "deprecated": true
             }
           }
+        },
+        "ornaments": {
+          "__compat": {
+            "description": "<code>ornaments()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#ornaments()",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "24",
+                  "version_removed": "34",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This adds features to `font-variant-alternates` for the functions:

* `annotation()`
* `character-variant()`
* `ornaments()`
* `styleset()`
* `stylistic()`
* `swash()`