### PR TITLE
Added mdn_url for APIs

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/Alarm"
           }
         },
         "clear": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clear"
           }
         },
         "clearAll": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll"
           }
         },
         "create": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/create"
           }
         },
         "get": {
@@ -104,7 +108,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/get"
           }
         },
         "getAll": {
@@ -125,7 +130,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll"
           }
         },
         "onAlarm": {
@@ -146,7 +152,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm"
           }
         }
       }

--- a/webextensions/api/bookmarks.json
+++ b/webextensions/api/bookmarks.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode"
           },
           "type": {
             "__compat": {
@@ -62,7 +63,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType"
           }
         },
         "BookmarkTreeNodeUnmodifiable": {
@@ -83,7 +85,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeUnmodifiable"
           }
         },
         "CreateDetails": {
@@ -104,7 +107,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/CreateDetails"
           },
           "type": {
             "__compat": {
@@ -146,7 +150,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/create"
           }
         },
         "get": {
@@ -167,7 +172,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/get"
           }
         },
         "getChildren": {
@@ -188,7 +194,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getChildren"
           }
         },
         "getRecent": {
@@ -209,7 +216,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getRecent"
           }
         },
         "getSubTree": {
@@ -230,7 +238,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getSubTree"
           }
         },
         "getTree": {
@@ -251,7 +260,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getTree"
           }
         },
         "move": {
@@ -272,7 +282,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/move"
           }
         },
         "onChanged": {
@@ -293,7 +304,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onChanged"
           }
         },
         "onChildrenReordered": {
@@ -314,7 +326,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onChildrenReordered"
           }
         },
         "onCreated": {
@@ -335,7 +348,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onCreated"
           }
         },
         "onImportBegan": {
@@ -356,7 +370,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportBegan"
           }
         },
         "onImportEnded": {
@@ -377,7 +392,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportEnded"
           }
         },
         "onMoved": {
@@ -398,7 +414,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onMoved"
           }
         },
         "onRemoved": {
@@ -419,7 +436,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onRemoved"
           }
         },
         "remove": {
@@ -440,7 +458,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/remove"
           }
         },
         "removeTree": {
@@ -461,7 +480,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/removeTree"
           }
         },
         "search": {
@@ -482,7 +502,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/search"
           }
         },
         "update": {
@@ -503,7 +524,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/update"
           }
         }
       }

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray"
           }
         },
         "ImageDataType": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ImageDataType"
           }
         },
         "disable": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/disable"
           }
         },
         "enable": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/enable"
           }
         },
         "getBadgeBackgroundColor": {
@@ -104,7 +108,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeBackgroundColor"
           }
         },
         "getBadgeText": {
@@ -125,7 +130,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeText"
           }
         },
         "getPopup": {
@@ -146,7 +152,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup"
           }
         },
         "getTitle": {
@@ -167,7 +174,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getTitle"
           }
         },
         "onClicked": {
@@ -188,7 +196,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked"
           }
         },
         "openPopup": {
@@ -209,7 +218,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup"
           }
         },
         "setBadgeBackgroundColor": {
@@ -230,7 +240,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor"
           }
         },
         "setBadgeText": {
@@ -254,7 +265,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeText"
           }
         },
         "setIcon": {
@@ -278,7 +290,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon"
           },
           "imageData": {
             "__compat": {
@@ -320,7 +333,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup"
           }
         },
         "setTitle": {
@@ -341,7 +355,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setTitle"
           }
         }
       }

--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/allowPopupsForUserEvents"
           }
         },
         "cacheEnabled": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/cacheEnabled"
           }
         },
         "homepageOverride": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/homepageOverride"
           }
         },
         "imageAnimationBehavior": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/imageAnimationBehavior"
           }
         },
         "newTabPageOverride": {
@@ -104,7 +108,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPageOverride"
           }
         },
         "webNotificationsDisabled": {
@@ -125,7 +130,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled"
           }
         }
       }

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -393,7 +393,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove"
           }
         },
         "removeCache": {
@@ -420,7 +421,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache"
           }
         },
         "removeCookies": {
@@ -441,7 +443,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeCookies"
           }
         },
         "removeDownloads": {
@@ -462,7 +465,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeDownloads"
           }
         },
         "removeFormData": {
@@ -483,7 +487,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeFormData"
           }
         },
         "removeHistory": {
@@ -507,7 +512,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeHistory"
           }
         },
         "removeLocalStorage": {
@@ -534,7 +540,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeLocalStorage"
           },
           "removalOptions": {
             "hostnames": {
@@ -578,7 +585,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removePasswords"
           }
         },
         "removePluginData": {
@@ -599,7 +607,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removePluginData"
           }
         },
         "settings": {
@@ -620,7 +629,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/settings"
           }
         }
       }

