### PR TITLE
Note Firefox behavior with private windows

### DIFF
--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -106,9 +106,15 @@
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then its return value will not include the extension's background page."
+                ],
                 "version_added": "45"
               },
               "firefox_android": {
+                "notes": [
+                  "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then its return value will not include the extension's background page."
+                ],
                 "version_added": "48"
               },
               "opera": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -366,9 +366,15 @@
                 "version_added": true
               },
               "firefox": {
+                "notes": [
+                  "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then it will always return <code>null</code>."
+                ],
                 "version_added": "45"
               },
               "firefox_android": {
+                "notes": [
+                  "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then it will always return <code>null</code>."
+                ],
                 "version_added": "48"
               },
               "opera": {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1329304: [`extension.getViews()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/extension/getViews) and [`runtime.getBackgroundPage()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/getBackgroundPage) both don't include the background page if they are called from a private browsing context.