### PR TITLE
Add version compatibility for `options_ui` WebExtension manifest

### DIFF
--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -5,19 +5,19 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "40"
             },
             "edge": {
               "version_added": false
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "48"
             },
             "firefox_android": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "27"
             }
           }
         },
@@ -25,7 +25,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "40"
               },
               "edge": {
                 "version_added": false
@@ -37,7 +37,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               }
             }
           }
@@ -59,6 +59,30 @@
               },
               "opera": {
                 "version_added": false
+              }
+            }
+          }
+        },
+        "open_in_tab": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false,
+                "notes": [
+                  "Does not support inline extension options, it always opens it in a separate tab."
+                ]
               }
             }
           }


### PR DESCRIPTION
[Chrome started supporting `options_ui` since Chrome 40](https://developer.chrome.com/extensions/optionsV2)
[Firefox started supporting `options_ui` since Firefox 48](https://blog.mozilla.org/addons/2016/04/29/webextensions-in-firefox-48/)

Inline extension options UI is only supported on Chrome and Firefox, Opera always opens it in a separate tab.

![chrome](https://user-images.githubusercontent.com/6135313/31931348-86c2a652-b8d5-11e7-93b8-79751a7c9c3c.PNG)

![firefox48](https://user-images.githubusercontent.com/6135313/31932620-5ac69f50-b8d9-11e7-8606-3c7d0b70eb10.PNG)

![opera](https://user-images.githubusercontent.com/6135313/31931353-89d5a2e0-b8d5-11e7-81b0-461ad60b9b2a.PNG)