### PR TITLE
Add yet more list-style-type values

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -51,6 +51,120 @@
             "deprecated": false
           }
         },
+        "arabic-indic": {
+          "__compat": {
+            "description": "<code>arabic-indic</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "bengali": {
+          "__compat": {
+            "description": "<code>bengali</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "cjk-decimal": {
           "__compat": {
             "description": "<code>cjk-decimal</code>",
@@ -76,6 +190,120 @@
               "firefox_android": {
                 "version_added": null
               },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "cjk-earthly-branch": {
+          "__compat": {
+            "description": "<code>cjk-earthly-branch</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "cjk-heavenly-stem": {
+          "__compat": {
+            "description": "<code>cjk-heavenly-stem</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -211,6 +439,121 @@
             }
           }
         },
+        "devanagari": {
+          "__compat": {
+            "description": "<code>devanagari</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ethiopic-numeric": {
+          "__compat": {
+            "description": "<code>ethiopic-numeric</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33",
+                  "notes": "Before Firefox 38, Firefox added a dot as suffix of the number for <code>ethiopic-numeric</code> (for example, ፫. instead of ፫). The specification later defined the absence of a suffix, which Firefox 38 followed."
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "armenian": {
           "__compat": {
             "description": "<code>armenian</code>",
@@ -308,6 +651,120 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "gujarati": {
+          "__compat": {
+            "description": "<code>gujarati</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "gurmukhi": {
+          "__compat": {
+            "description": "<code>gurmukhi</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -601,6 +1058,63 @@
             }
           }
         },
+        "kannada": {
+          "__compat": {
+            "description": "<code>kannada</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "katakana": {
           "__compat": {
             "description": "<code>katakana</code>",
@@ -705,6 +1219,63 @@
               },
               "safari": {
                 "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "khmer": {
+          "__compat": {
+            "description": "<code>khmer</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": null
@@ -870,6 +1441,63 @@
             }
           }
         },
+        "lao": {
+          "__compat": {
+            "description": "<code>lao</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "lower-greek": {
           "__compat": {
             "description": "<code>lower-greek</code>",
@@ -972,6 +1600,234 @@
             }
           }
         },
+        "malayalam": {
+          "__compat": {
+            "description": "<code>malayalam</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "myanmar": {
+          "__compat": {
+            "description": "<code>myanmar</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "oriya": {
+          "__compat": {
+            "description": "<code>oriya</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "persian": {
+          "__compat": {
+            "description": "<code>persian</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "simp-chinese-formal": {
           "__compat": {
             "description": "<code>simp-chinese-formal</code>",
@@ -1060,6 +1916,177 @@
               "firefox_android": {
                 "version_added": null
               },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "tamil": {
+          "__compat": {
+            "description": "<code>tamil</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "telugu": {
+          "__compat": {
+            "description": "<code>telugu</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "thai": {
+          "__compat": {
+            "description": "<code>thai</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -108,6 +108,57 @@
             }
           }
         },
+        "armenian": {
+          "__compat": {
+            "description": "<code>armenian</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "6"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "bengali": {
           "__compat": {
             "description": "<code>bengali</code>",
@@ -549,57 +600,6 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "armenian": {
-          "__compat": {
-            "description": "<code>armenian</code>",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": "6"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR migrates [the seventh row of the existing MDN table for `list-style-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Browser_compatibility), the following values:

- `arabic-indic`
- `bengali`
- `cjk-earthly-branch`
- `cjk-heavenly-stem`
- `devanagari`
- `ethiopic-numeric`
- `gujarati`
- `gurmukhi`
- `kannada`
- `khmer`
- `lao`
- `malayalam`
- `myanmar`
- `oriya`
- `persian`
- `tamil`
- `telugu`
- `thai`

Only a few more values after this one!