--- a/webextensions/api/clipboard.json
+++ b/webextensions/api/clipboard.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData"
           }
         }
       }

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/Command"
           }
         },
         "getAll": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/getAll"
           }
         },
         "onCommand": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onCommand"
           }
         }
       }

--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -154,7 +154,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/create"
           }
         },
         "get": {
@@ -183,7 +184,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/get"
           }
         },
         "onCreated": {
@@ -204,7 +206,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onCreated"
           }
         },
         "onRemoved": {
@@ -225,7 +228,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onRemoved"
           }
         },
         "onUpdated": {
@@ -246,7 +250,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onUpdated"
           }
         },
         "query": {
@@ -273,7 +278,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/query"
           }
         },
         "remove": {
@@ -302,7 +308,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/remove"
           }
         },
         "update": {
@@ -331,7 +338,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/update"
           }
         }
       }

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie"
           }
         },
         "CookieStore": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore"
           }
         },
         "OnChangedCause": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/OnChangedCause"
           }
         },
         "get": {
@@ -86,7 +89,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/get"
           }
         },
         "getAll": {
@@ -113,7 +117,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll"
           }
         },
         "getAllCookieStores": {
@@ -140,7 +145,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAllCookieStores"
           }
         },
         "onChanged": {
@@ -161,7 +167,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/onChanged"
           }
         },
         "remove": {
@@ -188,7 +195,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/remove"
           }
         },
         "set": {
@@ -215,7 +223,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set"
           }
         }
       }

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -21,7 +21,8 @@
                 "opera": {
                   "version_added": true
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/eval"
             },
             "$0": {
               "__compat": {
@@ -105,7 +106,8 @@
                 "opera": {
                   "version_added": true
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/reload"
             }
           },
           "tabId": {
@@ -126,7 +128,8 @@
                 "opera": {
                   "version_added": true
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/tabId"
             }
           }
         },
@@ -149,7 +152,8 @@
                 "opera": {
                   "version_added": true
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/onNavigated"
             }
           }
         },
@@ -173,7 +177,8 @@
                   "opera": {
                     "version_added": true
                   }
-                }
+                },
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel/createSidebarPane"
               }
             },
             "onSelectionChanged": {
@@ -194,7 +199,8 @@
                   "opera": {
                     "version_added": true
                   }
-                }
+                },
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel/onSelectionChanged"
               }
             }
           },
@@ -285,7 +291,8 @@
                   "opera": {
                     "version_added": true
                   }
-                }
+                },
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/onHidden"
               }
             },
             "onShown": {
@@ -309,7 +316,8 @@
                   "opera": {
                     "version_added": true
                   }
-                }
+                },
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/onShown"
               }
             },
             "setExpression": {
@@ -336,7 +344,8 @@
                   "opera": {
                     "version_added": true
                   }
-                }
+                },
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/setExpression"
               }
             },
             "setObject": {
@@ -363,7 +372,8 @@
                   "opera": {
                     "version_added": true
                   }
-                }
+                },
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/setObject"
               }
             }
           },
@@ -385,7 +395,8 @@
                 "opera": {
                   "version_added": true
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/create"
             }
           },
           "elements": {
@@ -406,7 +417,8 @@
                 "opera": {
                   "version_added": true
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/elements"
             }
           },
           "onThemeChanged": {
@@ -427,7 +439,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/onThemeChanged"
             }
           },
           "themeName": {
@@ -448,7 +461,8 @@
                 "opera": {
                   "version_added": "41"
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/themeName"
             }
           }
         }

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/BooleanDelta"
           }
         },
         "DangerType": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DangerType"
           }
         },
         "DoubleDelta": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DoubleDelta"
           }
         },
         "DownloadItem": {
@@ -511,7 +514,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DownloadQuery"
           }
         },
         "DownloadTime": {
@@ -532,7 +536,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DownloadTime"
           }
         },
         "FilenameConflictAction": {
@@ -553,7 +558,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/FilenameConflictAction"
           },
           "prompt": {
             "__compat": {
@@ -595,7 +601,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/InterruptReason"
           }
         },
         "State": {
@@ -616,7 +623,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/State"
           }
         },
         "StringDelta": {
@@ -637,7 +645,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/StringDelta"
           }
         },
         "acceptDanger": {
@@ -658,7 +667,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/acceptDanger"
           }
         },
         "cancel": {
@@ -679,7 +689,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/cancel"
           }
         },
         "download": {
@@ -700,7 +711,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/download"
           },
           "body": {
             "__compat": {
@@ -880,7 +892,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/drag"
           }
         },
         "erase": {
@@ -901,7 +914,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/erase"
           }
         },
         "getFileIcon": {
@@ -922,7 +936,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/getFileIcon"
           }
         },
         "onChanged": {
@@ -943,7 +958,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onChanged"
           }
         },
         "onCreated": {
@@ -964,7 +980,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onCreated"
           }
         },
         "onErased": {
@@ -985,7 +1002,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onErased"
           }
         },
         "open": {
@@ -1006,7 +1024,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/open"
           }
         },
         "pause": {
@@ -1027,7 +1046,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/pause"
           }
         },
         "removeFile": {
@@ -1048,7 +1068,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/removeFile"
           }
         },
         "resume": {
@@ -1069,7 +1090,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/resume"
           }
         },
         "search": {
@@ -1090,7 +1112,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/search"
           }
         },
         "setShelfEnabled": {
@@ -1111,7 +1134,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/setShelfEnabled"
           }
         },
         "show": {
@@ -1132,7 +1156,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/show"
           }
         },
         "showDefaultFolder": {
@@ -1153,7 +1178,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/showDefaultFolder"
           }
         }
       }

