### PR TITLE
Add compat data for the <transform-function> CSS type

### DIFF
--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -4,7 +4,7 @@
       "transform-function": {
         "__compat": {
           "description": "<code>&lt;transform-function&gt;</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/REPLACENAME",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function",
           "support": {
             "webview_android": {
               "version_added": "2.1"

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -1,0 +1,114 @@
+{
+  "css": {
+    "types": {
+      "transform-function": {
+        "__compat": {
+          "description": "<code>&lt;transform-function&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/REPLACENAME",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "3.5",
+              "notes": [
+                "Firefox 14 removed experiment support for <a href='https://developer.mozilla.org/docs/Web/CSS/transform-function/skew'><code>skew()</code></a>, but it was reintroduced in Firefox 15.",
+                "Before Firefox 16, the translation values of <code>matrix()</code> and <code>matrix3d()</code> could be <a href='https://developer.mozilla.org/docs/Web/CSS/length'><code>&lt;length&gt;</code></a>s, in addition to the standard <a href='https://developer.mozilla.org/docs/Web/CSS/number'><code>&lt;number&gt;</code></a>."
+              ]
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9",
+              "notes": "Internet Explorer 9 supports 2D but not 3D transforms. In version 9, mixing 2D and 3D transform functions invalidates the entire property."
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "11.5"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "3d": {
+          "__compat": {
+            "description": "3D support",
+            "support": {
+              "webview_android": {
+                "version_added": "3"
+              },
+              "chrome": {
+                "version_added": "12"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "10"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "22"
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": "3.2"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -24,7 +24,7 @@
             "firefox": {
               "version_added": "3.5",
               "notes": [
-                "Firefox 14 removed experiment support for <a href='https://developer.mozilla.org/docs/Web/CSS/transform-function/skew'><code>skew()</code></a>, but it was reintroduced in Firefox 15.",
+                "Firefox 14 removed experimental support for <a href='https://developer.mozilla.org/docs/Web/CSS/transform-function/skew'><code>skew()</code></a>, but it was reintroduced in Firefox 15.",
                 "Before Firefox 16, the translation values of <code>matrix()</code> and <code>matrix3d()</code> could be <a href='https://developer.mozilla.org/docs/Web/CSS/length'><code>&lt;length&gt;</code></a>s, in addition to the standard <a href='https://developer.mozilla.org/docs/Web/CSS/number'><code>&lt;number&gt;</code></a>."
               ]
             },


### PR DESCRIPTION
This PR migrates the compat data for the [`<transform-function>`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function) type (which captures `perspective()`, `skew()`, and other functions used with the `transform` property). Let me know if you want to see any changes!