### PR TITLE
Add browser version checking for array support statements

### DIFF
--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -101,12 +101,6 @@
             "opera": [
               {
                 "version_added": "12"
-              },
-              {
-                "prefix": "-o-",
-                "version_added": true,
-                "version_removed": "12.50",
-                "notes": "See the <a href='http://my.opera.com/ODIN/blog/2012/08/03/a-hot-opera-12-50-summer-time-snapshot'>Opera 12.50 release notes</a>."
               }
             ],
             "safari": [

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -44,7 +44,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": "1"
+                "version_added": "4"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -75,7 +75,7 @@
                 ]
               },
               {
-                "version_added": "3.5",
+                "version_added": "4",
                 "prefix": "-moz-",
                 "notes": "An earlier version of the specification was implemented, prefixed, in Firefox versions prior to 15."
               },

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -53,7 +53,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "1"
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -64,7 +64,7 @@
             },
             "opera": [
               {
-                "version_added": "11.10"
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -35,7 +35,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "13"
+                "version_added": "14"
               }
             ]
           },

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -54,7 +54,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "1.5"
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -62,7 +62,7 @@
             },
             "opera": [
               {
-                "version_added": "11.10"
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -67,7 +67,7 @@
             },
             "opera": [
               {
-                "version_added": "11.10"
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -67,7 +67,7 @@
             },
             "opera": [
               {
-                "version_added": "11.10"
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -57,7 +57,7 @@
             },
             "opera": [
               {
-                "version_added": "11.10"
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -61,7 +61,7 @@
             },
             "opera": [
               {
-                "version_added": "11.10"
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -59,7 +59,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "1"
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -70,7 +70,7 @@
             },
             "opera": [
               {
-                "version_added": "11.10"
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -69,7 +69,7 @@
             },
             "opera": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",
@@ -78,7 +78,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -64,7 +64,7 @@
             },
             "opera": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",
@@ -73,7 +73,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -66,7 +66,7 @@
             },
             "opera": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",
@@ -75,7 +75,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -98,7 +98,7 @@
             },
             "opera": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",
@@ -107,7 +107,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.10"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -79,7 +79,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -187,7 +187,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -295,7 +295,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -352,7 +352,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -518,7 +518,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -678,7 +678,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -786,7 +786,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -843,7 +843,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -1188,7 +1188,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -1361,7 +1361,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -1571,7 +1571,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -1730,7 +1730,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -1838,7 +1838,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -1895,7 +1895,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -1952,7 +1952,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -2123,7 +2123,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -2180,7 +2180,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {
@@ -2237,7 +2237,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "4"
                 }
               ],
               "ie": {

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -45,7 +45,7 @@
               },
               {
                 "alternative_name": "-moz-padding-end",
-                "version_added": "3"
+                "version_added": "4"
               },
               {
                 "version_added": "38",

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -45,7 +45,7 @@
               },
               {
                 "alternative_name": "-moz-padding-start",
-                "version_added": "3"
+                "version_added": "4"
               },
               {
                 "version_added": "38",

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -56,7 +56,7 @@
               },
               {
                 "alternative_name": "-moz-padding-end",
-                "version_added": "3"
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -56,7 +56,7 @@
               },
               {
                 "alternative_name": "-moz-padding-start",
-                "version_added": "3"
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -55,7 +55,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": "12",
+                "version_added": "14",
                 "version_removed": "53"
               },
               {

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -434,11 +434,6 @@
               "firefox_android": [
                 {
                   "version_added": "4"
-                },
-                {
-                  "alternative_name": "autobuffer",
-                  "version_added": "1",
-                  "version_removed": "4"
                 }
               ],
               "ie": {

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -191,7 +191,7 @@
               "firefox_android": [
                 {
                   "prefix": "-moz-",
-                  "version_added": "12",
+                  "version_added": "14",
                   "version_removed": "53",
                   "notes": [
                     "First note",

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -5,6 +5,13 @@ for (let browser of Object.keys(browsers)) {
   validBrowserVersions[browser] = Object.keys(browsers[browser].releases);
 }
 
+function isValidVersion(browserIdentifier, version) {
+  if (typeof version === "string") {
+    return validBrowserVersions[browserIdentifier].includes(version);
+  } else {
+    return true;
+  }
+}
 
 function testVersions(dataFilename) {
   var hasErrors = false;
@@ -14,13 +21,11 @@ function testVersions(dataFilename) {
     var browsersToCheck = Object.keys(supportData);
     for (let browser of browsersToCheck) {
       if (validBrowserVersions[browser]) {
-        if (typeof supportData[browser].version_added === "string" &&
-            !validBrowserVersions[browser].includes(supportData[browser].version_added)) {
+        if (!isValidVersion(browser, supportData[browser].version_added)) {
           console.log('\x1b[31m  version_added: "' + supportData[browser].version_added + '" is not a valid version number for ' + browser);
           hasErrors = true;
         }
-        if (typeof supportData[browser].version_removed === "string" &&
-            !validBrowserVersions[browser].includes(supportData[browser].version_removed)) {
+        if (!isValidVersion(browser, supportData[browser].version_removed)) {
           console.log('\x1b[31m  version_removed: "' + supportData[browser].version_removed + '" is not a valid version number for ' + browser);
           hasErrors = true;
         }

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -21,13 +21,23 @@ function testVersions(dataFilename) {
     var browsersToCheck = Object.keys(supportData);
     for (let browser of browsersToCheck) {
       if (validBrowserVersions[browser]) {
-        if (!isValidVersion(browser, supportData[browser].version_added)) {
-          console.log('\x1b[31m  version_added: "' + supportData[browser].version_added + '" is not a valid version number for ' + browser);
-          hasErrors = true;
+
+        let supportStatements = [];
+        if (Array.isArray(supportData[browser])) {
+          Array.prototype.push.apply(supportStatements, supportData[browser]);
+        } else {
+          supportStatements.push(supportData[browser]);
         }
-        if (!isValidVersion(browser, supportData[browser].version_removed)) {
-          console.log('\x1b[31m  version_removed: "' + supportData[browser].version_removed + '" is not a valid version number for ' + browser);
-          hasErrors = true;
+
+        for (let statement of supportStatements) {
+          if (!isValidVersion(browser, statement.version_added)) {
+            console.log('\x1b[31m  version_added: "' + statement.version_added + '" is not a valid version number for ' + browser);
+            hasErrors = true;
+          }
+          if (!isValidVersion(browser, statement.version_removed)) {
+            console.log('\x1b[31m  version_removed: "' + statement.version_removed + '" is not a valid version number for ' + browser);
+            hasErrors = true;
+          }
         }
       }
     }


### PR DESCRIPTION
I noticed that invalid browser versions were being rejected by the linter in some places, but not others. After some investigating, I found that the linter was checking simple support statements, but not array support statements. This PR:

* Adds checks to array support statement version numbers
* Fixes unreleased Firefox for Android version numbers (i.e., raising values <4 to 4, though some compat data is discarded with 794af0f because it applies only to versions of Firefox for which there was no such Android release)
* Fixes Opera versions with trailing zeroes

Unfortunately, there are five version numbers that fail the linter, but I don't know how best to correct them. If anyone has guidance for those cases, I'd be happy to fix the remainder. 