### PR TITLE
TypedArray.toString

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -2144,7 +2144,7 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": true
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": true


### PR DESCRIPTION
IE11 just outputs "[object Uint8Array]" instead of the described behaviour