### PR TITLE
Mark tabs.onReplaced as unsupported in Firefox

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1564,16 +1564,10 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ],
-                "version_added": "45"
+                "version_added": false
               },
               "firefox_android": {
-                "notes": [
-                  "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
-                ],
-                "version_added": "54"
+                "version_added": false
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
Marking this event as unsupported is clearly more helpful than saying it is supported, then saying it is unsupported in the notes :).
