### PR TITLE
Add compat data for some CSS grid properties

### DIFF
--- a/css/properties/grid-area.json
+++ b/css/properties/grid-area.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "grid-area": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-area",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -1,0 +1,121 @@
+{
+  "css": {
+    "properties": {
+      "grid-auto-columns": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-columns",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "-ms-grid-columns"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "-ms-grid-columns"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10",
+              "alternative_name": "-ms-grid-columns"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-auto-flow.json
+++ b/css/properties/grid-auto-flow.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "grid-auto-flow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -1,0 +1,121 @@
+{
+  "css": {
+    "properties": {
+      "grid-auto-columns": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-columns",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "-ms-grid-columns"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "-ms-grid-columns"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "10",
+              "alternative_name": "-ms-grid-rows"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid.json
+++ b/css/properties/grid.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "grid": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Here's some initial grid data! This adds the following CSS properties:

* [`grid`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid)
* [`grid-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area)
* [`grid-auto-columns`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-columns)
* [`grid-auto-flow`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow)
* [`grid-auto-rows`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows)

Based on what I read in Safari release notes, I'm trusting that Safari is actually implementing CSS grid (changing some of the entries from "not implemented"). Otherwise, this _seems_ like a pretty straightforward migration.
