### PR TITLE
New namespace, pkcs11

### DIFF
--- a/webextensions/api/pkcs11.json
+++ b/webextensions/api/pkcs11.json
@@ -1,0 +1,92 @@
+{
+  "webextensions": {
+    "api": {
+      "pkcs11": {
+        "getModuleSlots": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "installModule": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "isModuleInstalled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "uninstallModule": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/api/pkcs11.json
+++ b/webextensions/api/pkcs11.json
@@ -20,6 +20,11 @@
               "opera": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         },
@@ -41,6 +46,11 @@
               "opera": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         },
@@ -62,6 +72,11 @@
               "opera": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         },
@@ -83,6 +98,11 @@
               "opera": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1357391 adds a new API, "pkcs11": http://searchfox.org/mozilla-central/source/browser/components/extensions/schemas/pkcs11.json.

Firefox desktop only, new in version 58.