### PR TITLE
Add compat data for remaining CSS grid properties

### DIFF
--- a/css/properties/grid-gap.json
+++ b/css/properties/grid-gap.json
@@ -1,0 +1,157 @@
+{
+  "css": {
+    "properties": {
+      "grid-gap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-gap",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "percentage_values": {
+          "__compat": {
+            "description": "<code>&lt;percentage&gt;</code> values",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-row-end.json
+++ b/css/properties/grid-row-end.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "grid-row-end": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row-end",
+          "support": {
+            "webview_android": {
+              "version_added": "57"
+            },
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-row-gap.json
+++ b/css/properties/grid-row-gap.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "grid-row-gap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row-gap",
+          "support": {
+            "webview_android": {
+              "version_added": "57"
+            },
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-row-start.json
+++ b/css/properties/grid-row-start.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "grid-row-start": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row-start",
+          "support": {
+            "webview_android": {
+              "version_added": "57"
+            },
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-row.json
+++ b/css/properties/grid-row.json
@@ -1,0 +1,104 @@
+{
+  "css": {
+    "properties": {
+      "grid-row": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row",
+          "support": {
+            "webview_android": {
+              "version_added": "57"
+            },
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-template-areas.json
+++ b/css/properties/grid-template-areas.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "grid-template-areas": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-areas",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "grid-template-columns": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-columns",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "grid-template-rows": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-rows",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/grid-template.json
+++ b/css/properties/grid-template.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "grid-template": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "29",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "40",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "28",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              }
+            ],
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [`grid-template-rows`](https://developer.mozilla.org/docs/Web/CSS/grid-template-rows)
* [`grid-template-columns`](https://developer.mozilla.org/docs/Web/CSS/grid-template-columns)
* [`grid-template-areas`](https://developer.mozilla.org/docs/Web/CSS/grid-template-areas)
* [`grid-template`](https://developer.mozilla.org/docs/Web/CSS/grid-template)
* [`grid-row-gap`](https://developer.mozilla.org/docs/Web/CSS/grid-row-gap)
* [`grid-row-start`](https://developer.mozilla.org/docs/Web/CSS/grid-row-start)
* [`grid-row-end`](https://developer.mozilla.org/docs/Web/CSS/grid-row-end)
* [`grid-row`](https://developer.mozilla.org/docs/Web/CSS/grid-row)
* [`grid-gap`](https://developer.mozilla.org/docs/Web/CSS/grid-gap)
