### PR TITLE
Add compat data for clear CSS property

### DIFF
--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -97,7 +97,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "clear": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clear",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "flow_relative_values": {
+          "__compat": {
+            "description": "Flow-relative values <code>inline-start</code> and <code>inline-end</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the [`clear`](https://developer.mozilla.org/en-US/docs/Web/CSS/clear) property.