### PR TITLE
<a> – Add link to Edge bug report

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -167,7 +167,7 @@
               },
               "edge": {
                 "version_added": "13",
-                "notes": "Until Edge 14 (build 14357), attempting to download data URIs caused Edge to crash."
+                "notes": "Until Edge 14 (build 14357), attempting to download data URIs caused Edge to crash (<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7160092/'>bug 7160092</a>)."
               },
               "edge_mobile": {
                 "version_added": true


### PR DESCRIPTION
See: [DataURL Download links crash Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7160092/).