### PR TITLE
Add two new privacy settings for Firefox 58

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -91,6 +91,27 @@
           }
         },
         "websites": {
+          "firstPartyIsolate": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "58"
+                },
+                "firefox_android": {
+                  "version_added": "58"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "hyperlinkAuditingEnabled": {
             "__compat": {
               "support": {
@@ -150,6 +171,27 @@
                 },
                 "opera": {
                   "version_added": true
+                }
+              }
+            }
+          },
+          "resistFingerprinting": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "58"
+                },
+                "firefox_android": {
+                  "version_added": "58"
+                },
+                "opera": {
+                  "version_added": false
                 }
               }
             }


### PR DESCRIPTION
Two new settings in [`privacy.websites`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/privacy/websites):

* https://bugzilla.mozilla.org/show_bug.cgi?id=1397611 added `resistFingerprinting`: https://hg.mozilla.org/mozilla-central/diff/3bf4a8d9d126/toolkit/components/extensions/schemas/privacy.json

* https://bugzilla.mozilla.org/show_bug.cgi?id=1409045 added `firstPartyIsolate`: https://hg.mozilla.org/mozilla-central/diff/0f6d8491f80a/toolkit/components/extensions/schemas/privacy.json