### PR TITLE
Add compat data for text-emphasis CSS properties

### DIFF
--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -1,0 +1,89 @@
+{
+  "css": {
+    "properties": {
+      "text-emphasis-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": "33"
+            },
+            "safari": [
+              {
+                "version_added": "7.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": {
+              "version_added": "7.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -66,7 +66,7 @@
             },
             "safari": [
               {
-                "version_added": "7.1"
+                "version_added": true
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -1,0 +1,160 @@
+{
+  "css": {
+    "properties": {
+      "text-emphasis-position": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "33"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "left_and_right": {
+          "__compat": {
+            "description": "<code>left</code> and <code>right</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "62"
+              },
+              "chrome": {
+                "version_added": "62"
+              },
+              "chrome_android": {
+                "version_added": "62"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "46"
+              },
+              "firefox_android": {
+                "version_added": "46"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "49"
+              },
+              "opera_android": {
+                "version_added": "49"
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -1,0 +1,89 @@
+{
+  "css": {
+    "properties": {
+      "text-emphasis-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": "33"
+            },
+            "safari": [
+              {
+                "version_added": "7.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": {
+              "version_added": "7.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -66,7 +66,7 @@
             },
             "safari": [
               {
-                "version_added": "7.1"
+                "version_added": true
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -1,0 +1,89 @@
+{
+  "css": {
+    "properties": {
+      "text-emphasis": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "45",
+                "version_removed": "49",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.text-emphasis.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": "33"
+            },
+            "safari": [
+              {
+                "version_added": "7.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": {
+              "version_added": "7.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -66,7 +66,7 @@
             },
             "safari": [
               {
-                "version_added": "7.1"
+                "version_added": true
               },
               {
                 "prefix": "-webkit-",


### PR DESCRIPTION
This PR adds compat data for these CSS properties:

* [`text-emphasis-style`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style)
* [`text-emphasis-position`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position)
* [`text-emphasis-color`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color)
* [`text-emphasis`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis)
