### PR TITLE
Add support for windowId parameter to theme.reset()

### DIFF
--- a/webextensions/api/theme.json
+++ b/webextensions/api/theme.json
@@ -42,6 +42,27 @@
                 "version_added": false
               }
             }
+          },
+          "windowId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "update": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1401691 added a `windowId` parameter to [`theme.reset()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/theme/reset), and it got uplifted to 57.