### PR TITLE
changing support for coords and shape attributes of the a element 

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -107,19 +107,19 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": true
+                "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": true,
@@ -132,22 +132,22 @@
                 "notes": "You can no longer nest an <code>&lt;a&gt;</code> element inside a <code>&lt;map&gt;</code> element to create a hotspot region — <code>coords</code> and <code>shape</code> attribute support removed."
               },
               "ie": {
-                "version_added": true
+                "version_added": false
               },
               "ie_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -623,19 +623,19 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": true
+                "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": true,
@@ -648,22 +648,22 @@
                 "notes": "You can no longer nest an <code>&lt;a&gt;</code> element inside a <code>&lt;map&gt;</code> element to create a hotspot region — <code>coords</code> and <code>shape</code> attribute support removed."
               },
               "ie": {
-                "version_added": true
+                "version_added": false
               },
               "ie_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -122,10 +122,14 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "58",
+                "notes": "You can no longer nest an <code>&lt;a&gt;</code> element inside a <code>&lt;map&gt;</code> element to create a hotspot region — <code>coords</code> and <code>shape</code> attribute support removed."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "58",
+                "notes": "You can no longer nest an <code>&lt;a&gt;</code> element inside a <code>&lt;map&gt;</code> element to create a hotspot region — <code>coords</code> and <code>shape</code> attribute support removed."
               },
               "ie": {
                 "version_added": true
@@ -634,10 +638,14 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "58",
+                "notes": "You can no longer nest an <code>&lt;a&gt;</code> element inside a <code>&lt;map&gt;</code> element to create a hotspot region — <code>coords</code> and <code>shape</code> attribute support removed."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "58",
+                "notes": "You can no longer nest an <code>&lt;a&gt;</code> element inside a <code>&lt;map&gt;</code> element to create a hotspot region — <code>coords</code> and <code>shape</code> attribute support removed."
               },
               "ie": {
                 "version_added": true


### PR DESCRIPTION
In Firefox 58, we removed support for these attributes - see https://www.fxsitecompat.com/en-CA/docs/2017/a-elements-can-no-longer-be-used-as-image-map-regions/ for details.

Let me know if I've represented this correctly; it's a bit of a funny one, and I'm not quite sure.