### PR TITLE
Add npm as a deployment provider to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,10 @@ node_js: stable
 sudo: false
 notifications:
   email: false
+deploy:
+  provider: npm
+  email: mdn-npm@mozilla.com
+  api_key: $NPM_TOKEN
+  on:
+    tags: true
+    repo: mdn/browser-compat-data


### PR DESCRIPTION
I followed the steps here https://docs.travis-ci.com/user/deployment/npm/
(basically, I just did `$ travis setup npm`)

With this, everyone with push access should be able to push a new tag, for example like this:
```cli
$ npm version patch -m "12th alpha version"
$ git push --tags
```
And then this should: 
1) add a new commit to master updating the version in package.json,
2) add a new tag, like "v0.0.12" to the repo,
3) trigger travis to react on the new tag and to publish version 0.0.12 to npm.