### PR TITLE
Date.toLocaleFormat removed in Firefox 58

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2775,10 +2775,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1.5",
+                "version_removed": "58"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4",
+                "version_removed": "58"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Added in Firefox 1.5 https://bugzilla.mozilla.org/show_bug.cgi?id=291494
Removed in Firefox 58: https://bugzilla.mozilla.org/show_bug.cgi?id=818634