### PR TITLE
Add mask-size CSS property

### DIFF
--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "mask-size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-size",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the [`mask-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-size) property. The original table on MDN was a bit odd, so only Firefox is represented here. 