### PR TITLE
Add compat data for more CSS grid properties

### DIFF
--- a/css/properties/grid-column-end.json
+++ b/css/properties/grid-column-end.json
@@ -1,0 +1,113 @@
+{
+  "css": {
+    "properties": {
+      "grid-column-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column-end",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-column-gap.json
+++ b/css/properties/grid-column-gap.json
@@ -1,0 +1,113 @@
+{
+  "css": {
+    "properties": {
+      "grid-column-gap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column-gap",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-column-start.json
+++ b/css/properties/grid-column-start.json
@@ -1,0 +1,113 @@
+{
+  "css": {
+    "properties": {
+      "grid-column-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column-start",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-column.json
+++ b/css/properties/grid-column.json
@@ -1,0 +1,113 @@
+{
+  "css": {
+    "properties": {
+      "grid-column": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following CSS grid properties:

* [`grid-column`](https://developer.mozilla.org/docs/Web/CSS/grid-column)
* [`grid-column-end`](https://developer.mozilla.org/docs/Web/CSS/grid-column-end)
* [`grid-column-gap`](https://developer.mozilla.org/docs/Web/CSS/grid-column-gap)
* [`grid-column-start`](https://developer.mozilla.org/docs/Web/CSS/grid-column-start)
