### PR TITLE
IANA timezone name support in Chrome/Opera

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -493,10 +493,10 @@
                   "version_added": null
                 },
                 "chrome": {
-                  "version_added": null
+                  "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "26"
                 },
                 "edge": {
                   "version_added": null
@@ -520,7 +520,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
                   "version_added": null


### PR DESCRIPTION
In Chrome/Opera,  IANA timezone support  in Intl.DateTimeFormat was enabled when DateTimeFormat was enabled.

