### PR TITLE
update compat data: parseInt > leading_zero_strings_as_decimal

### DIFF
--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -707,19 +707,19 @@
             "description": "Parses leading-zero strings are decimal, not octal",
             "support": {
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               },
               "chrome": {
-                "version_added": true
+                "version_added": "23"
               },
               "chrome_android": {
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": "21"
@@ -728,7 +728,7 @@
                 "version_added": "21"
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "ie_mobile": {
                 "version_added": true
@@ -743,10 +743,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               }
             },
             "status": {


### PR DESCRIPTION
Version support data taken from https://github.com/kangax/compat-table/blob/f75cdde8e60fb65951d0ae8b7d8b6f5f070c668a/data-es5.js#L1044