### PR TITLE
Add Samsung Internet

### DIFF
--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1422,5 +1422,65 @@
         "status": "current"
       }
     }
+  },
+  "samsunginternet": {
+    "releases": {
+      "1.0": {
+        "release_date": "2013-04-27",
+        "status": "retired"
+      },
+      "1.5": {
+        "release_date": "2013-09-25",
+        "status": "retired"
+      },
+      "1.6": {
+        "release_date": "2014-04-11",
+        "status": "retired"
+      },
+      "2.0": {
+        "release_date": "2014-10-17",
+        "status": "retired"
+      },
+      "2.1": {
+        "release_date": "2015-01-07",
+        "status": "retired"
+      },
+      "3.0": {
+        "release_date": "2015-04-10",
+        "status": "retired"
+      },
+      "3.2": {
+        "release_date": "2015-08-24",
+        "status": "retired"
+      },
+      "4.0": {
+        "release_date": "2016-03-11",
+        "status": "retired"
+      },
+      "4.2": {
+        "release_date": "2016-08-02",
+        "status": "retired"
+      },
+      "5.0": {
+        "release_date": "2016-12-15",
+        "status": "retired"
+      },
+      "5.2": {
+        "release_date": "2017-04-21",
+        "status": "retired"
+      },
+      "5.4": {
+        "release_date": "2017-05-17",
+        "status": "retired"
+      },
+      "6.0": {
+        "release_date": "2017-08-23",
+        "status": "retired"
+      },
+      "6.2": {
+        "release_date": "2017-10-26",
+        "status": "current"
+      }
+    }
   }
 }

--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1423,7 +1423,7 @@
       }
     }
   },
-  "samsunginternet": {
+  "samsunginternet_android": {
     "releases": {
       "1.0": {
         "release_date": "2013-04-27",

--- a/browsers/browsers.schema.json
+++ b/browsers/browsers.schema.json
@@ -45,7 +45,8 @@
       "opera": { "$ref": "#/definitions/browser_statement" },
       "opera_android": { "$ref": "#/definitions/browser_statement" },
       "safari": { "$ref": "#/definitions/browser_statement" },
-      "safari_ios": { "$ref": "#/definitions/browser_statement" }
+      "safari_ios": { "$ref": "#/definitions/browser_statement" },
+      "samsunginternet_android": { "$ref": "#/definitions/browser_statement" }
     },
     "additionalProperties": false
 }

--- a/compat-data-schema.md
+++ b/compat-data-schema.md
@@ -108,7 +108,8 @@ The currently accepted browser identifiers should be declared in the following o
 * `opera`, the Opera browser (desktop), based on Blink since Opera 15,
 * `opera_android`, the Opera browser (Android version),
 * `safari`, Apple Safari, on Mac OS,
-* `safari_ios`, Apple Safari, on iOS.
+* `safari_ios`, Apple Safari, on iOS,
+* `samsunginternet_android`, the Samsung Internet browser (Android version).
 
 No browser identifier is mandatory.
 

--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -79,7 +79,8 @@
         "opera": { "$ref": "#/definitions/support_statement" },
         "opera_android": { "$ref": "#/definitions/support_statement" },
         "safari": { "$ref": "#/definitions/support_statement" },
-        "safari_ios": { "$ref": "#/definitions/support_statement" }
+        "safari_ios": { "$ref": "#/definitions/support_statement" },
+        "samsunginternet_android": { "$ref": "#/definitions/support_statement" }
       },
       "additionalProperties": false
     },

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -47,6 +47,9 @@
           },
           "safari_ios": {
             "version_added": true
+          },
+          "samsunginternet_android": {
+            "version_added": true
           }
         },
         "status": {

--- a/http/methods.json
+++ b/http/methods.json
@@ -43,6 +43,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -93,6 +96,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -145,6 +151,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -195,6 +204,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -247,6 +259,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -298,6 +313,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -348,6 +366,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },

--- a/http/status.json
+++ b/http/status.json
@@ -43,6 +43,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -93,6 +96,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -145,6 +151,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -195,6 +204,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -247,6 +259,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -297,6 +312,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -349,6 +367,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -399,6 +420,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -451,6 +475,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -501,6 +528,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -553,6 +583,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -603,6 +636,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -655,6 +691,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -705,6 +744,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -757,6 +799,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -807,6 +852,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -859,6 +907,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -909,6 +960,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -961,6 +1015,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -1011,6 +1068,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -1063,6 +1123,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -1113,6 +1176,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },
@@ -1165,6 +1231,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -1216,6 +1285,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -1266,6 +1338,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             }
           },

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -57,6 +57,9 @@
             "safari_ios": {
               "version_added": true,
               "notes": "The same note twice should only be displayed once and have one anchor number"
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             }
           },
           "status": {
@@ -115,6 +118,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             }
           },
           "status": {
@@ -226,6 +232,9 @@
               },
               "safari_ios": {
                 "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
               }
             },
             "status": {

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -16,7 +16,6 @@ function testSchema(dataFilename, schemaFilename = '../compat-data.schema.json')
       separator: '\n    ',
       dataVar: 'item'
     }));
-    console.log(ajv.errors);
     return true;
   }
 }

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -16,6 +16,7 @@ function testSchema(dataFilename, schemaFilename = '../compat-data.schema.json')
       separator: '\n    ',
       dataVar: 'item'
     }));
+    console.log(ajv.errors);
     return true;
   }
 }


### PR DESCRIPTION
Hi. I'm hoping as per #608, this should add the initial data required to set up the Samsung Internet browser.

NB. The release dates are confirmed as best as I've been able to so far. There's a small risk some of the older ones could be out by a few days - I presume that won't be a massive deal and we can always update later if we had a slight date change confirmed?

I've included in this PR our support data for some basic HTTP features, as a quick win. I will discuss with the team a plan to add our support data for all the other features!