### PR TITLE
Fix inconsistency in at-rule naming

### DIFF
--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "at-rules": {
-      "@counter-style": {
+      "counter-style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style",
           "support": {


### PR DESCRIPTION
This is a follow-up PR to the apparently incomplete #629. This should fix issue #674.