### PR TITLE
Add compat data for CSS text decoration properties

### DIFF
--- a/css/properties/text-decoration-color.json
+++ b/css/properties/text-decoration-color.json
@@ -1,0 +1,73 @@
+{
+  "css": {
+    "properties": {
+      "text-decoration-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-color",
+          "support": {
+            "webview_android": {
+              "version_added": "57"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "6",
+                "version_removed": "39"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "6",
+                "version_removed": "39"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "8"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -1,0 +1,129 @@
+{
+  "css": {
+    "properties": {
+      "text-decoration-line": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-line",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "6",
+                "version_removed": "39"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "6",
+                "version_removed": "39"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "8"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "blink": {
+          "__compat": {
+            "description": "<code>blink</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "chrome": {
+                "version_added": "57",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "chrome_android": {
+                "version_added": "57",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "26",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "firefox_android": {
+                "version_added": "26",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-decoration-style.json
+++ b/css/properties/text-decoration-style.json
@@ -1,0 +1,124 @@
+{
+  "css": {
+    "properties": {
+      "text-decoration-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-style",
+          "support": {
+            "webview_android": {
+              "version_added": "57"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "6",
+                "version_removed": "39"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "6",
+                "version_removed": "39"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "wavy": {
+          "__compat": {
+            "description": "<code>wavy</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": {
+                "version_added": "6"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -1,0 +1,201 @@
+{
+  "css": {
+    "properties": {
+      "text-decoration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "blink": {
+          "__compat": {
+            "description": "<code>blink</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "chrome": {
+                "version_added": "57",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "chrome_android": {
+                "version_added": "57",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "edge": {
+                "version_added": true,
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "edge_mobile": {
+                "version_added": true,
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "firefox": [
+                {
+                  "version_added": "23",
+                  "notes": "The <code>blink</code> value does not have any effect."
+                },
+                {
+                  "version_added": "1"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "23",
+                  "notes": "The <code>blink</code> value does not have any effect."
+                },
+                {
+                  "version_added": "4"
+                }
+              ],
+              "ie": {
+                "version_added": true,
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "ie_mobile": {
+                "version_added": true,
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "opera": [
+                {
+                  "version_added": "15",
+                  "notes": "The <code>blink</code> value does not have any effect."
+                },
+                {
+                  "version_added": "4"
+                }
+              ],
+              "opera_android": {
+                "version_added": "4",
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "safari": {
+                "version_added": true,
+                "notes": "The <code>blink</code> value does not have any effect."
+              },
+              "safari_ios": {
+                "version_added": true,
+                "notes": "The <code>blink</code> value does not have any effect."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "shorthand": {
+          "__compat": {
+            "description": "Shorthand",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "36"
+                },
+                {
+                  "partial_implementation": true,
+                  "version_added": "6"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "36"
+                },
+                {
+                  "partial_implementation": true,
+                  "version_added": "6"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true,
+                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
+              },
+              "safari_ios": {
+                "version_added": "8",
+                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds compat data for the following properties:

* [`text-decoration`](https://developer.mozilla.org/docs/Web/CSS/text-decoration)
* [`text-decoration-color`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-color)
* [`text-decoration-line`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-line)
* [`text-decoration-style`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-style)

A couple notes:

* `blink` values are a bit… odd. Most of the browsers "support" them in the sense of recognizing them as valid values, but don't actually _do_ anything. There are many notes to this effect.
* Several of the original tables have Safari 7.1 (macOS) listed, which isn't a valid browser according to our schema. I've substituted `"7.1"` for `true` in those cases.
* Overall, the data here seems to be very complete with the exception of Edge.

Let me know if you want to see any changes. Thanks!