--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event"
           }
         },
         "Rule": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Rule"
           }
         },
         "UrlFilter": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/UrlFilter"
           }
         }
       }

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/ViewType"
           }
         },
         "getBackgroundPage": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage"
           }
         },
         "getExtensionTabs": {
@@ -67,7 +69,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getExtensionTabs"
           }
         },
         "getURL": {
@@ -93,7 +96,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL"
           }
         },
         "getViews": {
@@ -120,7 +124,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getViews"
           }
         },
         "inIncognitoContext": {
@@ -141,7 +146,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext"
           }
         },
         "isAllowedFileSchemeAccess": {
@@ -162,7 +168,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedFileSchemeAccess"
           }
         },
         "isAllowedIncognitoAccess": {
@@ -183,7 +190,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedIncognitoAccess"
           }
         },
         "lastError": {
@@ -204,7 +212,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/lastError"
           }
         },
         "onRequest": {
@@ -230,7 +239,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/onRequest"
           }
         },
         "onRequestExternal": {
@@ -256,7 +266,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/onRequestExternal"
           }
         },
         "sendRequest": {
@@ -282,7 +293,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/sendRequest"
           }
         },
         "setUpdateUrlData": {
@@ -303,7 +315,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/setUpdateUrlData"
           }
         }
       }

--- a/webextensions/api/extensionTypes.json
+++ b/webextensions/api/extensionTypes.json
@@ -32,7 +32,8 @@
                   "This feature is supported but not exposed through the 'extensionTypes' object."
                 ]
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails"
           }
         },
         "ImageFormat": {
@@ -65,7 +66,8 @@
                   "This feature is supported but not exposed through the 'extensionTypes' object."
                 ]
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageFormat"
           }
         },
         "RunAt": {
@@ -94,7 +96,8 @@
                   "This feature is supported but not exposed through the 'extensionTypes' object."
                 ]
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt"
           }
         },
         "CSSOrigin": {

--- a/webextensions/api/find.json
+++ b/webextensions/api/find.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find/find"
           }
         },
         "highlightResults": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find/highlightResults"
           }
         },
         "removeHighlighting": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find/removeHighlighting"
           }
         }
       }

--- a/webextensions/api/history.json
+++ b/webextensions/api/history.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/HistoryItem"
           },
           "typedCount": {
             "__compat": {
@@ -62,7 +63,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/TransitionType"
           }
         },
         "VisitItem": {
@@ -83,7 +85,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/VisitItem"
           }
         },
         "addUrl": {
@@ -104,7 +107,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/addUrl"
           },
           "title": {
             "__compat": {
@@ -188,7 +192,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteAll"
           }
         },
         "deleteRange": {
@@ -209,7 +214,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteRange"
           }
         },
         "deleteUrl": {
@@ -230,7 +236,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteUrl"
           }
         },
         "getVisits": {
@@ -251,7 +258,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/getVisits"
           }
         },
         "onTitleChanged": {
@@ -272,7 +280,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/onTitleChanged"
           }
         },
         "onVisitRemoved": {
@@ -293,7 +302,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/onVisitRemoved"
           }
         },
         "onVisited": {
@@ -317,7 +327,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/onVisited"
           }
         },
         "search": {
@@ -338,7 +349,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/search"
           }
         }
       }

--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": "34"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode"
           }
         },
         "detectLanguage": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": "34"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/detectLanguage"
           }
         },
         "getAcceptLanguages": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": "34"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages"
           }
         },
         "getMessage": {
@@ -90,7 +93,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage"
           }
         },
         "getUILanguage": {
@@ -111,7 +115,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage"
           }
         }
       }

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL"
           }
         },
         "launchWebAuthFlow": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/launchWebAuthFlow"
           }
         }
       }

