### PR TITLE
Fix Chrome/Opera data for forget* APIs

### DIFF
--- a/webextensions/api/sessions.json
+++ b/webextensions/api/sessions.json
@@ -72,7 +72,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "37"
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -84,7 +84,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               }
             }
           }
@@ -93,7 +93,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "37"
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
These two APIs:

    sessions.forgetClosedTab()
    sessions.forgetClosedWindow()

...and Firefox-only: https://developer.chrome.com/extensions/sessions.