### PR TITLE
Add compat data for CSS mask property

### DIFF
--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -40,7 +40,7 @@
               "notes": "From Firefox 10, the default color space when handling masks is sRGB. Previously, the default and only supported color space was linear RGB. This changes the appearance of mask effects, but brings Firefox into compliance with the second edition of the SVG 1.1 specification."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -163,7 +163,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "53"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -40,7 +40,7 @@
               "notes": "From Firefox 10, the default color space when handling masks is sRGB. Previously, the default and only supported color space was linear RGB. This changes the appearance of mask effects, but brings Firefox into compliance with the second edition of the SVG 1.1 specification."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "ie": {
               "version_added": false

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -40,7 +40,7 @@
               "notes": "From Firefox 10, the default color space when handling masks is sRGB. Previously, the default and only supported color space was linear RGB. This changes the appearance of mask effects, but brings Firefox into compliance with the second edition of the SVG 1.1 specification."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": null
             },
             "ie": {
               "version_added": false

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -1,0 +1,198 @@
+{
+  "css": {
+    "properties": {
+      "mask": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "2.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true,
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true,
+              "notes": "From Firefox 10, the default color space when handling masks is sRGB. Previously, the default and only supported color space was linear RGB. This changes the appearance of mask effects, but brings Firefox into compliance with the second edition of the SVG 1.1 specification."
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true,
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true,
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "applies_to_html_elements": {
+          "__compat": {
+            "description": "Applies to HTML elements",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "shorthand_for_mask_properties": {
+          "__compat": {
+            "description": "Shorthand for <code>mask-*</code> properties",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the [`mask`](https://developer.mozilla.org/docs/Web/CSS/mask) property. I was a bit suspicious of the data here (and my interpretation of the table), so I thought I'd open a PR for this one before moving on to the other `mask-*` properties.