### PR TITLE
Add browserSettings.webNotificationsDisabled

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -106,6 +106,27 @@
               }
             }
           }
+        },
+        "webNotificationsDisabled": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": {
+                "version_added": "58"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1364942 adds  [`browserSettings.webNotificationsDisabled`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled).

It's Firefox (desktop and mobile) only, and only from version 58 onwards.