### PR TITLE
Add more CSS mask- properties

### DIFF
--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -1,0 +1,264 @@
+{
+  "css": {
+    "properties": {
+      "mask-clip": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-clip",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "border": {
+          "__compat": {
+            "description": "<code>border<code>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.1"
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "content": {
+          "__compat": {
+            "description": "<code>content</content>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.1"
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "padding": {
+          "__compat": {
+            "description": "<code>padding</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.1"
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "text": {
+          "__compat": {
+            "description": "<code>text</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.1"
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -1,0 +1,60 @@
+{
+  "css": {
+    "properties": {
+      "mask-composite": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-composite",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -5,24 +5,16 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-image",
           "support": {
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "2.1"
-              }
-            ],
-            "chrome": [
-              {
-                "version_added": "8"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "1"
-              }
-            ],
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "2.1",
+              "notes": "Initially, Android supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "1",
+              "notes": "From version 8, Chrome added support for gradient values. Initially, Chrome supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
+            },
             "chrome_android": {
               "version_added": null
             },
@@ -51,24 +43,16 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": [
-              {
-                "version_added": "4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "3.2"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ]
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "4",
+              "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "3.2",
+              "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
+            }
           },
           "status": {
             "experimental": true,

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -1,0 +1,184 @@
+{
+  "css": {
+    "properties": {
+      "mask-image": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-image",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.1"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "8"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "3.2"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multiple_mask_images": {
+          "__compat": {
+            "description": "Multiple mask images",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "svg_masks": {
+          "__compat": {
+            "description": "SVG masks",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "8"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following CSS properties:

* [`mask-clip`](https://developer.mozilla.org/docs/Web/CSS/mask-clip)
* [`mask-composite`](https://developer.mozilla.org/docs/Web/CSS/mask-composite)
* [`mask-image`](https://developer.mozilla.org/docs/Web/CSS/mask-image)

Let me know what changes you want to see here. Thanks!