### PR TITLE
Add compat data for transform CSS properties

### DIFF
--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1316,12 +1316,17 @@
       },
       "48": {
         "release_date": "2017-09-27",
-        "status": "current"
+        "status": "retired"
       },
       "49": {
-        "status": "planned"
+        "release_date": "2017-11-08",
+        "release_notes": "https://dev.opera.com/blog/opera-49/",
+        "status": "current"
       },
       "50": {
+        "status": "planned"
+      },
+      "51": {
         "status": "planned"
       }
     }

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -1,0 +1,95 @@
+{
+  "css": {
+    "properties": {
+      "transform-box": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-box",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "43",
+                "flag": {
+                  "type": "preference",
+                  "name": "svg.transform-box.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "41",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "svg.transform-origin.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "43",
+                "flag": {
+                  "type": "preference",
+                  "name": "svg.transform-box.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "version_added": "41",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "svg.transform-origin.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-box",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "64"
             },
             "chrome": {
-              "version_added": false
+              "version_added": "64"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "64"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -34,7 +34,7 @@
               },
               {
                 "version_added": "41",
-                "version_removed": true,
+                "version_removed": "43",
                 "flag": {
                   "type": "preference",
                   "name": "svg.transform-origin.enabled",
@@ -68,13 +68,13 @@
               "version_added": false
             },
             "ie_mobile": {
-              "version_added": null
-            },
-            "opera": {
               "version_added": false
             },
+            "opera": {
+              "version_added": "51"
+            },
             "opera_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "safari": {
               "version_added": null

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -55,9 +55,28 @@
                 }
               }
             ],
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
             "ie": [
               {
                 "version_added": "10"

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -1,0 +1,218 @@
+{
+  "css": {
+    "properties": {
+      "transform-origin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-origin",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "3.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": [
+              {
+                "version_added": "10"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "9"
+              }
+            ],
+            "ie_mobile": {
+              "prefix": "-webkit-",
+              "version_added": "8.1"
+            },
+            "opera": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10.5"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "three_value_syntax": {
+          "__compat": {
+            "description": "Three-value syntax",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "10"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "support_in_svg": {
+          "__compat": {
+            "description": "Support in SVG",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "43",
+                  "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
+                },
+                {
+                  "version_added": "41",
+                  "version_removed": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "svg.transform-origin.enabled",
+                    "value_to_set": "true"
+                  },
+                  "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -1,0 +1,113 @@
+{
+  "css": {
+    "properties": {
+      "transform-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-style",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "12"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -1,0 +1,178 @@
+{
+  "css": {
+    "properties": {
+      "transform": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "2.1",
+              "notes": "Android 2.3 has a bug where input forms will \"jump\" when typing, if any container element has a <code>-webkit-transform</code>."
+            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": [
+              {
+                "version_added": "10",
+                "notes": "Internet Explorer does not support the global values <code>initial</code> and <code>unset</code>."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "11"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "9",
+                "notes": "Internet Explorer 5.5 or later supports a proprietary <a href='https://msdn.microsoft.com/en-us/library/ms533014(VS.85,loband).aspx'>Matrix Filter</a> which can be used to achieve a similar effect."
+              }
+            ],
+            "ie_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "11"
+              }
+            ],
+            "opera": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10.5",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": "11.5"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "3d": {
+          "__compat": {
+            "description": "3D support",
+            "support": {
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              },
+              "chrome": {
+                "version_added": "12"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "10"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "10",
+                "notes": "Internet Explorer 9.0 or earlier has no support for 3D transforms. Mixing 3D and 2D transform functions, such as <code>-ms-transform:rotate(10deg) translateZ(0);</code>, will prevent the entire property from being applied."
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "22"
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -49,9 +49,24 @@
                 }
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
             "ie": [
               {
                 "version_added": "10",


### PR DESCRIPTION
This PR adds compat data for the following CSS properties:

* [`transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform) (Note: there are many value features that need to be added here; they'll come along in future PRs.)
* [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box)
* [`transform-origin`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin)
* [`transform-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style)

