### PR TITLE
Editorial: Add CustomElementRegistry platform support

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -49,7 +49,8 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           }
         },
 

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -27,8 +27,6 @@
             "version_added": "41",
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           },
-
-
           "chrome_android": {
             "version_added": "61",
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
@@ -53,7 +51,6 @@
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           }
         },
-
         "status": {
           "experimental": true,
           "standard_track": true,

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -3,7 +3,6 @@
     "CustomElementRegistry": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry",
-        "description": "The CustomElementRegistry interface provides methods for registering custom elements and querying registered elements.",
         "support": {
           "chrome": {
             "version_added": "33",

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -27,10 +27,10 @@
           "firefox": {
             "version_added": true,
             "notes": "Enabled through the `dom.webcomponents.enabled` preference in `about:config`",
-            "flags": {
+            "flag": {
               "type": "preference",
               "name": "dom.webcomponents.enabled",
-              "value_to_set": true
+              "value_to_set": "true"
             }
           },
           "ie": {

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -26,7 +26,6 @@
           },
           "firefox": {
             "version_added": true,
-            "notes": "Enabled through the `dom.webcomponents.enabled` preference in `about:config`",
             "flag": {
               "type": "preference",
               "name": "dom.webcomponents.enabled",

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -39,8 +39,7 @@
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           },
           "opera_android": {
-            "version_added": false,
-            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+            "version_added": false
           },
           "safari": {
             "version_added": "10.1",

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -4,50 +4,50 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry",
         "support": {
+          "webview_android": {
+            "version_added": "56",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
           "chrome": {
             "version_added": "54",
-            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
-          },
-          "firefox": {
-            "version_added": true,
-            "notes": "Enabled through the `dom.webcomponents.enabled` preference in `about:config`"
-          },
-          "safari": {
-            "version_added": "10.1",
-            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
-          },
-          "edge": {
-            "version_added": false,
-            "notes": "Under consideration"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": "41",
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           },
           "chrome_android": {
             "version_added": "61",
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           },
-          "webview_android": {
-            "version_added": "56",
-            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          "edge": {
+            "version_added": false,
+            "notes": "Under consideration"
           },
           "edge_mobile": {
             "version_added": false,
             "notes": "Under consideration"
           },
-          "safari_ios": {
-            "version_added": "10.1",
-            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          "firefox": {
+            "version_added": true,
+            "notes": "Enabled through the `dom.webcomponents.enabled` preference in `about:config`"
+          },
+          "ie": {
+            "version_added": false
           },
           "ie_mobile": {
             "version_added": false
           },
+          "opera": {
+            "version_added": "41",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
           "opera_android": {
             "version_added": false,
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
+          "safari": {
+            "version_added": "10.1",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
+          "safari_ios": {
+            "version_added": "10.1",
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           }
         },

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -1,0 +1,65 @@
+{
+  "api": {
+    "CustomElementRegistry": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry",
+        "description": "The CustomElementRegistry interface provides methods for registering custom elements and querying registered elements.",
+        "support": {
+          "chrome": {
+            "version_added": "33",
+            "notes": "Chrome 36+/Opera 20+ implemented a previous version of Custom Elements (v0) that used `.registerElement()`"
+          },
+          "firefox": {
+            "version_added": true,
+            "notes": "Enabled through the `dom.webcomponents.enabled` preference in `about:config`"
+          },
+          "safari": {
+            "version_added": "10.1",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
+          "edge": {
+            "version_added": false,
+            "notes": "Under consideration"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "41",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
+
+
+          "chrome_android": {
+            "version_added": "61",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
+          "webview_android": {
+            "version_added": "56",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
+          "edge_mobile": {
+            "version_added": false,
+            "notes": "Under consideration"
+          },
+          "safari_ios": {
+            "version_added": "10.1",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+          },
+          "ie_mobile": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          }
+        },
+
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -5,8 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry",
         "support": {
           "chrome": {
-            "version_added": "33",
-            "notes": "Chrome 36+/Opera 20+ implemented a previous version of Custom Elements (v0) that used `.registerElement()`"
+            "version_added": "54",
+            "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
           },
           "firefox": {
             "version_added": true,

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -26,7 +26,12 @@
           },
           "firefox": {
             "version_added": true,
-            "notes": "Enabled through the `dom.webcomponents.enabled` preference in `about:config`"
+            "notes": "Enabled through the `dom.webcomponents.enabled` preference in `about:config`",
+            "flags": {
+              "type": "preference",
+              "name": "dom.webcomponents.enabled",
+              "value_to_set": true
+            }
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
  - [x] √ CustomElementRegistry` Basic support
  - [ ] √ CustomElementRegistry.define()` support
  - [ ] √ CustomElementRegistry.get()` get
  - [ ] √ CustomElementRegistry.whenDefined()` whenDefined

  Addresses:
    - https://github.com/w3c/webcomponents/issues/664

  Related MDN Documentation:
    - `CustomElementRegistry.define()` - https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define
    - `CustomElementRegistry.get()` - https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/get
    - `CustomElementRegistry.whenDefined()` - https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/whenDefined

  References:
    - Can I Use - https://caniuse.com/#feat=custom-elementsv1
    - Chrome Status - http://www.chromestatus.com/feature/4696261944934400
    - Firefox Status - https://platform-status.mozilla.org/#custom-elements
    - Webkit Status - http://webkit.org/status.html#feature-custom-elements
    - Edge Status - http://status.modern.ie/customelements

  Notes:
    - Firefox flag status - https://bugzilla.mozilla.org/show_bug.cgi?id=889230#c9