--- a/webextensions/api/idle.json
+++ b/webextensions/api/idle.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/IdleState"
           }
         },
         "onStateChanged": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/onStateChanged"
           },
           "locked": {
             "__compat": {
@@ -89,7 +91,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/queryState"
           },
           "locked": {
             "__compat": {
@@ -131,7 +134,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/setDetectionInterval"
           }
         }
       }

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo"
           },
           "disabledReason": {
             "__compat": {
@@ -125,7 +126,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/get"
           }
         },
         "getAll": {
@@ -152,7 +154,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getAll"
           }
         },
         "getPermissionWarningsById": {
@@ -173,7 +176,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsById"
           }
         },
         "getPermissionWarningsByManifest": {
@@ -194,7 +198,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsByManifest"
           }
         },
         "getSelf": {
@@ -215,7 +220,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getSelf"
           }
         },
         "onDisabled": {
@@ -236,7 +242,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onDisabled"
           }
         },
         "onEnabled": {
@@ -257,7 +264,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onEnabled"
           }
         },
         "onInstalled": {
@@ -278,7 +286,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onInstalled"
           }
         },
         "onUninstalled": {
@@ -299,7 +308,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onUninstalled"
           }
         },
         "setEnabled": {
@@ -326,7 +336,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/setEnabled"
           }
         },
         "uninstall": {
@@ -347,7 +358,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstall"
           }
         },
         "uninstallSelf": {
@@ -368,7 +380,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf"
           },
           "dialogMessage": {
             "__compat": {

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -29,7 +29,8 @@
                 "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/ACTION_MENU_TOP_LEVEL_LIMIT"
           }
         },
         "ContextType": {
@@ -62,7 +63,8 @@
                 "alternative_name": "contextMenus.ContextType",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType"
           },
           "bookmark": {
             "__compat": {
@@ -245,7 +247,8 @@
                 "alternative_name": "contextMenus.ItemType",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/ItemType"
           }
         },
         "OnClickData": {
@@ -275,7 +278,8 @@
                 "alternative_name": "contextMenus.OnClickData",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/OnClickData"
           },
           "bookmarkId": {
             "__compat": {
@@ -403,7 +407,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/create"
           },
           "command": {
             "__compat": {
@@ -475,7 +480,8 @@
                 "alternative_name": "contextMenus.onClicked",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/onClicked"
           }
         },
         "remove": {
@@ -505,7 +511,8 @@
                 "alternative_name": "contextMenus.remove",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/remove"
           }
         },
         "removeAll": {
@@ -535,7 +542,8 @@
                 "alternative_name": "contextMenus.removeAll",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/removeAll"
           }
         },
         "update": {
@@ -565,7 +573,8 @@
                 "alternative_name": "contextMenus.update",
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/update"
           }
         }
       }

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -26,7 +26,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions"
           }
         },
         "TemplateType": {
@@ -56,7 +57,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/TemplateType"
           }
         },
         "clear": {
@@ -77,7 +79,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/clear"
           }
         },
         "create": {
@@ -98,7 +101,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create"
           }
         },
         "getAll": {
@@ -119,7 +123,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/getAll"
           }
         },
         "onButtonClicked": {
@@ -140,7 +145,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onButtonClicked"
           }
         },
         "onClicked": {
@@ -161,7 +167,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClicked"
           }
         },
         "onClosed": {
@@ -182,7 +189,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClosed"
           },
           "byUser": {
             "__compat": {
@@ -224,7 +232,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onShown"
           }
         },
         "update": {
@@ -248,7 +257,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/update"
           }
         }
       }

--- a/webextensions/api/omnibox.json
+++ b/webextensions/api/omnibox.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/OnInputEnteredDisposition"
           }
         },
         "SuggestResult": {
@@ -44,7 +45,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/SuggestResult"
           }
         },
         "onInputCancelled": {
@@ -65,7 +67,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputCancelled"
           }
         },
         "onInputChanged": {
@@ -86,7 +89,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputChanged"
           }
         },
         "onInputEntered": {
@@ -107,7 +111,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputEntered"
           }
         },
         "onInputStarted": {
@@ -128,7 +133,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputStarted"
           }
         },
         "setDefaultSuggestion": {
@@ -152,7 +158,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/setDefaultSuggestion"
           }
         }
       }

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/ImageDataType"
           }
         },
         "getPopup": {
@@ -44,7 +45,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getPopup"
           }
         },
         "getTitle": {
@@ -65,7 +67,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getTitle"
           }
         },
         "hide": {
@@ -89,7 +92,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/hide"
           }
         },
         "onClicked": {
@@ -110,7 +114,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked"
           }
         },
         "openPopup": {
@@ -131,7 +136,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/openPopup"
           }
         },
         "setIcon": {
@@ -155,7 +161,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setIcon"
           },
           "imageData": {
             "__compat": {
@@ -200,7 +207,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setPopup"
           }
         },
         "setTitle": {
@@ -221,7 +229,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setTitle"
           }
         },
         "show": {
@@ -245,7 +254,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/show"
           }
         }
       }

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/contains"
           }
         },
         "getAll": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/getAll"
           }
         },
         "onAdded": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onAdded"
           }
         },
         "onRemoved": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved"
           }
         },
         "Permissions": {
@@ -104,7 +108,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions"
           }
         },
         "remove": {
@@ -125,7 +130,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/remove"
           }
         },
         "request": {
@@ -152,7 +158,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request"
           }
         }
       }

