### PR TITLE
Changing Firefox support information to include Mac OSX support

### DIFF
--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -57,10 +63,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -100,10 +112,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -143,10 +161,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -186,10 +210,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -229,10 +259,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -272,10 +308,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -315,10 +357,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -358,10 +406,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -401,10 +455,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -444,10 +504,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -482,9 +548,16 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -523,10 +596,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -602,10 +681,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -645,10 +730,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -688,10 +779,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -731,10 +828,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -774,10 +877,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -817,10 +926,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -860,10 +975,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -70,7 +70,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -119,7 +119,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -168,7 +168,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -217,7 +217,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -266,7 +266,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -315,7 +315,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -364,7 +364,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -413,7 +413,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -462,7 +462,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -511,7 +511,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -555,7 +555,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -603,7 +603,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -688,7 +688,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -737,7 +737,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -786,7 +786,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -835,7 +835,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -884,7 +884,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -933,7 +933,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -982,7 +982,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -70,7 +70,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -119,7 +119,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -168,7 +168,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -217,7 +217,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -266,7 +266,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -57,10 +63,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -100,10 +112,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -143,10 +161,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -186,10 +210,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -229,10 +259,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -58,10 +64,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -101,10 +113,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -144,10 +162,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -71,7 +71,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -120,7 +120,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -169,7 +169,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -70,7 +70,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -114,7 +114,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -157,7 +157,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -205,7 +205,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -290,7 +290,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -375,7 +375,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -57,10 +63,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -95,9 +107,16 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -131,9 +150,16 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -172,10 +198,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -251,10 +283,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -330,10 +368,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -107,7 +107,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -156,7 +156,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -205,7 +205,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -254,7 +254,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -94,10 +100,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -137,10 +149,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -180,10 +198,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -223,10 +247,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -71,7 +71,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -120,7 +120,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -169,7 +169,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -218,7 +218,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -267,7 +267,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -316,7 +316,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -365,7 +365,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -58,10 +64,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -101,10 +113,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -144,10 +162,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -187,10 +211,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -230,10 +260,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -273,10 +309,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -316,10 +358,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -57,10 +63,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -100,10 +112,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -143,10 +161,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -70,7 +70,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -119,7 +119,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -168,7 +168,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -70,7 +70,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -119,7 +119,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -240,7 +240,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -289,7 +289,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -338,7 +338,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -387,7 +387,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -57,10 +63,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -100,10 +112,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -215,10 +233,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -258,10 +282,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -301,10 +331,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -344,10 +380,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -15,10 +15,16 @@
           "edge": {
             "version_added": true
           },
-          "firefox": {
-            "version_added": "55",
-            "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "55",
+              "notes": "Windows support was enabled in Firefox 55."
+            },
+            {
+              "version_added": "58",
+              "notes": "Mac OSX support was enabled in Firefox 58."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -57,10 +63,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -100,10 +112,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -143,10 +161,16 @@
             "edge": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "58",
+                "notes": "Mac OSX support was enabled in Firefox 58."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -22,7 +22,7 @@
             },
             {
               "version_added": "58",
-              "notes": "Mac OSX support was enabled in Firefox 58."
+              "notes": "macOS support was enabled in Firefox 58."
             }
           ],
           "ie": {
@@ -70,7 +70,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -119,7 +119,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {
@@ -168,7 +168,7 @@
               },
               {
                 "version_added": "58",
-                "notes": "Mac OSX support was enabled in Firefox 58."
+                "notes": "macOS support was enabled in Firefox 58."
               }
             ],
             "ie": {


### PR DESCRIPTION
I've included all of this in one PR, as it is a simple change — every bit of firefox support information has been included to include separate entries for Windows support, and Mac OSX support.