### PR TITLE
Add compat data for CSS grid repeat()

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -101,6 +101,98 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "repeat": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat",
+            "description": "<code>repeat()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "52",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": [
+                {
+                  "version_added": "44"
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -101,6 +101,98 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "repeat": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat",
+            "description": "<code>repeat()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "52",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": [
+                {
+                  "version_added": "44"
+                },
+                {
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds compat data for [`repeat()`](https://developer.mozilla.org/en-US/docs/Web/CSS/repeat) as features on `grid-template-rows` and `grid-template-columns`.