### PR TITLE
Note Firefox's old behavior for downloads.saveAs

### DIFF
--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -844,9 +844,15 @@
                   "version_added": false
                 },
                 "firefox": {
+                  "notes": [
+                    "Before version 58, if this option was omitted, Firefox would never show the file chooser, regardless of the value of the browser's preference."
+                  ],
                   "version_added": "52"
                 },
                 "firefox_android": {
+                  "notes": [
+                    "Before version 58, if this option was omitted, Firefox would never show the file chooser, regardless of the value of the browser's preference."
+                  ],
                   "version_added": "52"
                 },
                 "opera": {


### PR DESCRIPTION
The [`downloads.download()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/downloads/download) API can take a `saveAs` option, which will make the browser show a file chooser for the download.

Before version 58, if this was omitted, Firefox would never show the file chooser. In https://bugzilla.mozilla.org/show_bug.cgi?id=1394851 this is changed, so Firefox respects the general user preference (`browser.download.useDownloadDir`) if the option is omitted.

Since that behavior is the same as Chrome's, and seems more sensible, I'm suggesting that we note the old behavior in compat, and document the new behavior as the correct/"normal" behavior.