--- a/webextensions/api/pkcs11.json
+++ b/webextensions/api/pkcs11.json
@@ -25,7 +25,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": false
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/getModuleSlots"
           }
         },
         "installModule": {
@@ -51,7 +52,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": false
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/installModule"
           }
         },
         "isModuleInstalled": {
@@ -77,7 +79,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": false
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/isModuleInstalled"
           }
         },
         "uninstallModule": {
@@ -103,7 +106,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": false
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/uninstallModule"
           }
         }
       }

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onProxyError"
           }
         },
         "register": {
@@ -47,7 +48,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/register"
           }
         },
         "unregister": {
@@ -68,7 +70,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/unregister"
           }
         }
       }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -26,7 +26,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender"
           },
           "url": {
             "__compat": {
@@ -122,7 +123,8 @@
                   "Uses 'chrome_update' instead of 'browser_update'."
                 ]
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason"
           }
         },
         "OnRestartRequiredReason": {
@@ -143,7 +145,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnRestartRequiredReason"
           }
         },
         "PlatformArch": {
@@ -164,7 +167,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch"
           }
         },
         "PlatformInfo": {
@@ -185,7 +189,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformInfo"
           },
           "nacl_arch": {
             "__compat": {
@@ -227,7 +232,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformNaclArch"
           }
         },
         "PlatformOs": {
@@ -248,7 +254,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformOs"
           }
         },
         "Port": {
@@ -269,7 +276,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port"
           },
           "error": {
             "__compat": {
@@ -311,7 +319,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/RequestUpdateCheckStatus"
           }
         },
         "connect": {
@@ -332,7 +341,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connect"
           }
         },
         "connectNative": {
@@ -353,7 +363,8 @@
               "opera": {
                 "version_added": "16"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connectNative"
           }
         },
         "getBackgroundPage": {
@@ -380,7 +391,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getBackgroundPage"
           }
         },
         "getBrowserInfo": {
@@ -401,7 +413,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getBrowserInfo"
           }
         },
         "getManifest": {
@@ -422,7 +435,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getManifest"
           }
         },
         "getPackageDirectoryEntry": {
@@ -443,7 +457,8 @@
               "opera": {
                 "version_added": "16"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getPackageDirectoryEntry"
           }
         },
         "getPlatformInfo": {
@@ -464,7 +479,8 @@
               "opera": {
                 "version_added": "16"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getPlatformInfo"
           }
         },
         "getURL": {
@@ -485,7 +501,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL"
           }
         },
         "id": {
@@ -506,7 +523,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/id"
           }
         },
         "lastError": {
@@ -533,7 +551,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError"
           }
         },
         "onBrowserUpdateAvailable": {
@@ -559,7 +578,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onBrowserUpdateAvailable"
           }
         },
         "onConnect": {
@@ -580,7 +600,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnect"
           }
         },
         "onConnectExternal": {
@@ -601,7 +622,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnectExternal"
           }
         },
         "onInstalled": {
@@ -628,7 +650,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled"
           },
           "details": {
             "id": {
@@ -735,7 +758,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage"
           }
         },
         "onMessageExternal": {
@@ -756,7 +780,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal"
           }
         },
         "onRestartRequired": {
@@ -777,7 +802,8 @@
               "opera": {
                 "version_added": "16"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onRestartRequired"
           }
         },
         "onStartup": {
@@ -798,7 +824,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onStartup"
           }
         },
         "onSuspend": {
@@ -819,7 +846,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onSuspend"
           }
         },
         "onSuspendCanceled": {
@@ -840,7 +868,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onSuspendCanceled"
           }
         },
         "onUpdateAvailable": {
@@ -861,7 +890,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onUpdateAvailable"
           }
         },
         "openOptionsPage": {
@@ -882,7 +912,8 @@
               "opera": {
                 "version_added": "29"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage"
           }
         },
         "reload": {
@@ -903,7 +934,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/reload"
           }
         },
         "requestUpdateCheck": {
@@ -924,7 +956,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/requestUpdateCheck"
           }
         },
         "sendMessage": {
@@ -948,7 +981,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage"
           },
           "options": {
             "includeTlsChannelId": {
@@ -1013,7 +1047,8 @@
               "opera": {
                 "version_added": "16"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage"
           }
         },
         "setUninstallURL": {
@@ -1034,7 +1069,8 @@
               "opera": {
                 "version_added": "28"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/setUninstallURL"
           }
         }
       }

