### PR TITLE
Update regex anchored sticky flag compatibilty

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1309,10 +1309,10 @@
                   "version_added": null
                 },
                 "chrome": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": true
@@ -1336,13 +1336,13 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera_android": {
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "safari_ios": {
                   "version_added": null


### PR DESCRIPTION
Tested on Chrome 61, Safari 11, Opera 46