### PR TITLE
Editorial: Fix schema documentation for `flag`

### DIFF
--- a/compat-data-schema.md
+++ b/compat-data-schema.md
@@ -228,7 +228,7 @@ In some cases features are named entirely differently and not just prefixed. Exa
 }
 ```
 
-#### `flags`
+#### `flag`
 An optional object indicating what kind of flags must be set for this feature to work.
 It consists of three properties:
 * `type` (mandatory): an enum that indicates the flag type:
@@ -239,6 +239,16 @@ a flag that the user can set (like in `about:config` in Firefox)
 * `value_to_set` (optional): representing the actual value to set the flag to.
 It is a string, that may be converted to the right type
 (that is `true` or `false` for Boolean value, or `4` for an integer value). It doesn't need to be enclosed in `<code>` tags.
+```json
+{
+  "version_added": true,
+  "flag": {
+    "type": "preference",
+    "name": "browser.flag.name",
+    "value_to_set": "true"
+  }
+}
+```
 
 #### `partial_implementation`
 A `boolean` value indicating whether or not the implementation of the sub-feature


### PR DESCRIPTION
This was annoying to no end and had to make 2 dozen changes before figured out it was `flag` not `flags`.

  - [x] - Change documentation `flags` -> `flag`
  - [x] - Provide example for `flag`

  Addresses:
    - https://github.com/mdn/browser-compat-data/issues/626

  References:
    - https://github.com/mdn/browser-compat-data/pull/623
    - https://github.com/mdn/browser-compat-data/commit/a140245a75d23785d4a14deaa00790f08a6c0bb0
