### PR TITLE
Add more values to list-style-type

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -51,6 +51,64 @@
             "deprecated": false
           }
         },
+        "cjk-ideographic": {
+          "__compat": {
+            "description": "<code>cjk-ideographic</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "7",
+                  "partial_implementation": true,
+                  "notes": "Until version 15, only decimal numbers display."
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "decimal-leading-zero": {
           "__compat": {
             "description": "<code>decimal-leading-zero</code>",
@@ -199,6 +257,296 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hebrew": {
+          "__compat": {
+            "description": "<code>hebrew</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "7",
+                  "partial_implementation": true,
+                  "notes": "Until version 15, only decimal numbers display."
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hiragana": {
+          "__compat": {
+            "description": "<code>hiragana</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "7",
+                  "partial_implementation": true,
+                  "notes": "Until version 15, only decimal numbers display."
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hiragana-iroha": {
+          "__compat": {
+            "description": "<code>hiragana-iroha</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "7",
+                  "partial_implementation": true,
+                  "notes": "Until version 15, only decimal numbers display."
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "katakana": {
+          "__compat": {
+            "description": "<code>katakana</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "7",
+                  "partial_implementation": true,
+                  "notes": "Until version 15, only decimal numbers display."
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "katakana-iroha": {
+          "__compat": {
+            "description": "<code>katakana-iroha</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "7",
+                  "partial_implementation": true,
+                  "notes": "Until version 15, only decimal numbers display."
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -51,6 +51,57 @@
             "deprecated": false
           }
         },
+        "decimal-leading-zero": {
+          "__compat": {
+            "description": "<code>decimal-leading-zero</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "8"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "armenian": {
           "__compat": {
             "description": "<code>armenian</code>",


### PR DESCRIPTION
This PR adds the following values to `list-style-type`:

* `decimal-leading-zero`
* `hebrew`
* `cjk-ideographic`
* `hiragana`
* `hiragana-iroha`
* `katakana`
* `katakana-iroha`

This corresponds to the third and fourth rows of the [existing MDN table](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Browser_compatibility).