### PR TITLE
WebExtensions : Tab.favIconUrl never implemented for Firefox Android

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -205,7 +205,7 @@
                   "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "54"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": true


### PR DESCRIPTION
See issue on https://bugzilla.mozilla.org/show_bug.cgi?id=1414498