### PR TITLE
Add data for sessions.forgetClosedTab and sessions.forgetClosedWindow

### DIFF
--- a/webextensions/api/sessions.json
+++ b/webextensions/api/sessions.json
@@ -68,6 +68,48 @@
             }
           }
         },
+        "forgetClosedTab": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "37"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "forgetClosedWindow": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "37"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
         "getRecentlyClosed": {
           "__compat": {
             "support": {


### PR DESCRIPTION
Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1334266 added support for `sessions.forgetClosedTab()` and `sessions.forgetClosedWindow()`:

https://hg.mozilla.org/mozilla-central/diff/0602301ef1b2/browser/components/extensions/schemas/sessions.json

