### PR TITLE
Add compat data for position CSS property

### DIFF
--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -22,14 +22,10 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": [
-                "Since Firefox 30, Firefox allows <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead'><code>&lt;thead&gt;</code></a>, and <a  href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a> elements with a <code>position: relative;</code> style to act as absolute positioning containers. This means that a <code>position: absolute;</code> styled element inside the table can be positioned relative to these elements. In other browsers and in older versions of Firefox, setting <code>position: relative;</code> on a table row or row group has no effect. Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Relative positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;",
-                "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>)."
-              ]
+              "notes": "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>)."
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": "Since Firefox 30, Firefox allows <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead'><code>&lt;thead&gt;</code></a>, and <a  href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a> elements with a <code>position: relative;</code> style to act as absolute positioning containers. This means that a <code>position: absolute;</code> styled element inside the table can be positioned relative to these elements. In other browsers and in older versions of Firefox, setting <code>position: relative;</code> on a table row or row group has no effect. Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Relative positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4",
@@ -160,6 +156,59 @@
               "safari": {
                 "prefix": "-webkit-",
                 "version_added": "6.1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "position_relative_table_elements": {
+          "__compat": {
+            "description": "Table elements as absolute positioning containers",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "30",
+                "notes": "Firefox later helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Relative positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
+              },
+              "firefox_android": {
+                "version_added": "30",
+                "notes": "Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Relative positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
               },
               "safari_ios": {
                 "version_added": null

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -1,0 +1,178 @@
+{
+  "css": {
+    "properties": {
+      "position": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": [
+                "Since Firefox 30, Firefox allows <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead'><code>&lt;thead&gt;</code></a>, and <a  href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a> elements with a <code>position: relative;</code> style to act as absolute positioning containers. This means that a <code>position: absolute;</code> styled element inside the table can be positioned relative to these elements. In other browsers and in older versions of Firefox, setting <code>position: relative;</code> on a table row or row group has no effect. Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Relative positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;",
+                "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>)."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "Since Firefox 30, Firefox allows <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead'><code>&lt;thead&gt;</code></a>, and <a  href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a> elements with a <code>position: relative;</code> style to act as absolute positioning containers. This means that a <code>position: absolute;</code> styled element inside the table can be positioned relative to these elements. In other browsers and in older versions of Firefox, setting <code>position: relative;</code> on a table row or row group has no effect. Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Relative positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
+            },
+            "ie": {
+              "version_added": "4",
+              "notes": "In Internet Explorer, fixed positioning doesn't work if the document is in <a href='http://msdn.microsoft.com/en-us/library/ie/ms531140(v=vs.85).aspx'>quirks mode</a>."
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "fixed": {
+          "__compat": {
+            "description": "<code>fixed</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1",
+                "notes": "Before Firefox 44, <code>position: fixed</code> didn't create a stacking context in most cases. Firefox and the specification have been modified to mimic Chrome and Safari's long-time behavior."
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "7"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sticky": {
+          "__compat": {
+            "description": "<code>sticky</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": "16"
+              },
+              "firefox": [
+                {
+                  "version_added": "32"
+                },
+                {
+                  "version_added": "26",
+                  "version_removed": "48",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.sticky.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds [`position`](https://developer.mozilla.org/docs/Web/CSS/position) compat data. Let me know if you want to see any changes. Thanks!