### PR TITLE
Firefox removed prefixed WebGL extensions (bug 1403413)

### DIFF
--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -19,9 +19,16 @@
           "edge_mobile": {
             "version_added": false
           },
-          "firefox": {
-            "version_added": "18"
-          },
+          "firefox": [
+            {
+              "version_added": "18"
+            },
+            {
+              "prefix": "MOZ_",
+              "version_added": true,
+              "version_removed": "58"
+            }
+          ],
           "firefox_android": {
             "version_added": null
           },

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -19,9 +19,16 @@
           "edge_mobile": {
             "version_added": false
           },
-          "firefox": {
-            "version_added": "18"
-          },
+          "firefox": [
+            {
+              "version_added": "18"
+            },
+            {
+              "prefix": "MOZ_",
+              "version_added": true,
+              "version_removed": "58"
+            }
+          ],
           "firefox_android": {
             "version_added": null
           },

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -21,12 +21,12 @@
           },
           "firefox": [
             {
-              "prefix": "MOZ_",
-              "version_added": "15",
-              "version_removed": "21"
+              "version_added": "22"
             },
             {
-              "version_added": "22"
+              "prefix": "MOZ_",
+              "version_added": "15",
+              "version_removed": "58"
             }
           ],
           "firefox_android": {

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -21,12 +21,12 @@
           },
           "firefox": [
             {
-              "prefix": "MOZ_",
-              "version_added": true,
-              "version_removed": "22"
+              "version_added": "22"
             },
             {
-              "version_added": "22"
+              "prefix": "MOZ_",
+              "version_added": true,
+              "version_removed": "58"
             }
           ],
           "firefox_android": {

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -21,12 +21,12 @@
           },
           "firefox": [
             {
-              "prefix": "MOZ_",
-              "version_added": "19",
-              "version_removed": "22"
+              "version_added": "22"
             },
             {
-              "version_added": "22"
+              "prefix": "MOZ_",
+              "version_added": "19",
+              "version_removed": "58"
             }
           ],
           "firefox_android": {
@@ -78,12 +78,12 @@
             },
             "firefox": [
               {
-                "prefix": "MOZ_",
-                "version_added": "19",
-                "version_removed": "22"
+                "version_added": "22"
               },
               {
-                "version_added": "22"
+                "prefix": "MOZ_",
+                "version_added": "19",
+                "version_removed": "58"
               }
             ],
             "firefox_android": {
@@ -136,12 +136,12 @@
             },
             "firefox": [
               {
-                "prefix": "MOZ_",
-                "version_added": "19",
-                "version_removed": "22"
+                "version_added": "22"
               },
               {
-                "version_added": "22"
+                "prefix": "MOZ_",
+                "version_added": "19",
+                "version_removed": "58"
               }
             ],
             "firefox_android": {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1403413
Also fixes the order in the array support statements, so that the supported version comes first.
Affected MDN pages:
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_atc
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_pvrtc
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_s3tc
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_depth_texture
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context