--- a/webextensions/api/sessions.json
+++ b/webextensions/api/sessions.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/Filter"
           }
         },
         "MAX_SESSION_RESULTS": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/MAX_SESSION_RESULTS"
           }
         },
         "Session": {
@@ -65,7 +67,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/Session"
           }
         },
         "forgetClosedTab": {
@@ -86,7 +89,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedTab"
           }
         },
         "forgetClosedWindow": {
@@ -107,7 +111,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedWindow"
           }
         },
         "getRecentlyClosed": {
@@ -128,7 +133,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/getRecentlyClosed"
           }
         },
         "getTabValue": {
@@ -149,7 +155,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/getTabValue"
           }
         },
         "getWindowValue": {
@@ -170,7 +177,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/getWindowValue"
           }
         },
         "onChanged": {
@@ -191,7 +199,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/onChanged"
           }
         },
         "removeTabValue": {
@@ -212,7 +221,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/removeTabValue"
           }
         },
         "removeWindowValue": {
@@ -233,7 +243,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/removeWindowValue"
           }
         },
         "restore": {
@@ -254,7 +265,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/restore"
           }
         },
         "setTabValue": {
@@ -275,7 +287,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/setTabValue"
           }
         },
         "setWindowValue": {
@@ -296,7 +309,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/setWindowValue"
           }
         }
       }

--- a/webextensions/api/sidebarAction.json
+++ b/webextensions/api/sidebarAction.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/ImageDataType"
           }
         },
         "close": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/close"
           }
         },
         "getPanel": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/getPanel"
           }
         },
         "getTitle": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/getTitle"
           }
         },
         "open": {
@@ -104,7 +108,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/open"
           }
         },
         "setIcon": {
@@ -125,7 +130,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/setIcon"
           }
         },
         "setPanel": {
@@ -146,7 +152,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/setPanel"
           }
         },
         "setTitle": {
@@ -167,7 +174,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/setTitle"
           }
         }
       }

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea"
           },
           "clear": {
             "__compat": {
@@ -40,7 +41,8 @@
                 "opera": {
                   "version_added": "33"
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear"
             }
           },
           "get": {
@@ -61,7 +63,8 @@
                 "opera": {
                   "version_added": "33"
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get"
             }
           },
           "getBytesInUse": {
@@ -82,7 +85,8 @@
                 "opera": {
                   "version_added": "33"
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse"
             }
           },
           "remove": {
@@ -103,7 +107,8 @@
                 "opera": {
                   "version_added": "33"
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove"
             }
           },
           "set": {
@@ -127,7 +132,8 @@
                 "opera": {
                   "version_added": "33"
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set"
             }
           }
         },
