### PR TITLE
Update status for CSS Scroll Snapping properties

### DIFF
--- a/css/properties/scroll-snap-coordinate.json
+++ b/css/properties/scroll-snap-coordinate.json
@@ -27,7 +27,7 @@
               "version_added": "39",
               "flag": {
                 "type": "preference",
-                "name": "layout.css.vertical-text.enabled",
+                "name": "layout.css.scroll-snap.enabled",
                 "value_to_set": "true"
               }
             },

--- a/css/properties/scroll-snap-coordinate.json
+++ b/css/properties/scroll-snap-coordinate.json
@@ -23,14 +23,19 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "39",
-              "flag": {
-                "type": "preference",
-                "name": "layout.css.scroll-snap.enabled",
-                "value_to_set": "true"
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "39",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scroll-snap.enabled",
+                  "value_to_set": "true"
+                }
               }
-            },
+            ],
             "ie_mobile": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -14,6 +14,12 @@
             "chrome_android": {
               "version_added": false
             },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": "39"
             },

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -21,7 +21,7 @@
               "version_added": "39",
               "flag": {
                 "type": "preference",
-                "name": "layout.css.vertical-text.enabled",
+                "name": "layout.css.scroll-snap.enabled",
                 "value_to_set": "true"
               }
             },

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -23,14 +23,19 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "39",
-              "flag": {
-                "type": "preference",
-                "name": "layout.css.scroll-snap.enabled",
-                "value_to_set": "true"
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "39",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scroll-snap.enabled",
+                  "value_to_set": "true"
+                }
               }
-            },
+            ],
             "ie_mobile": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -24,7 +24,7 @@
               "version_added": "39",
               "flag": {
                 "type": "preference",
-                "name": "layout.css.vertical-text.enabled",
+                "name": "layout.css.scroll-snap.enabled",
                 "value_to_set": "true"
               }
             },

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -23,14 +23,19 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "39",
-              "flag": {
-                "type": "preference",
-                "name": "layout.css.scroll-snap.enabled",
-                "value_to_set": "true"
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "39",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scroll-snap.enabled",
+                  "value_to_set": "true"
+                }
               }
-            },
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -21,15 +21,15 @@
               "version_added": false
             },
             "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
               "version_added": "39",
               "flag": {
                 "type": "preference",
                 "name": "layout.css.scroll-snap.enabled",
                 "value_to_set": "true"
               }
-            },
-            "firefox_android": {
-              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -24,7 +24,7 @@
               "version_added": "39",
               "flag": {
                 "type": "preference",
-                "name": "layout.css.vertical-text.enabled",
+                "name": "layout.css.scroll-snap.enabled",
                 "value_to_set": "true"
               }
             },

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -23,14 +23,19 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "39",
-              "flag": {
-                "type": "preference",
-                "name": "layout.css.scroll-snap.enabled",
-                "value_to_set": "true"
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "39",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scroll-snap.enabled",
+                  "value_to_set": "true"
+                }
               }
-            },
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -21,15 +21,15 @@
               "version_added": false
             },
             "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
               "version_added": "39",
               "flag": {
                 "type": "preference",
                 "name": "layout.css.scroll-snap.enabled",
                 "value_to_set": "true"
               }
-            },
-            "firefox_android": {
-              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-type-x.json
+++ b/css/properties/scroll-snap-type-x.json
@@ -23,9 +23,19 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "39"
-            },
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "39",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scroll-snap.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-type-y.json
+++ b/css/properties/scroll-snap-type-y.json
@@ -23,9 +23,19 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "39"
-            },
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "39",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scroll-snap.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -25,14 +25,19 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "39",
-              "flag": {
-                "type": "preference",
-                "name": "layout.css.scroll-snap.enabled",
-                "value_to_set": "true"
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "39",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scroll-snap.enabled",
+                  "value_to_set": "true"
+                }
               }
-            },
+            ],
             "ie": {
               "version_added": "10",
               "prefix": "-ms-"

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -29,7 +29,7 @@
               "version_added": "39",
               "flag": {
                 "type": "preference",
-                "name": "layout.css.vertical-text.enabled",
+                "name": "layout.css.scroll-snap.enabled",
                 "value_to_set": "true"
               }
             },


### PR DESCRIPTION
this patch updates CSS Scroll Snapping properties with the following changes:

* corrects the name of the flag to enable the property
* update support status on Firefox for Android
* fixing errors and adding missing entries for Edge(s)