### PR TITLE
Add compat data for more CSS text properties

### DIFF
--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -1,0 +1,159 @@
+{
+  "css": {
+    "properties": {
+      "text-indent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-indent",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "each-line": {
+          "__compat": {
+            "description": "<code>each-line</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hanging": {
+          "__compat": {
+            "description": "<code>hanging</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -1,0 +1,84 @@
+{
+  "css": {
+    "properties": {
+      "text-justify": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-justify",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "Enable Experimental Web Platform Features",
+                "value_to_set": "true"
+              },
+              "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
+            },
+            "chrome_android": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "Enable Experimental Web Platform Features",
+                "value_to_set": "true"
+              },
+              "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
+            },
+            "edge": {
+              "version_added": "14",
+              "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
+            },
+            "edge_mobile": {
+              "version_added": "14",
+              "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": "11",
+              "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "Enable Experimental Web Platform Features",
+                "value_to_set": "true"
+              },
+              "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
+            },
+            "opera_android": {
+              "version_added": true,
+              "flag": {
+                "type": "preference",
+                "name": "Enable Experimental Web Platform Features",
+                "value_to_set": "true"
+              },
+              "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -1,0 +1,151 @@
+{
+  "css": {
+    "properties": {
+      "text-orientation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-orientation",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "48"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "sideways": {
+          "__compat": {
+            "description": "<code>sideways</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "44",
+                "notes": "<code>sideways-right</code> has become an alias of <code>sideways</code>."
+              },
+              "firefox_android": {
+                "version_added": "44",
+                "notes": "<code>sideways-right</code> has become an alias of <code>sideways</code>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -1,0 +1,275 @@
+{
+  "css": {
+    "properties": {
+      "text-overflow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-overflow",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "7",
+              "notes": "Until Firefox 10, handling of <code>text-overflow</code> on blocks with inline overflow on both horizontal sides was incorrect. Before Firefox 10, if only one value was specified (such as <code>text-overflow: ellipsis;</code>), text was ellipsed on both sides of the block, instead of only the end edge based on the block's text direction."
+            },
+            "firefox_android": {
+              "version_added": "7",
+              "notes": "Until Firefox 10, handling of <code>text-overflow</code> on blocks with inline overflow on both horizontal sides was incorrect. Before Firefox 10, if only one value was specified (such as <code>text-overflow: ellipsis;</code>), text was ellipsed on both sides of the block, instead of only the end edge based on the block's text direction."
+            },
+            "ie": [
+              {
+                "version_added": "6"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "8"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "9"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1.3"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "two_value_syntax": {
+          "__compat": {
+            "description": "Two-value syntax",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "9"
+              },
+              "firefox_android": {
+                "version_added": "9"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "string": {
+          "__compat": {
+            "description": "&lt;string&gt;",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "9"
+              },
+              "firefox_android": {
+                "version_added": "9"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fade_value": {
+          "__compat": {
+            "description": "<code>fade</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fade_function": {
+          "__compat": {
+            "description": "<code>fade()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following `text-*` properties:

* [`text-overflow`](https://developer.mozilla.org/docs/Web/CSS/text-overflow)
* [`text-orientation`](https://developer.mozilla.org/docs/Web/CSS/text-orientation)
* [`text-justify`](https://developer.mozilla.org/docs/Web/CSS/text-justify)
* [`text-indent`](https://developer.mozilla.org/docs/Web/CSS/text-indent) (since this is an old property, some basic support values were presumed to be `true` even though the original table didn't have complete data)