### PR TITLE
Add valid browser versions to error output

### DIFF
--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -32,10 +32,12 @@ function testVersions(dataFilename) {
         for (let statement of supportStatements) {
           if (!isValidVersion(browser, statement.version_added)) {
             console.error('\x1b[31m  version_added: "' + statement.version_added + '" is not a valid version number for ' + browser);
+            console.error('  Valid ' + browser + ' versions are: ' + validBrowserVersions[browser].join(', '));
             hasErrors = true;
           }
           if (!isValidVersion(browser, statement.version_removed)) {
             console.error('\x1b[31m  version_removed: "' + statement.version_removed + '" is not a valid version number for ' + browser);
+            console.error('  Valid ' + browser + ' versions are: ' + validBrowserVersions[browser].join(', '));
             hasErrors = true;
           }
         }
@@ -57,7 +59,7 @@ function testVersions(dataFilename) {
   findSupport(data);
 
   if (hasErrors) {
-    console.error('\x1b[31m  File : ' + filename); 
+    console.error('\x1b[31m  File : ' + dataFilename);
     console.error('\x1b[31m  Browser version error(s)\x1b[0m');
     return true;
   } else {


### PR DESCRIPTION
I thought it would be nice to present the valid versions of a browser when there was an error.
The output looks like this then:
```
javascript/statements.json
  Style – OK 
  JSON schema – OK 
  version_added: "7.1" is not a valid version number for safari
  Valid safari versions are: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 1.1, 1.2, 1.3, 3.1, 3.2, 4.1, 5.1, 6.1, 9.1, 10.1
  Browser version error(s)
```
