### PR TITLE
Add node.js releases

### DIFF
--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -932,6 +932,45 @@
       }
     }
   },
+  "nodejs": {
+    "releases": {
+      "0.10": {
+        "release_date": "2013-03-11",
+        "status": "retired"
+      },
+      "0.12": {
+        "release_date": "2015-02-06",
+        "status": "retired"
+      },
+      "4": {
+        "release_date": "2015-09-08",
+        "status": "current"
+      },
+      "5": {
+        "release_date": "2015-10-29",
+        "status": "retired"
+      },
+      "6": {
+        "release_date": "2016-04-26",
+        "status": "current"
+      },
+      "7": {
+        "release_date": "2016-10-25",
+        "status": "retired"
+      },
+      "8": {
+        "release_date": "2017-05-30",
+        "status": "current"
+      },
+      "9": {
+        "release_date": "2017-10-31",
+        "status": "current"
+      },
+      "10": {
+        "status": "planned"
+      }
+    }
+  },
   "opera": {
     "releases": {
       "2": {


### PR DESCRIPTION
We don't have much node.js data yet, so no existing data fails here I guess.
Wasn't sure which release notes URLs I could use here, but we can add those later, too.