@@ -149,7 +155,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageChange"
           }
         },
         "local": {
@@ -173,7 +180,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/local"
           }
         },
         "managed": {
@@ -199,7 +207,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed"
           }
         },
         "onChanged": {
@@ -220,7 +229,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged"
           }
         },
         "sync": {
@@ -241,7 +251,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync"
           }
         }
       }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo"
           }
         },
         "MutedInfoReason": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfoReason"
           }
         },
         "PageSettings": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/PageSettings"
           }
         },
         "TAB_ID_NONE": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/TAB_ID_NONE"
           }
         },
         "Tab": {
@@ -616,7 +620,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/TabStatus"
           }
         },
         "WindowType": {
@@ -637,7 +642,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/WindowType"
           }
         },
         "ZoomSettings": {
@@ -658,7 +664,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettings"
           }
         },
         "ZoomSettingsMode": {
@@ -679,7 +686,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsMode"
           }
         },
         "ZoomSettingsScope": {
@@ -700,7 +708,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsScope"
           }
         },
         "captureVisibleTab": {
@@ -727,7 +736,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab"
           }
         },
         "connect": {
@@ -748,7 +758,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/connect"
           },
           "connectInfo": {
             "frameId": {
@@ -792,7 +803,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create"
           },
           "createProperties": {
             "active": {
@@ -1018,7 +1030,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage"
           }
         },
         "duplicate": {
@@ -1039,7 +1052,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate"
           }
         },
         "executeScript": {
@@ -1063,7 +1077,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript"
           },
           "runAt": {
             "__compat": {
@@ -1153,7 +1168,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/get"
           }
         },
         "getAllInWindow": {
@@ -1179,7 +1195,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getAllInWindow"
           }
         },
         "getCurrent": {
@@ -1200,7 +1217,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent"
           }
         },
         "getSelected": {
@@ -1226,7 +1244,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getSelected"
           }
         },
         "getZoom": {
@@ -1247,7 +1266,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom"
           }
         },
         "getZoomSettings": {
@@ -1268,7 +1288,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoomSettings"
           }
         },
         "highlight": {
@@ -1289,7 +1310,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/highlight"
           }
         },
         "insertCSS": {
@@ -1310,7 +1332,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS"
           },
           "runAt": {
             "__compat": {
@@ -1415,7 +1438,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/move"
           }
         },
         "onActivated": {
@@ -1436,7 +1460,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActivated"
           }
         },
         "onActiveChanged": {
@@ -1462,7 +1487,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActiveChanged"
           }
         },
         "onAttached": {
@@ -1483,7 +1509,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onAttached"
           }
         },
         "onCreated": {
@@ -1504,7 +1531,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onCreated"
           }
         },
         "onDetached": {
@@ -1525,7 +1553,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onDetached"
           }
         },
         "onHighlightChanged": {
@@ -1551,7 +1580,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlightChanged"
           }
         },
         "onHighlighted": {
@@ -1572,7 +1602,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted"
           }
         },
         "onMoved": {
@@ -1593,7 +1624,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onMoved"
           }
         },
         "onRemoved": {
@@ -1614,7 +1646,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved"
           }
         },
         "onReplaced": {
@@ -1635,7 +1668,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onReplaced"
           }
         },
         "onSelectionChanged": {
@@ -1661,7 +1695,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onSelectionChanged"
           }
         },
         "onUpdated": {
@@ -1682,7 +1717,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated"
           },
           "changeInfo": {
             "audible": {
@@ -1873,7 +1909,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onZoomChange"
           }
         },
         "print": {
@@ -1894,7 +1931,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/print"
           }
         },
         "printPreview": {
@@ -1915,7 +1953,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/printPreview"
           }
         },
         "query": {
@@ -1939,7 +1978,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query"
           },
           "queryInfo": {
             "active": {
@@ -2327,7 +2367,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/reload"
           }
         },
         "remove": {
@@ -2348,7 +2389,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/remove"
           }
         },
         "removeCSS": {
@@ -2369,7 +2411,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS"
           }
         },
         "saveAsPDF": {
@@ -2393,7 +2436,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/saveAsPDF"
           }
         },
         "sendMessage": {
@@ -2417,7 +2461,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage"
           },
           "options": {
             "frameId": {
@@ -2466,7 +2511,8 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendRequest"
           }
         },
         "setZoom": {
@@ -2487,7 +2533,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom"
           }
         },
         "setZoomSettings": {
@@ -2508,7 +2555,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoomSettings"
           }
         },
         "toggleReaderMode": {
@@ -2529,7 +2577,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode"
           }
         },
         "update": {
@@ -2550,7 +2599,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update"
           },
           "updateProperties": {
             "active": {

--- a/webextensions/api/theme.json
+++ b/webextensions/api/theme.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/Theme"
           }
         },
         "getCurrent": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/getCurrent"
           }
         },
         "onUpdated": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/onUpdated"
           }
         },
         "reset": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/reset"
           },
           "windowId": {
             "__compat": {
@@ -125,7 +129,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/update"
           },
           "windowId": {
             "__compat": {

--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/topSites/MostVisitedURL"
           }
         },
         "get": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/topSites/get"
           }
         }
       }

--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting"
           },
           "onChange": {
             "__compat": {
@@ -40,7 +41,8 @@
                 "opera": {
                   "version_added": true
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange"
             }
           }
         }

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -26,7 +26,8 @@
               "opera": {
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionQualifier"
           },
           "from_address_bar": {
             "__compat": {
@@ -74,7 +75,8 @@
               "opera": {
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionType"
           }
         },
         "getAllFrames": {
@@ -95,7 +97,8 @@
               "opera": {
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames"
           }
         },
         "getFrame": {
@@ -116,7 +119,8 @@
               "opera": {
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame"
           }
         },
         "onBeforeNavigate": {
@@ -154,7 +158,8 @@
                 ],
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate"
           }
         },
         "onCommitted": {
@@ -192,7 +197,8 @@
                 ],
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted"
           },
           "transitionQualifiers": {
             "__compat": {
@@ -272,7 +278,8 @@
                 ],
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted"
           }
         },
         "onCreatedNavigationTarget": {
@@ -308,7 +315,8 @@
                 ],
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCreatedNavigationTarget"
           },
           "sourceProcessId": {
             "__compat": {
@@ -388,7 +396,8 @@
                 ],
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded"
           }
         },
         "onErrorOccurred": {
@@ -426,7 +435,8 @@
                 ],
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred"
           },
           "error": {
             "__compat": {
@@ -471,7 +481,8 @@
               "opera": {
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onHistoryStateUpdated"
           },
           "transitionQualifiers": {
             "__compat": {
@@ -551,7 +562,8 @@
                 ],
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onReferenceFragmentUpdated"
           },
           "transitionQualifiers": {
             "__compat": {
@@ -620,7 +632,8 @@
               "opera": {
                 "version_added": "17"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onTabReplaced"
           }
         }
       }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -20,7 +20,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse"
           }
         },
         "HttpHeaders": {
@@ -41,7 +42,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/HttpHeaders"
           }
         },
         "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
