### PR TITLE
removeLocalStorage supports hostnames from version 58

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -553,7 +553,7 @@
                     "version_added": "58"
                   },
                   "opera": {
-                    "version_added": true
+                    "version_added": false
                   }
                 }
               }

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -535,6 +535,29 @@
                 "version_added": true
               }
             }
+          },
+          "removalOptions": {
+            "hostnames": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "58"
+                  },
+                  "firefox_android": {
+                    "version_added": "58"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            }
           }
         },
         "removePasswords": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1388428: from version 58, you can use [`RemovalOptions.hostnames`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/RemovalOptions) with [`browsingData.removeLocalStorage()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/removeLocalStorage).