### PR TITLE
Safari has implemented upgrade-insecure-requests

### DIFF
--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -40,10 +40,10 @@
               "version_added": "31"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             }
           },
           "status": {

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -40,10 +40,10 @@
               "version_added": "31"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10"
             }
           },
           "status": {

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -40,10 +40,10 @@
               "version_added": "31"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             }
           },
           "status": {


### PR DESCRIPTION
Safari both on desktop and IOS implemented upgrade-insecure-requests in version 10