### PR TITLE
GeneratorFunction - Edge & Opera

### DIFF
--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
@@ -68,7 +68,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -89,7 +89,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
Added info that GeneratorFunction and GeneratorFunction.prototype are available in Edge and Opera. All functionality works as described in the documentation pages.
I'm not sure what versions they were added in, I'm using the latest (Edge: 40.15063.674.0, Opera: 48.0.2685.52 (PGO)) on Windows 10 x64.