### PR TITLE
Mark `add` and `set` methods of Set, Map and WeakMap objects as partially implemented on IE 11

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -728,7 +728,9 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": "11"
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Returns 'undefined' instead of the 'Map' object."
               },
               "ie_mobile": {
                 "version_added": "11"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -296,7 +296,9 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": "11"
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Returns 'undefined' instead of the 'Set' object."
               },
               "ie_mobile": {
                 "version_added": "11"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -529,7 +529,9 @@
                 "notes": "Prior to Firefox 38, this method threw a <code>TypeError</code> when the key parameter was not an object. This has been fixed in version 38 and later to return <code>false</code> as per the ES2015 standard."
               },
               "ie": {
-                "version_added": "11"
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Returns 'undefined' instead of the 'Map' object."
               },
               "ie_mobile": {
                 "version_added": "11"


### PR DESCRIPTION
According to specification `add` method of Set object and `set` method of Map and WeakMap objects should return instance of an object for chaining but on Internet Explorer 11 they return `undefined`