### PR TITLE
Add compat data for text-rendering and text-shadow CSS properties

### DIFF
--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -1,0 +1,173 @@
+{
+  "css": {
+    "properties": {
+      "text-rendering": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-rendering",
+          "support": {
+            "webview_android": {
+              "version_added": "3",
+              "notes": "From version 3 to 4.3, there is a serious bug where <code>text-rendering: optimizeLegibility</code> causes custom web fonts to not render. This was fixed in version 4.4."
+            },
+            "chrome": {
+              "version_added": "4",
+              "notes": [
+                "This property is only supported on Windows and Linux.",
+                "Initial versions had bugs on Windows and Linux that broke <a href='http://crbug.com/114719'>font substitition</a>, <a href='http://crbug.com/51973'>small-caps</a>, <a href='http://crbug.com/55458'>letter-spacing</a> or caused <a href='http://crbug.com/149548'>text to overlap</a>."
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "3",
+              "notes": [
+                "This property is only supported on Windows and Linux.",
+                "The <code>optimizeSpeed</code> option has no effect on Firefox 4 because the standard code for text rendering is already fast and there is not a faster code path at this time. See <a href='https://bugzil.la/595688'>bug 595688</a> for details."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "46"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "36"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "4.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true,
+                "notes": "Chrome treats <code>auto</code> as <code>optimizeSpeed</code>."
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true,
+                "notes": "If the font size is 20 pixels or higher, Firefox treats <code>auto</code> as <code>optimizeLegibility</code>. For smaller text, Firefox treats <code>auto</code> as <code>optimizeSpeed</code>. The 20-pixel threshold can be changed with the <code>browser.display.auto_quality_min_font_size</code> preference."
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true,
+                "notes": "Safari treats <code>auto</code> as <code>optimizeSpeed</code>. See <a href='https://bugs.webkit.org/show_bug.cgi?id=41363'>WebKit bug 41363</a>."
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "geometricPrecision": {
+          "__compat": {
+            "description": "<code>geometricPrecision</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "13",
+                "notes": "Supports true geometric precision without rounding up or down to the nearest supported font size in the operating system."
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true,
+                "notes": "Firefox treats <code>geometricPrecision</code> the same as <code>optimizeLegibility</code>."
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-shadow.json
+++ b/css/properties/text-shadow.json
@@ -1,0 +1,71 @@
+{
+  "css": {
+    "properties": {
+      "text-shadow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-shadow",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5",
+              "notes": [
+                "Firefox versions before 57 have a bug whereby <a href='https://developer.mozilla.org/docs/Web/CSS/transition'><code>transition</code></a>s will not work when transitioning from a <code>text-shadow</code> with a color specified to a <code>text-shadow</code> without a color specified (<a href='https://bugzil.la/726550'>bug 726550</a>).",
+                "From Firefox 4, the blur radius is capped at 300 for performance reasons.",
+                "Firefox theoretically supports infinite text-shadows (don't try it).",
+                "If the <code>&lt;color&gt;</code> value is unspecified, then Firefox uses the value of the element's <a href='https://developer.mozilla.org/docs/Web/CSS/color'><code>color</code></a> property."
+              ]
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "9.5",
+              "notes": [
+                "Opera supports a maximum of 6-9 text-shadows for performance reasons. The blur radius is limited to 100px.",
+                "Opera 9.5 to 10.1 adheres to the old, reverse painting order (in CSS2, the first specified shadow is on the bottom)."
+              ]
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1.1",
+              "notes": [
+                "In Safari, any shadows that do not explicitly specify a color are transparent.",
+                "Safari 1.1 to 3.2 only supports one text-shadow (displays the first shadow of a comma-separated list and ignores the rest). Safari 4.0 (WebKit 528) and later support multiple text-shadows."
+              ]
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds compat data for the properties [`text-rendering`](https://developer.mozilla.org/docs/Web/CSS/text-rendering) and [`text-shadow`](https://developer.mozilla.org/docs/Web/CSS/text-shadow), both with a bunch of somewhat complicated notes. Let me know if you want to see any changes. Thanks!