### PR TITLE
Added sampleRate option to new AudioContext()

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -111,6 +111,9 @@
             "ie_mobile": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "42"
             },
@@ -161,6 +164,9 @@
               "ie_mobile": {
                 "version_added": false
               },
+              "nodejs": {
+                "version_added": false
+              },
               "opera": {
                 "version_added": "47"
               },
@@ -175,7 +181,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -212,6 +218,9 @@
               "ie_mobile": {
                 "version_added": null
               },
+              "nodejs": {
+                "version_added": false
+              },
               "opera": {
                 "version_added": null
               },
@@ -226,7 +235,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -94,7 +94,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -130,9 +130,9 @@
             "deprecated": false
           }
         },
-        "options": {
+        "latencyHint": {
           "__compat": {
-            "description": "<code>options</code> parameter",
+            "description": "<code>latencyHint</code> option",
             "support": {
               "webview_android": {
                 "version_added": "60"
@@ -144,7 +144,7 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -166,6 +166,57 @@
               },
               "opera_android": {
                 "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sampleRate": {
+          "__compat": {
+            "description": "<code>sampleRate</code> option",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
`new AudioContext()` was missing the newly added sampleRate option. Since Chrome supports the `latencyHint` option but not the `sampleRate` option, it makes sense to separate the two.

Also, renamed "options parameter" to "latencyHint option" because no browser has issues with `new AudioContext({})` or `new AudioContext({ foo: 1, bar: 2 })`; they'll just ignore any options they don't currently support.