### PR TITLE
Update IE and Edge version compatibility for the button form attr

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -214,7 +214,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": 16
+                "version_added": "16"
               },
               "edge_mobile": {
                 "version_added": true

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -214,7 +214,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": 16
               },
               "edge_mobile": {
                 "version_added": true
@@ -226,10 +226,10 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
+                "version_added": false
               },
               "ie_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
Internet Explorer and Edge Browsers ( prior to v 16 ) do not actually support the form attribute on buttons.

https://caniuse.com/#feat=form-attribute