### PR TITLE
Add compat data for minmax() CSS grid function

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -102,6 +102,96 @@
             "deprecated": false
           }
         },
+        "minmax": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax",
+            "description": "<code>minmax()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "version_added": "29",
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": "40",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": "40",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "44"
+                },
+                {
+                  "version_added": "28",
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                }
+              ],
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "repeat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -102,6 +102,96 @@
             "deprecated": false
           }
         },
+        "minmax": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax",
+            "description": "<code>minmax()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "version_added": "29",
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": "40",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": "40",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": [
+                {
+                  "version_added": "44"
+                },
+                {
+                  "version_added": "28",
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                }
+              ],
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "repeat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat",


### PR DESCRIPTION
This PR adds the [`minmax()`](https://developer.mozilla.org/docs/Web/CSS/minmax) function to `grid-template-rows` and `grid-template-columns`.