### PR TITLE
textarea@autocomplete was added to Firefox in version 59

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -130,11 +130,11 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": false,
+                "version_added": "59",
                 "notes": "See <a href='https://bugzil.la/1020698'>bug 1020698</a>."
               },
               "firefox_android": {
-                "version_added": false,
+                "version_added": "59",
                 "notes": "See <a href='https://bugzil.la/1020698'>bug 1020698</a>."
               },
               "ie": {


### PR DESCRIPTION
See https://bugzil.la/1020698 and https://groups.google.com/d/topic/mozilla.dev.platform/NmPczVPmmDw/discussion