### PR TITLE
Comprehensions have been removed from Fx58 (bug 1414340)

### DIFF
--- a/javascript/operators/array_comprehensions.json
+++ b/javascript/operators/array_comprehensions.json
@@ -22,10 +22,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "30"
+              "version_added": "30",
+              "version_removed": "58"
             },
             "firefox_android": {
-              "version_added": "30"
+              "version_added": "30",
+              "version_removed": "58"
             },
             "ie": {
               "version_added": false

--- a/javascript/operators/generator_comprehensions.json
+++ b/javascript/operators/generator_comprehensions.json
@@ -22,10 +22,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "30"
+              "version_added": "30",
+              "version_removed": "58"
             },
             "firefox_android": {
-              "version_added": "30"
+              "version_added": "30",
+              "version_removed": "58"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1414340

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Generator_comprehensions