### PR TITLE
fix: WebExtensions chrome_url_overrides not yet supported on Firefox for Android

### DIFF
--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -14,7 +14,7 @@
               "version_added": "54"
             },
             "firefox_android": {
-              "version_added": "54"
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -40,10 +40,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "54",
-                "notes": [
-                  "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome and Opera, the last extension wins."
-                ]
+                "version_added": false
               },
               "opera": {
                 "version_added": true,


### PR DESCRIPTION
See [Bug 1414785](https://bugzilla.mozilla.org/show_bug.cgi?id=1414785)