@@ -62,7 +64,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES"
           }
         },
         "RequestFilter": {
@@ -83,7 +86,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter"
           },
           "urls": {
             "__compat": {
@@ -173,7 +177,8 @@
               "opera": {
                 "version_added": "31"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType"
           },
           "ping": {
             "__compat": {
@@ -458,7 +463,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter"
           },
           "close": {
             "__compat": {
@@ -478,7 +484,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/close"
             }
           },
           "disconnect": {
@@ -499,7 +506,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/disconnect"
             }
           },
           "error": {
@@ -520,7 +528,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/error"
             }
           },
           "ondata": {
@@ -541,7 +550,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/ondata"
             }
           },
           "onerror": {
@@ -562,7 +572,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onerror"
             }
           },
           "onstart": {
@@ -583,7 +594,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstart"
             }
           },
           "onstop": {
@@ -604,7 +616,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstop"
             }
           },
           "resume": {
@@ -625,7 +638,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/resume"
             }
           },
           "status": {
@@ -646,7 +660,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/status"
             }
           },
           "suspend": {
@@ -667,7 +682,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/suspend"
             }
           },
           "write": {
@@ -688,7 +704,8 @@
                 "opera": {
                   "version_added": false
                 }
-              }
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/write"
             }
           }
         },
@@ -710,7 +727,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/UploadData"
           }
         },
         "filterResponseData": {
@@ -731,7 +749,8 @@
               "opera": {
                 "version_added": false
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/filterResponseData"
           }
         },
         "handlerBehaviorChanged": {
@@ -752,7 +771,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/handlerBehaviorChanged"
           }
         },
         "onAuthRequired": {
@@ -779,7 +799,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired"
           },
           "asyncBlocking": {
             "__compat": {
@@ -1144,7 +1165,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRedirect"
           },
           "details": {
             "frameId": {
@@ -1518,7 +1540,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest"
           },
           "details": {
             "frameAncestors": {
@@ -1808,7 +1831,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders"
           },
           "details": {
             "frameId": {
@@ -2062,7 +2086,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onCompleted"
           },
           "details": {
             "frameId": {
@@ -2400,7 +2425,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onErrorOccurred"
           },
           "details": {
             "error": {
@@ -2713,7 +2739,8 @@
                 ],
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived"
           },
           "details": {
             "frameId": {
@@ -3009,7 +3036,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted"
           },
           "details": {
             "frameId": {
@@ -3347,7 +3375,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onSendHeaders"
           },
           "details": {
             "frameId": {

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -29,7 +29,8 @@
                   "`detached_panel` is not supported."
                 ]
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/CreateType"
           }
         },
         "WINDOW_ID_CURRENT": {
@@ -50,7 +51,8 @@
               "opera": {
                 "version_added": "15"
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT"
           }
         },
         "WINDOW_ID_NONE": {
@@ -71,7 +73,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_NONE"
           }
         },
         "Window": {
@@ -92,7 +95,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window"
           },
           "alwaysOnTop": {
             "__compat": {
@@ -387,7 +391,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WindowState"
           },
           "minimized": {
             "__compat": {
@@ -497,7 +502,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WindowType"
           },
           "panel": {
             "__compat": {
@@ -585,7 +591,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/create"
           },
           "createData": {
             "allowScriptsToClose": {
@@ -863,7 +870,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get"
           },
           "getInfo": {
             "__compat": {
@@ -926,7 +934,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getAll"
           },
           "populate": {
             "__compat": {
@@ -989,7 +998,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent"
           },
           "getInfo": {
             "__compat": {
@@ -1052,7 +1062,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused"
           },
           "getInfo": {
             "__compat": {
@@ -1115,7 +1126,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onCreated"
           }
         },
         "onFocusChanged": {
@@ -1136,7 +1148,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged"
           }
         },
         "onRemoved": {
@@ -1157,7 +1170,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onRemoved"
           }
         },
         "remove": {
@@ -1178,7 +1192,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/remove"
           }
         },
         "update": {
@@ -1199,7 +1214,8 @@
               "opera": {
                 "version_added": true
               }
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/update"
           },
           "drawAttention": {
             "__compat": {


### PR DESCRIPTION
We had planned to do this once the WebExtension docs get moved to Browser/Extensions or wherever. But I decided that since it will take a while to move these docs, and it's pretty easy to change URLs once they are in the data, we might as well try to get `mdn_url` in now.

This PR should add `mdn_url` for every feature under `webextensions.api` that actually has a corresponding page on MDN.
