### PR TITLE
Add support for page_action for FF for Android

### DIFF
--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -21,7 +21,7 @@
               "version_added": "48"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This is wrong, Fennec extensions use page_action in the manifest (for example https://github.com/tynn/close-tab-button).