### PR TITLE
Tabs readermode 58

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -274,6 +274,9 @@
                     "version_added": false
                   },
                   "firefox": {
+                    "notes": [
+                      "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>."
+                    ],
                     "version_added": "57"
                   },
                   "firefox_android": {
@@ -295,6 +298,9 @@
                     "version_added": false
                   },
                   "firefox": {
+                    "notes": [
+                      "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>."
+                    ],
                     "version_added": "57"
                   },
                   "firefox_android": {
@@ -310,12 +316,18 @@
               "__compat": {
                 "support": {
                   "chrome": {
+                    "notes": [
+                      "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar."
+                    ],
                     "version_added": true
                   },
                   "edge": {
                     "version_added": false
                   },
                   "firefox": {
+                    "notes": [
+                      "The expression must evaluate to an object that can be serialized to JSON, or nothing is shown in the sidebar. In particular, JavaScript cyclic objects and DOM nodes are not supported.  See <a href='https://bugzil.la/1403130'>bug 1403130</a>."
+                    ],
                     "version_added": "57"
                   },
                   "firefox_android": {
@@ -331,12 +343,18 @@
               "__compat": {
                 "support": {
                   "chrome": {
+                    "notes": [
+                      "If the <code>jsonObject</code> parameter is a string, it is not displayed."
+                    ],
                     "version_added": true
                   },
                   "edge": {
                     "version_added": false
                   },
                   "firefox": {
+                    "notes": [
+                      "If the <code>jsonObject</code> is a string, then <code>rootTitle</code> must also be given, or <code>jsonObject</code> will not be displayed. See <a href='https://bugzil.la/1412310'>bug 1412310</a>."
+                    ],
                     "version_added": "57"
                   },
                   "firefox_android": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -319,6 +319,48 @@
               }
             }
           },
+          "isArticle": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "58"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "isInReaderMode": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "58"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "lastAccessed": {
             "__compat": {
               "support": {
@@ -812,6 +854,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "openInReaderMode": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "58"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -2444,6 +2507,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          }
+        },
+        "toggleReaderMode": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
Bugs https://bugzilla.mozilla.org/show_bug.cgi?id=1408993 
https://bugzilla.mozilla.org/show_bug.cgi?id=1381992 extended the [tabs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs) API to expose reader mode to extensions:

https://hg.mozilla.org/mozilla-central/diff/beb6d23925c0/browser/components/extensions/schemas/tabs.json

https://hg.mozilla.org/mozilla-central/diff/d2c18cfef4e3/browser/components/extensions/schemas/tabs.json