### PR TITLE
Firefox removed legacy generators

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -830,10 +830,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "5"
+                "version_added": "5",
+                "version_removed": "58"
               },
               "firefox_android": {
-                "version_added": "5"
+                "version_added": "5",
+                "version_removed": "58"
               },
               "ie": {
                 "version_added": false

--- a/javascript/operators/legacy_generator_function.json
+++ b/javascript/operators/legacy_generator_function.json
@@ -22,10 +22,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "2",
+              "version_removed": "58"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "version_removed": "58"
             },
             "ie": {
               "version_added": false

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -22,10 +22,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "2",
+              "version_removed": "58"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "version_removed": "58"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
* Bug 119777: Remove non-standard Function.prototype.isGenerator
* Bug 1083482: Remove SpiderMonkey support for JS1.7 legacy generators