### PR TITLE
Add compat data for text-combine-upright CSS property

### DIFF
--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -1,0 +1,200 @@
+{
+  "css": {
+    "properties": {
+      "text-combine-upright": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-combine-upright",
+          "support": {
+            "webview_android": {
+              "version_added": "48"
+            },
+            "chrome": [
+              {
+                "version_added": "48"
+              },
+              {
+                "partial_implementation": true,
+                "alternative_name": "-webkit-text-combine",
+                "version_added": true,
+                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
+              }
+            ],
+            "chrome_android": {
+              "version_added": "48"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "48",
+                "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."
+              },
+              {
+                "version_added": "41",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-combine-upright.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "31",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "26",
+                "version_removed": "31",
+                "alternative_name": "text-combine-horizontal",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "48",
+                "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."
+              },
+              {
+                "version_added": "41",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-combine-upright.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "31",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "26",
+                "version_removed": "31",
+                "alternative_name": "text-combine-horizontal",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "alternative_name": "-ms-text-combine-horizontal"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": true
+              },
+              {
+                "partial_implementation": true,
+                "alternative_name": "-webkit-text-combine",
+                "version_added": true,
+                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without digits."
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "partial_implementation": true,
+              "alternative_name": "-webkit-text-combine",
+              "version_added": true,
+              "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without digits."
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "digits": {
+          "__compat": {
+            "description": "<code>digits</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-combine-upright-digits.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'> bug 1258635</a>)."
+              },
+              "firefox_android": {
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-combine-upright-digits.enabled",
+                  "value_to_set": "true"
+                },
+                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'> bug 1258635</a>)."
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the [`text-combine-upright`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-combine-upright) CSS property. Migrating this one was interesting because the original notes really contained most of the story. Let me know if you want to see any changes. Thanks!