### PR TITLE
Add data for tabs.discard

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1021,6 +1021,37 @@
             }
           }
         },
+        "discard": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "54",
+                "notes": [
+                  "Only accepts a single tab ID as a parameter, not an array.",
+                  "The tab ID argument is optional: if it is omitted, the browser discards the least important tab.",
+                  "The callback is passed a <code>Tab</code> object representing the tab that was discarded."
+                ]
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true,
+                "notes": [
+                  "Only accepts a single tab ID as a parameter, not an array.",
+                  "The tab ID argument is optional: if it is omitted, the browser discards the least important tab.",
+                  "The callback is passed a <code>Tab</code> object representing the tab that was discarded."
+                ]
+              }
+            }
+          }
+        },
         "duplicate": {
           "__compat": {
             "support": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1322485 added support for tabs.discard in Firefox 58, desktop only.

Chrome docs: https://developer.chrome.com/extensions/tabs#method-discard 
MDN docs: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/discard