### PR TITLE
Added mdn_url to APIs

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -4,6 +4,7 @@
       "alarms": {
         "Alarm": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/Alarm",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "clear": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "clearAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -67,6 +70,7 @@
         },
         "create": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/create",
             "support": {
               "chrome": {
                 "version_added": true
@@ -88,6 +92,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/get",
             "support": {
               "chrome": {
                 "version_added": true
@@ -109,6 +114,7 @@
         },
         "getAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -130,6 +136,7 @@
         },
         "onAlarm": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/bookmarks.json
+++ b/webextensions/api/bookmarks.json
@@ -4,6 +4,7 @@
       "bookmarks": {
         "BookmarkTreeNode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +47,7 @@
         },
         "BookmarkTreeNodeType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType",
             "support": {
               "chrome": {
                 "version_added": false
@@ -67,6 +69,7 @@
         },
         "BookmarkTreeNodeUnmodifiable": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeUnmodifiable",
             "support": {
               "chrome": {
                 "version_added": true
@@ -88,6 +91,7 @@
         },
         "CreateDetails": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/CreateDetails",
             "support": {
               "chrome": {
                 "version_added": true
@@ -130,6 +134,7 @@
         },
         "create": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/create",
             "support": {
               "chrome": {
                 "version_added": true
@@ -151,6 +156,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/get",
             "support": {
               "chrome": {
                 "version_added": true
@@ -172,6 +178,7 @@
         },
         "getChildren": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getChildren",
             "support": {
               "chrome": {
                 "version_added": true
@@ -193,6 +200,7 @@
         },
         "getRecent": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getRecent",
             "support": {
               "chrome": {
                 "version_added": true
@@ -214,6 +222,7 @@
         },
         "getSubTree": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getSubTree",
             "support": {
               "chrome": {
                 "version_added": true
@@ -235,6 +244,7 @@
         },
         "getTree": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getTree",
             "support": {
               "chrome": {
                 "version_added": true
@@ -256,6 +266,7 @@
         },
         "move": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/move",
             "support": {
               "chrome": {
                 "version_added": true
@@ -277,6 +288,7 @@
         },
         "onChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -298,6 +310,7 @@
         },
         "onChildrenReordered": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onChildrenReordered",
             "support": {
               "chrome": {
                 "version_added": true
@@ -319,6 +332,7 @@
         },
         "onCreated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onCreated",
             "support": {
               "chrome": {
                 "version_added": true
@@ -340,6 +354,7 @@
         },
         "onImportBegan": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportBegan",
             "support": {
               "chrome": {
                 "version_added": true
@@ -361,6 +376,7 @@
         },
         "onImportEnded": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportEnded",
             "support": {
               "chrome": {
                 "version_added": true
@@ -382,6 +398,7 @@
         },
         "onMoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onMoved",
             "support": {
               "chrome": {
                 "version_added": true
@@ -403,6 +420,7 @@
         },
         "onRemoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onRemoved",
             "support": {
               "chrome": {
                 "version_added": true
@@ -424,6 +442,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/remove",
             "support": {
               "chrome": {
                 "version_added": true
@@ -445,6 +464,7 @@
         },
         "removeTree": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/removeTree",
             "support": {
               "chrome": {
                 "version_added": true
@@ -466,6 +486,7 @@
         },
         "search": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/search",
             "support": {
               "chrome": {
                 "version_added": true
@@ -487,6 +508,7 @@
         },
         "update": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/update",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -4,6 +4,7 @@
       "browserAction": {
         "ColorArray": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "ImageDataType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ImageDataType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "disable": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/disable",
             "support": {
               "chrome": {
                 "version_added": true
@@ -67,6 +70,7 @@
         },
         "enable": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/enable",
             "support": {
               "chrome": {
                 "version_added": true
@@ -88,6 +92,7 @@
         },
         "getBadgeBackgroundColor": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeBackgroundColor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -109,6 +114,7 @@
         },
         "getBadgeText": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeText",
             "support": {
               "chrome": {
                 "version_added": true
@@ -130,6 +136,7 @@
         },
         "getPopup": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup",
             "support": {
               "chrome": {
                 "version_added": true
@@ -151,6 +158,7 @@
         },
         "getTitle": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getTitle",
             "support": {
               "chrome": {
                 "version_added": true
@@ -172,6 +180,7 @@
         },
         "onClicked": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked",
             "support": {
               "chrome": {
                 "version_added": true
@@ -193,6 +202,7 @@
         },
         "openPopup": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup",
             "support": {
               "chrome": {
                 "version_added": false
@@ -214,6 +224,7 @@
         },
         "setBadgeBackgroundColor": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -235,6 +246,7 @@
         },
         "setBadgeText": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeText",
             "support": {
               "chrome": {
                 "version_added": true
@@ -259,6 +271,7 @@
         },
         "setIcon": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon",
             "support": {
               "chrome": {
                 "version_added": true,
@@ -304,6 +317,7 @@
         },
         "setPopup": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup",
             "support": {
               "chrome": {
                 "version_added": true
@@ -325,6 +339,7 @@
         },
         "setTitle": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setTitle",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -4,6 +4,7 @@
       "browserSettings": {
         "allowPopupsForUserEvents": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/allowPopupsForUserEvents",
             "support": {
               "chrome": {
                 "version_added": false
@@ -25,6 +26,7 @@
         },
         "cacheEnabled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/cacheEnabled",
             "support": {
               "chrome": {
                 "version_added": false
@@ -46,6 +48,7 @@
         },
         "homepageOverride": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/homepageOverride",
             "support": {
               "chrome": {
                 "version_added": false
@@ -67,6 +70,7 @@
         },
         "imageAnimationBehavior": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/imageAnimationBehavior",
             "support": {
               "chrome": {
                 "version_added": false
@@ -88,6 +92,7 @@
         },
         "newTabPageOverride": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPageOverride",
             "support": {
               "chrome": {
                 "version_added": false
@@ -109,6 +114,7 @@
         },
         "webNotificationsDisabled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -371,6 +371,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove",
             "support": {
               "chrome": {
                 "version_added": true
@@ -398,6 +399,7 @@
         },
         "removeCache": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache",
             "support": {
               "chrome": {
                 "version_added": true
@@ -425,6 +427,7 @@
         },
         "removeCookies": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeCookies",
             "support": {
               "chrome": {
                 "version_added": true
@@ -446,6 +449,7 @@
         },
         "removeDownloads": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeDownloads",
             "support": {
               "chrome": {
                 "version_added": true
@@ -467,6 +471,7 @@
         },
         "removeFormData": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeFormData",
             "support": {
               "chrome": {
                 "version_added": true
@@ -488,6 +493,7 @@
         },
         "removeHistory": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeHistory",
             "support": {
               "chrome": {
                 "version_added": true
@@ -512,6 +518,7 @@
         },
         "removeLocalStorage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeLocalStorage",
             "support": {
               "chrome": {
                 "version_added": true
@@ -562,6 +569,7 @@
         },
         "removePasswords": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removePasswords",
             "support": {
               "chrome": {
                 "version_added": true
@@ -583,6 +591,7 @@
         },
         "removePluginData": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removePluginData",
             "support": {
               "chrome": {
                 "version_added": true
@@ -604,6 +613,7 @@
         },
         "settings": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/settings",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/clipboard.json
+++ b/webextensions/api/clipboard.json
@@ -4,6 +4,7 @@
       "clipboard": {
         "setImageData": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -4,6 +4,7 @@
       "commands": {
         "Command": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/Command",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "getAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/getAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "onCommand": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onCommand",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -132,6 +132,7 @@
         },
         "create": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/create",
             "support": {
               "chrome": {
                 "version_added": false
@@ -159,6 +160,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/get",
             "support": {
               "chrome": {
                 "version_added": false
@@ -188,6 +190,7 @@
         },
         "onCreated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onCreated",
             "support": {
               "chrome": {
                 "version_added": false
@@ -209,6 +212,7 @@
         },
         "onRemoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onRemoved",
             "support": {
               "chrome": {
                 "version_added": false
@@ -230,6 +234,7 @@
         },
         "onUpdated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onUpdated",
             "support": {
               "chrome": {
                 "version_added": false
@@ -251,6 +256,7 @@
         },
         "query": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/query",
             "support": {
               "chrome": {
                 "version_added": false
@@ -278,6 +284,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/remove",
             "support": {
               "chrome": {
                 "version_added": false
@@ -307,6 +314,7 @@
         },
         "update": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/update",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -4,6 +4,7 @@
       "cookies": {
         "Cookie": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "CookieStore": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "OnChangedCause": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/OnChangedCause",
             "support": {
               "chrome": {
                 "version_added": true
@@ -67,6 +70,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/get",
             "support": {
               "chrome": {
                 "version_added": true
@@ -91,6 +95,7 @@
         },
         "getAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -118,6 +123,7 @@
         },
         "getAllCookieStores": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAllCookieStores",
             "support": {
               "chrome": {
                 "version_added": true
@@ -145,6 +151,7 @@
         },
         "onChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/onChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -166,6 +173,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/remove",
             "support": {
               "chrome": {
                 "version_added": true
@@ -193,6 +201,7 @@
         },
         "set": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -5,6 +5,7 @@
         "inspectedWindow": {
           "eval": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/eval",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -89,6 +90,7 @@
           },
           "reload": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/reload",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -110,6 +112,7 @@
           },
           "tabId": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/tabId",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -133,6 +136,7 @@
         "network": {
           "onNavigated": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/onNavigated",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -157,6 +161,7 @@
           "ElementsPanel": {
             "createSidebarPane": {
               "__compat": {
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel/createSidebarPane",
                 "support": {
                   "chrome": {
                     "version_added": true
@@ -178,6 +183,7 @@
             },
             "onSelectionChanged": {
               "__compat": {
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel/onSelectionChanged",
                 "support": {
                   "chrome": {
                     "version_added": true
@@ -266,6 +272,7 @@
           "ExtensionSidebarPane": {
             "onHidden": {
               "__compat": {
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/onHidden",
                 "support": {
                   "chrome": {
                     "version_added": true
@@ -290,6 +297,7 @@
             },
             "onShown": {
               "__compat": {
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/onShown",
                 "support": {
                   "chrome": {
                     "version_added": true
@@ -314,6 +322,7 @@
             },
             "setExpression": {
               "__compat": {
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/setExpression",
                 "support": {
                   "chrome": {
                     "notes": [
@@ -341,6 +350,7 @@
             },
             "setObject": {
               "__compat": {
+                "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/setObject",
                 "support": {
                   "chrome": {
                     "notes": [
@@ -369,6 +379,7 @@
           },
           "create": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/create",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -390,6 +401,7 @@
           },
           "elements": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/elements",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -411,6 +423,7 @@
           },
           "onThemeChanged": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/onThemeChanged",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -432,6 +445,7 @@
           },
           "themeName": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/themeName",
               "support": {
                 "chrome": {
                   "version_added": "54"

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -4,6 +4,7 @@
       "downloads": {
         "BooleanDelta": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/BooleanDelta",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "DangerType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DangerType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "DoubleDelta": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DoubleDelta",
             "support": {
               "chrome": {
                 "version_added": true
@@ -495,6 +498,7 @@
         },
         "DownloadQuery": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DownloadQuery",
             "support": {
               "chrome": {
                 "version_added": true
@@ -516,6 +520,7 @@
         },
         "DownloadTime": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DownloadTime",
             "support": {
               "chrome": {
                 "version_added": true
@@ -537,6 +542,7 @@
         },
         "FilenameConflictAction": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/FilenameConflictAction",
             "support": {
               "chrome": {
                 "version_added": true
@@ -579,6 +585,7 @@
         },
         "InterruptReason": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/InterruptReason",
             "support": {
               "chrome": {
                 "version_added": true
@@ -600,6 +607,7 @@
         },
         "State": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/State",
             "support": {
               "chrome": {
                 "version_added": true
@@ -621,6 +629,7 @@
         },
         "StringDelta": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/StringDelta",
             "support": {
               "chrome": {
                 "version_added": true
@@ -642,6 +651,7 @@
         },
         "acceptDanger": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/acceptDanger",
             "support": {
               "chrome": {
                 "version_added": true
@@ -663,6 +673,7 @@
         },
         "cancel": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/cancel",
             "support": {
               "chrome": {
                 "version_added": true
@@ -684,6 +695,7 @@
         },
         "download": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/download",
             "support": {
               "chrome": {
                 "version_added": true
@@ -864,6 +876,7 @@
         },
         "drag": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/drag",
             "support": {
               "chrome": {
                 "version_added": true
@@ -885,6 +898,7 @@
         },
         "erase": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/erase",
             "support": {
               "chrome": {
                 "version_added": true
@@ -906,6 +920,7 @@
         },
         "getFileIcon": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/getFileIcon",
             "support": {
               "chrome": {
                 "version_added": true
@@ -927,6 +942,7 @@
         },
         "onChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -948,6 +964,7 @@
         },
         "onCreated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onCreated",
             "support": {
               "chrome": {
                 "version_added": true
@@ -969,6 +986,7 @@
         },
         "onErased": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onErased",
             "support": {
               "chrome": {
                 "version_added": true
@@ -990,6 +1008,7 @@
         },
         "open": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/open",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1011,6 +1030,7 @@
         },
         "pause": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/pause",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1032,6 +1052,7 @@
         },
         "removeFile": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/removeFile",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1053,6 +1074,7 @@
         },
         "resume": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/resume",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1074,6 +1096,7 @@
         },
         "search": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/search",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1095,6 +1118,7 @@
         },
         "setShelfEnabled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/setShelfEnabled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1116,6 +1140,7 @@
         },
         "show": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/show",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1137,6 +1162,7 @@
         },
         "showDefaultFolder": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/showDefaultFolder",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -4,6 +4,7 @@
       "events": {
         "Event": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "Rule": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Rule",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "UrlFilter": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/UrlFilter",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -4,6 +4,7 @@
       "extension": {
         "ViewType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/ViewType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "getBackgroundPage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,12 @@
         },
         "getExtensionTabs": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getExtensionTabs",
             "support": {
               "chrome": {
                 "version_added": true
@@ -62,16 +70,17 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "getURL": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL",
             "support": {
               "chrome": {
                 "version_added": true
@@ -88,16 +97,12 @@
               "opera": {
                 "version_added": true
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "getViews": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getViews",
             "support": {
               "chrome": {
                 "version_added": true
@@ -125,6 +130,7 @@
         },
         "inIncognitoContext": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext",
             "support": {
               "chrome": {
                 "version_added": true
@@ -146,6 +152,7 @@
         },
         "isAllowedFileSchemeAccess": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedFileSchemeAccess",
             "support": {
               "chrome": {
                 "version_added": true
@@ -167,6 +174,7 @@
         },
         "isAllowedIncognitoAccess": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedIncognitoAccess",
             "support": {
               "chrome": {
                 "version_added": true
@@ -188,6 +196,7 @@
         },
         "lastError": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/lastError",
             "support": {
               "chrome": {
                 "version_added": true
@@ -209,6 +218,12 @@
         },
         "onRequest": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/onRequest",
             "support": {
               "chrome": {
                 "version_added": true
@@ -225,16 +240,17 @@
               "opera": {
                 "version_added": true
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "onRequestExternal": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/onRequestExternal",
             "support": {
               "chrome": {
                 "version_added": true
@@ -251,16 +267,17 @@
               "opera": {
                 "version_added": true
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "sendRequest": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/sendRequest",
             "support": {
               "chrome": {
                 "version_added": true
@@ -277,16 +294,12 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "setUpdateUrlData": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/setUpdateUrlData",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/extensionTypes.json
+++ b/webextensions/api/extensionTypes.json
@@ -4,6 +4,7 @@
       "extensionTypes": {
         "ImageDetails": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails",
             "support": {
               "chrome": {
                 "version_added": true,
@@ -37,6 +38,7 @@
         },
         "ImageFormat": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageFormat",
             "support": {
               "chrome": {
                 "version_added": true,
@@ -70,6 +72,7 @@
         },
         "RunAt": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt",
             "support": {
               "chrome": {
                 "version_added": "20",

--- a/webextensions/api/find.json
+++ b/webextensions/api/find.json
@@ -4,6 +4,7 @@
       "find": {
         "find": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find/find",
             "support": {
               "chrome": {
                 "version_added": false
@@ -25,6 +26,7 @@
         },
         "highlightResults": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find/highlightResults",
             "support": {
               "chrome": {
                 "version_added": false
@@ -46,6 +48,7 @@
         },
         "removeHighlighting": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find/removeHighlighting",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/history.json
+++ b/webextensions/api/history.json
@@ -4,6 +4,7 @@
       "history": {
         "HistoryItem": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/HistoryItem",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +47,7 @@
         },
         "TransitionType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/TransitionType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -67,6 +69,7 @@
         },
         "VisitItem": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/VisitItem",
             "support": {
               "chrome": {
                 "version_added": true
@@ -88,6 +91,7 @@
         },
         "addUrl": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/addUrl",
             "support": {
               "chrome": {
                 "version_added": true
@@ -172,6 +176,7 @@
         },
         "deleteAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -193,6 +198,7 @@
         },
         "deleteRange": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteRange",
             "support": {
               "chrome": {
                 "version_added": true
@@ -214,6 +220,7 @@
         },
         "deleteUrl": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteUrl",
             "support": {
               "chrome": {
                 "version_added": true
@@ -235,6 +242,7 @@
         },
         "getVisits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/getVisits",
             "support": {
               "chrome": {
                 "version_added": true
@@ -256,6 +264,7 @@
         },
         "onTitleChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/onTitleChanged",
             "support": {
               "chrome": {
                 "version_added": false
@@ -277,6 +286,7 @@
         },
         "onVisitRemoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/onVisitRemoved",
             "support": {
               "chrome": {
                 "version_added": true
@@ -298,6 +308,7 @@
         },
         "onVisited": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/onVisited",
             "support": {
               "chrome": {
                 "version_added": true
@@ -322,6 +333,7 @@
         },
         "search": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/search",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -4,6 +4,7 @@
       "i18n": {
         "LanguageCode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -25,6 +26,7 @@
         },
         "detectLanguage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/detectLanguage",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -46,6 +48,7 @@
         },
         "getAcceptLanguages": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -67,6 +70,7 @@
         },
         "getMessage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage",
             "support": {
               "chrome": {
                 "version_added": "17"
@@ -95,6 +99,7 @@
         },
         "getUILanguage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage",
             "support": {
               "chrome": {
                 "version_added": "35"

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -4,6 +4,7 @@
       "identity": {
         "getRedirectURL": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "launchWebAuthFlow": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/launchWebAuthFlow",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/idle.json
+++ b/webextensions/api/idle.json
@@ -4,6 +4,7 @@
       "idle": {
         "IdleState": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/IdleState",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "onStateChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/onStateChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -67,6 +69,7 @@
         },
         "queryState": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/queryState",
             "support": {
               "chrome": {
                 "version_added": true
@@ -115,6 +118,7 @@
         },
         "setDetectionInterval": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/setDetectionInterval",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -4,6 +4,7 @@
       "management": {
         "ExtensionInfo": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo",
             "support": {
               "chrome": {
                 "version_added": true
@@ -109,6 +110,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/get",
             "support": {
               "chrome": {
                 "version_added": true
@@ -130,6 +132,7 @@
         },
         "getAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -157,6 +160,7 @@
         },
         "getPermissionWarningsById": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsById",
             "support": {
               "chrome": {
                 "version_added": true
@@ -178,6 +182,7 @@
         },
         "getPermissionWarningsByManifest": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsByManifest",
             "support": {
               "chrome": {
                 "version_added": true
@@ -199,6 +204,7 @@
         },
         "getSelf": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/getSelf",
             "support": {
               "chrome": {
                 "version_added": true
@@ -220,6 +226,7 @@
         },
         "onDisabled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onDisabled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -241,6 +248,7 @@
         },
         "onEnabled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onEnabled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -262,6 +270,7 @@
         },
         "onInstalled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onInstalled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -283,6 +292,7 @@
         },
         "onUninstalled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/onUninstalled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -304,6 +314,7 @@
         },
         "setEnabled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/setEnabled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -331,6 +342,7 @@
         },
         "uninstall": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstall",
             "support": {
               "chrome": {
                 "version_added": true
@@ -352,6 +364,7 @@
         },
         "uninstallSelf": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -4,6 +4,7 @@
       "menus": {
         "ACTION_MENU_TOP_LEVEL_LIMIT": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/ACTION_MENU_TOP_LEVEL_LIMIT",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
@@ -34,6 +35,7 @@
         },
         "ContextType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.ContextType",
@@ -220,6 +222,7 @@
         },
         "ItemType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/ItemType",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.ItemType",
@@ -250,6 +253,7 @@
         },
         "OnClickData": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/OnClickData",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.OnClickData",
@@ -366,6 +370,7 @@
         },
         "create": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/create",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.create",
@@ -450,6 +455,7 @@
         },
         "onClicked": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/onClicked",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.onClicked",
@@ -480,6 +486,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/remove",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.remove",
@@ -510,6 +517,7 @@
         },
         "removeAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/removeAll",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.removeAll",
@@ -540,6 +548,7 @@
         },
         "update": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/update",
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.update",

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -4,6 +4,7 @@
       "notifications": {
         "NotificationOptions": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions",
             "support": {
               "chrome": {
                 "version_added": true
@@ -31,6 +32,7 @@
         },
         "TemplateType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/TemplateType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -61,6 +63,7 @@
         },
         "clear": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/clear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -82,6 +85,7 @@
         },
         "create": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create",
             "support": {
               "chrome": {
                 "version_added": true
@@ -103,6 +107,7 @@
         },
         "getAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/getAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -124,6 +129,7 @@
         },
         "onButtonClicked": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onButtonClicked",
             "support": {
               "chrome": {
                 "version_added": true
@@ -145,6 +151,7 @@
         },
         "onClicked": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClicked",
             "support": {
               "chrome": {
                 "version_added": true
@@ -166,6 +173,7 @@
         },
         "onClosed": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClosed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -208,6 +216,7 @@
         },
         "onShown": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onShown",
             "support": {
               "chrome": {
                 "version_added": false
@@ -229,6 +238,7 @@
         },
         "update": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/update",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/omnibox.json
+++ b/webextensions/api/omnibox.json
@@ -4,6 +4,7 @@
       "omnibox": {
         "OnInputEnteredDisposition": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/OnInputEnteredDisposition",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "SuggestResult": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/SuggestResult",
             "support": {
               "chrome": {
                 "version_added": true
@@ -49,6 +51,7 @@
         },
         "onInputCancelled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputCancelled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -70,6 +73,7 @@
         },
         "onInputChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -91,6 +95,7 @@
         },
         "onInputEntered": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputEntered",
             "support": {
               "chrome": {
                 "version_added": true
@@ -112,6 +117,7 @@
         },
         "onInputStarted": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputStarted",
             "support": {
               "chrome": {
                 "version_added": true
@@ -133,6 +139,7 @@
         },
         "setDefaultSuggestion": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/setDefaultSuggestion",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -4,6 +4,7 @@
       "pageAction": {
         "ImageDataType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/ImageDataType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "getPopup": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getPopup",
             "support": {
               "chrome": {
                 "version_added": true
@@ -49,6 +51,7 @@
         },
         "getTitle": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getTitle",
             "support": {
               "chrome": {
                 "version_added": true
@@ -70,6 +73,7 @@
         },
         "hide": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/hide",
             "support": {
               "chrome": {
                 "version_added": true
@@ -94,6 +98,7 @@
         },
         "onClicked": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked",
             "support": {
               "chrome": {
                 "version_added": true
@@ -115,6 +120,7 @@
         },
         "openPopup": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/openPopup",
             "support": {
               "chrome": {
                 "version_added": false
@@ -136,6 +142,7 @@
         },
         "setIcon": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setIcon",
             "support": {
               "chrome": {
                 "version_added": true,
@@ -181,6 +188,7 @@
         },
         "setPopup": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setPopup",
             "support": {
               "chrome": {
                 "version_added": true
@@ -205,6 +213,7 @@
         },
         "setTitle": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setTitle",
             "support": {
               "chrome": {
                 "version_added": true
@@ -226,6 +235,7 @@
         },
         "show": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/show",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -4,6 +4,7 @@
       "permissions": {
         "contains": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/contains",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "getAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/getAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "onAdded": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onAdded",
             "support": {
               "chrome": {
                 "version_added": true
@@ -67,6 +70,7 @@
         },
         "onRemoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved",
             "support": {
               "chrome": {
                 "version_added": true
@@ -88,6 +92,7 @@
         },
         "Permissions": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions",
             "support": {
               "chrome": {
                 "version_added": true
@@ -109,6 +114,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/remove",
             "support": {
               "chrome": {
                 "version_added": true
@@ -130,6 +136,7 @@
         },
         "request": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/pkcs11.json
+++ b/webextensions/api/pkcs11.json
@@ -4,6 +4,12 @@
       "pkcs11": {
         "getModuleSlots": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/getModuleSlots",
             "support": {
               "chrome": {
                 "version_added": false
@@ -20,16 +26,17 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
         "installModule": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/installModule",
             "support": {
               "chrome": {
                 "version_added": false
@@ -46,16 +53,17 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
         "isModuleInstalled": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/isModuleInstalled",
             "support": {
               "chrome": {
                 "version_added": false
@@ -72,16 +80,17 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
         "uninstallModule": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/uninstallModule",
             "support": {
               "chrome": {
                 "version_added": false
@@ -98,11 +107,6 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         }

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -4,6 +4,7 @@
       "proxy": {
         "onProxyError": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onProxyError",
             "support": {
               "chrome": {
                 "version_added": false
@@ -25,6 +26,7 @@
         },
         "register": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/register",
             "support": {
               "chrome": {
                 "version_added": false
@@ -52,6 +54,7 @@
         },
         "unregister": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/unregister",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -4,6 +4,7 @@
       "runtime": {
         "MessageSender": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -97,6 +98,7 @@
         },
         "OnInstalledReason": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason",
             "support": {
               "chrome": {
                 "version_added": true,
@@ -127,6 +129,7 @@
         },
         "OnRestartRequiredReason": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnRestartRequiredReason",
             "support": {
               "chrome": {
                 "version_added": true
@@ -148,6 +151,7 @@
         },
         "PlatformArch": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch",
             "support": {
               "chrome": {
                 "version_added": true
@@ -169,6 +173,7 @@
         },
         "PlatformInfo": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformInfo",
             "support": {
               "chrome": {
                 "version_added": true
@@ -211,6 +216,7 @@
         },
         "PlatformNaclArch": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformNaclArch",
             "support": {
               "chrome": {
                 "version_added": true
@@ -232,6 +238,7 @@
         },
         "PlatformOs": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformOs",
             "support": {
               "chrome": {
                 "version_added": true
@@ -253,6 +260,7 @@
         },
         "Port": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -295,6 +303,7 @@
         },
         "RequestUpdateCheckStatus": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/RequestUpdateCheckStatus",
             "support": {
               "chrome": {
                 "version_added": true
@@ -316,6 +325,7 @@
         },
         "connect": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connect",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -337,6 +347,7 @@
         },
         "connectNative": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connectNative",
             "support": {
               "chrome": {
                 "version_added": "29"
@@ -358,6 +369,7 @@
         },
         "getBackgroundPage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getBackgroundPage",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -385,6 +397,7 @@
         },
         "getBrowserInfo": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getBrowserInfo",
             "support": {
               "chrome": {
                 "version_added": false
@@ -406,6 +419,7 @@
         },
         "getManifest": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getManifest",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -427,6 +441,7 @@
         },
         "getPackageDirectoryEntry": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getPackageDirectoryEntry",
             "support": {
               "chrome": {
                 "version_added": "29"
@@ -448,6 +463,7 @@
         },
         "getPlatformInfo": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getPlatformInfo",
             "support": {
               "chrome": {
                 "version_added": "29"
@@ -469,6 +485,7 @@
         },
         "getURL": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -490,6 +507,7 @@
         },
         "id": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/id",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -511,6 +529,7 @@
         },
         "lastError": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError",
             "support": {
               "chrome": {
                 "notes": [
@@ -538,6 +557,12 @@
         },
         "onBrowserUpdateAvailable": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onBrowserUpdateAvailable",
             "support": {
               "chrome": {
                 "version_added": "27"
@@ -554,16 +579,12 @@
               "opera": {
                 "version_added": "15"
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "onConnect": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnect",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -585,6 +606,7 @@
         },
         "onConnectExternal": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnectExternal",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -606,6 +628,7 @@
         },
         "onInstalled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -719,6 +742,7 @@
         },
         "onMessage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -740,6 +764,7 @@
         },
         "onMessageExternal": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -761,6 +786,7 @@
         },
         "onRestartRequired": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onRestartRequired",
             "support": {
               "chrome": {
                 "version_added": "29"
@@ -782,6 +808,7 @@
         },
         "onStartup": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onStartup",
             "support": {
               "chrome": {
                 "version_added": "23"
@@ -803,6 +830,7 @@
         },
         "onSuspend": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onSuspend",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -824,6 +852,7 @@
         },
         "onSuspendCanceled": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onSuspendCanceled",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -845,6 +874,7 @@
         },
         "onUpdateAvailable": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onUpdateAvailable",
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -866,6 +896,7 @@
         },
         "openOptionsPage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage",
             "support": {
               "chrome": {
                 "version_added": "42"
@@ -887,6 +918,7 @@
         },
         "reload": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/reload",
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -908,6 +940,7 @@
         },
         "requestUpdateCheck": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/requestUpdateCheck",
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -929,6 +962,7 @@
         },
         "sendMessage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage",
             "support": {
               "chrome": {
                 "version_added": "26"
@@ -997,6 +1031,7 @@
         },
         "sendNativeMessage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage",
             "support": {
               "chrome": {
                 "version_added": "29"
@@ -1018,6 +1053,7 @@
         },
         "setUninstallURL": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/setUninstallURL",
             "support": {
               "chrome": {
                 "version_added": "41"

--- a/webextensions/api/sessions.json
+++ b/webextensions/api/sessions.json
@@ -4,6 +4,7 @@
       "sessions": {
         "Filter": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/Filter",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "MAX_SESSION_RESULTS": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/MAX_SESSION_RESULTS",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "Session": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/Session",
             "support": {
               "chrome": {
                 "version_added": true
@@ -70,6 +73,7 @@
         },
         "forgetClosedTab": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedTab",
             "support": {
               "chrome": {
                 "version_added": false
@@ -91,6 +95,7 @@
         },
         "forgetClosedWindow": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedWindow",
             "support": {
               "chrome": {
                 "version_added": false
@@ -112,6 +117,7 @@
         },
         "getRecentlyClosed": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/getRecentlyClosed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -133,6 +139,7 @@
         },
         "getTabValue": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/getTabValue",
             "support": {
               "chrome": {
                 "version_added": false
@@ -154,6 +161,7 @@
         },
         "getWindowValue": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/getWindowValue",
             "support": {
               "chrome": {
                 "version_added": false
@@ -175,6 +183,7 @@
         },
         "onChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/onChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -196,6 +205,7 @@
         },
         "removeTabValue": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/removeTabValue",
             "support": {
               "chrome": {
                 "version_added": false
@@ -217,6 +227,7 @@
         },
         "removeWindowValue": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/removeWindowValue",
             "support": {
               "chrome": {
                 "version_added": false
@@ -238,6 +249,7 @@
         },
         "restore": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/restore",
             "support": {
               "chrome": {
                 "version_added": true
@@ -259,6 +271,7 @@
         },
         "setTabValue": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/setTabValue",
             "support": {
               "chrome": {
                 "version_added": false
@@ -280,6 +293,7 @@
         },
         "setWindowValue": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/setWindowValue",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/sidebarAction.json
+++ b/webextensions/api/sidebarAction.json
@@ -4,6 +4,7 @@
       "sidebarAction": {
         "ImageDataType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/ImageDataType",
             "support": {
               "chrome": {
                 "version_added": false
@@ -25,6 +26,7 @@
         },
         "close": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/close",
             "support": {
               "chrome": {
                 "version_added": false
@@ -46,6 +48,7 @@
         },
         "getPanel": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/getPanel",
             "support": {
               "chrome": {
                 "version_added": false
@@ -67,6 +70,7 @@
         },
         "getTitle": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/getTitle",
             "support": {
               "chrome": {
                 "version_added": false
@@ -88,6 +92,7 @@
         },
         "open": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/open",
             "support": {
               "chrome": {
                 "version_added": false
@@ -109,6 +114,7 @@
         },
         "setIcon": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/setIcon",
             "support": {
               "chrome": {
                 "version_added": false
@@ -130,6 +136,7 @@
         },
         "setPanel": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/setPanel",
             "support": {
               "chrome": {
                 "version_added": false
@@ -151,6 +158,7 @@
         },
         "setTitle": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/setTitle",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -4,6 +4,7 @@
       "storage": {
         "StorageArea": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea",
             "support": {
               "chrome": {
                 "version_added": true
@@ -24,6 +25,7 @@
           },
           "clear": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -45,6 +47,7 @@
           },
           "get": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -66,6 +69,7 @@
           },
           "getBytesInUse": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -87,6 +91,7 @@
           },
           "remove": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -108,6 +113,7 @@
           },
           "set": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -133,6 +139,7 @@
         },
         "StorageChange": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageChange",
             "support": {
               "chrome": {
                 "version_added": true
@@ -154,6 +161,7 @@
         },
         "local": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/local",
             "support": {
               "chrome": {
                 "version_added": true
@@ -178,6 +186,7 @@
         },
         "managed": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -204,6 +213,7 @@
         },
         "onChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -225,6 +235,7 @@
         },
         "sync": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -4,6 +4,7 @@
       "tabs": {
         "MutedInfo": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "MutedInfoReason": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfoReason",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "PageSettings": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/PageSettings",
             "support": {
               "chrome": {
                 "version_added": false
@@ -67,6 +70,7 @@
         },
         "TAB_ID_NONE": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/TAB_ID_NONE",
             "support": {
               "chrome": {
                 "version_added": true
@@ -600,6 +604,7 @@
         },
         "TabStatus": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/TabStatus",
             "support": {
               "chrome": {
                 "version_added": true
@@ -621,6 +626,7 @@
         },
         "WindowType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/WindowType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -642,6 +648,7 @@
         },
         "ZoomSettings": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettings",
             "support": {
               "chrome": {
                 "version_added": true
@@ -663,6 +670,7 @@
         },
         "ZoomSettingsMode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsMode",
             "support": {
               "chrome": {
                 "version_added": true
@@ -684,6 +692,7 @@
         },
         "ZoomSettingsScope": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsScope",
             "support": {
               "chrome": {
                 "version_added": true
@@ -705,6 +714,7 @@
         },
         "captureVisibleTab": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab",
             "support": {
               "chrome": {
                 "notes": [
@@ -732,6 +742,7 @@
         },
         "connect": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/connect",
             "support": {
               "chrome": {
                 "version_added": true
@@ -776,6 +787,7 @@
         },
         "create": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1002,6 +1014,7 @@
         },
         "detectLanguage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1023,6 +1036,7 @@
         },
         "discard": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/discard",
             "support": {
               "chrome": {
                 "version_added": "54",
@@ -1054,6 +1068,7 @@
         },
         "duplicate": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1075,6 +1090,7 @@
         },
         "executeScript": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1168,6 +1184,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/get",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1189,6 +1206,12 @@
         },
         "getAllInWindow": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getAllInWindow",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1205,16 +1228,12 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "getCurrent": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1236,6 +1255,12 @@
         },
         "getSelected": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getSelected",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1252,16 +1277,12 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "getZoom": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1283,6 +1304,7 @@
         },
         "getZoomSettings": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoomSettings",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1304,6 +1326,7 @@
         },
         "highlight": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/highlight",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1325,6 +1348,7 @@
         },
         "insertCSS": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1430,6 +1454,7 @@
         },
         "move": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/move",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1451,6 +1476,7 @@
         },
         "onActivated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActivated",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1472,6 +1498,12 @@
         },
         "onActiveChanged": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActiveChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1488,16 +1520,12 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "onAttached": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onAttached",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1519,6 +1547,7 @@
         },
         "onCreated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onCreated",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1540,6 +1569,7 @@
         },
         "onDetached": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onDetached",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1561,6 +1591,12 @@
         },
         "onHighlightChanged": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlightChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1577,16 +1613,12 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "onHighlighted": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1608,6 +1640,7 @@
         },
         "onMoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onMoved",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1629,6 +1662,7 @@
         },
         "onRemoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1650,6 +1684,7 @@
         },
         "onReplaced": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onReplaced",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1671,6 +1706,12 @@
         },
         "onSelectionChanged": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onSelectionChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1687,16 +1728,12 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "onUpdated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1888,6 +1925,7 @@
         },
         "onZoomChange": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onZoomChange",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1909,6 +1947,7 @@
         },
         "print": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/print",
             "support": {
               "chrome": {
                 "version_added": false
@@ -1930,6 +1969,7 @@
         },
         "printPreview": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/printPreview",
             "support": {
               "chrome": {
                 "version_added": false
@@ -1951,6 +1991,7 @@
         },
         "query": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2342,6 +2383,7 @@
         },
         "reload": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/reload",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2363,6 +2405,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/remove",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2384,6 +2427,7 @@
         },
         "removeCSS": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS",
             "support": {
               "chrome": {
                 "version_added": false
@@ -2405,6 +2449,7 @@
         },
         "saveAsPDF": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/saveAsPDF",
             "support": {
               "chrome": {
                 "version_added": false
@@ -2429,6 +2474,7 @@
         },
         "sendMessage": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2476,6 +2522,12 @@
         },
         "sendRequest": {
           "__compat": {
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendRequest",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2492,16 +2544,12 @@
               "opera": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
         "setZoom": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2523,6 +2571,7 @@
         },
         "setZoomSettings": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoomSettings",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2544,6 +2593,7 @@
         },
         "toggleReaderMode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode",
             "support": {
               "chrome": {
                 "version_added": false
@@ -2565,6 +2615,7 @@
         },
         "update": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/theme.json
+++ b/webextensions/api/theme.json
@@ -4,6 +4,7 @@
       "theme": {
         "Theme": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/Theme",
             "support": {
               "chrome": {
                 "version_added": false
@@ -25,6 +26,7 @@
         },
         "getCurrent": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/getCurrent",
             "support": {
               "chrome": {
                 "version_added": false
@@ -46,6 +48,7 @@
         },
         "onUpdated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/onUpdated",
             "support": {
               "chrome": {
                 "version_added": false
@@ -67,6 +70,7 @@
         },
         "reset": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/reset",
             "support": {
               "chrome": {
                 "version_added": false
@@ -109,6 +113,7 @@
         },
         "update": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/update",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -4,6 +4,7 @@
       "topSites": {
         "MostVisitedURL": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/topSites/MostVisitedURL",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/topSites/get",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -4,6 +4,7 @@
       "types": {
         "BrowserSetting": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting",
             "support": {
               "chrome": {
                 "version_added": true
@@ -24,6 +25,7 @@
           },
           "onChange": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange",
               "support": {
                 "chrome": {
                   "version_added": true

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -4,6 +4,7 @@
       "webNavigation": {
         "TransitionQualifier": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionQualifier",
             "support": {
               "chrome": {
                 "version_added": true
@@ -52,6 +53,7 @@
         },
         "TransitionType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -79,6 +81,7 @@
         },
         "getAllFrames": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames",
             "support": {
               "chrome": {
                 "version_added": true
@@ -100,6 +103,7 @@
         },
         "getFrame": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame",
             "support": {
               "chrome": {
                 "version_added": true
@@ -121,6 +125,7 @@
         },
         "onBeforeNavigate": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate",
             "support": {
               "chrome": {
                 "notes": [
@@ -159,6 +164,7 @@
         },
         "onCommitted": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted",
             "support": {
               "chrome": {
                 "notes": [
@@ -239,6 +245,7 @@
         },
         "onCompleted": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted",
             "support": {
               "chrome": {
                 "notes": [
@@ -277,6 +284,7 @@
         },
         "onCreatedNavigationTarget": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCreatedNavigationTarget",
             "support": {
               "chrome": {
                 "notes": [
@@ -355,6 +363,7 @@
         },
         "onDOMContentLoaded": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded",
             "support": {
               "chrome": {
                 "notes": [
@@ -393,6 +402,7 @@
         },
         "onErrorOccurred": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred",
             "support": {
               "chrome": {
                 "notes": [
@@ -452,6 +462,7 @@
         },
         "onHistoryStateUpdated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onHistoryStateUpdated",
             "support": {
               "chrome": {
                 "version_added": true
@@ -518,6 +529,7 @@
         },
         "onReferenceFragmentUpdated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onReferenceFragmentUpdated",
             "support": {
               "chrome": {
                 "notes": [
@@ -598,6 +610,7 @@
         },
         "onTabReplaced": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onTabReplaced",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -4,6 +4,7 @@
       "webRequest": {
         "BlockingResponse": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse",
             "support": {
               "chrome": {
                 "version_added": true
@@ -25,6 +26,7 @@
         },
         "HttpHeaders": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/HttpHeaders",
             "support": {
               "chrome": {
                 "version_added": true
@@ -46,6 +48,7 @@
         },
         "MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES",
             "support": {
               "chrome": {
                 "version_added": true
@@ -67,6 +70,7 @@
         },
         "RequestFilter": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter",
             "support": {
               "chrome": {
                 "version_added": true
@@ -157,6 +161,7 @@
         },
         "ResourceType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType",
             "support": {
               "chrome": {
                 "version_added": "44"
@@ -442,6 +447,7 @@
         },
         "StreamFilter": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter",
             "support": {
               "chrome": {
                 "version_added": false
@@ -462,6 +468,7 @@
           },
           "close": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/close",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -483,6 +490,7 @@
           },
           "disconnect": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/disconnect",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -504,6 +512,7 @@
           },
           "error": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/error",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -525,6 +534,7 @@
           },
           "ondata": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/ondata",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -546,6 +556,7 @@
           },
           "onerror": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onerror",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -567,6 +578,7 @@
           },
           "onstart": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstart",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -588,6 +600,7 @@
           },
           "onstop": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstop",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -609,6 +622,7 @@
           },
           "resume": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/resume",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -630,6 +644,7 @@
           },
           "status": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/status",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -651,6 +666,7 @@
           },
           "suspend": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/suspend",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -672,6 +688,7 @@
           },
           "write": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/write",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -694,6 +711,7 @@
         },
         "UploadData": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/UploadData",
             "support": {
               "chrome": {
                 "version_added": true
@@ -715,6 +733,7 @@
         },
         "filterResponseData": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/filterResponseData",
             "support": {
               "chrome": {
                 "version_added": false
@@ -736,6 +755,7 @@
         },
         "handlerBehaviorChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/handlerBehaviorChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -757,6 +777,7 @@
         },
         "onAuthRequired": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1128,6 +1149,7 @@
         },
         "onBeforeRedirect": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRedirect",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1487,6 +1509,7 @@
         },
         "onBeforeRequest": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest",
             "support": {
               "chrome": {
                 "notes": [
@@ -1777,6 +1800,7 @@
         },
         "onBeforeSendHeaders": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders",
             "support": {
               "chrome": {
                 "notes": [
@@ -2046,6 +2070,7 @@
         },
         "onCompleted": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onCompleted",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2384,6 +2409,7 @@
         },
         "onErrorOccurred": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onErrorOccurred",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2680,6 +2706,7 @@
         },
         "onHeadersReceived": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived",
             "support": {
               "chrome": {
                 "notes": [
@@ -2993,6 +3020,7 @@
         },
         "onResponseStarted": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3331,6 +3359,7 @@
         },
         "onSendHeaders": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onSendHeaders",
             "support": {
               "chrome": {
                 "version_added": true

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -4,6 +4,7 @@
       "windows": {
         "CreateType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/CreateType",
             "support": {
               "chrome": {
                 "version_added": true,
@@ -34,6 +35,7 @@
         },
         "WINDOW_ID_CURRENT": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT",
             "support": {
               "chrome": {
                 "version_added": "18"
@@ -55,6 +57,7 @@
         },
         "WINDOW_ID_NONE": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_NONE",
             "support": {
               "chrome": {
                 "version_added": true
@@ -76,6 +79,7 @@
         },
         "Window": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window",
             "support": {
               "chrome": {
                 "version_added": true
@@ -371,6 +375,7 @@
         },
         "WindowState": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WindowState",
             "support": {
               "chrome": {
                 "version_added": true
@@ -481,6 +486,7 @@
         },
         "WindowType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WindowType",
             "support": {
               "chrome": {
                 "version_added": true
@@ -565,6 +571,7 @@
         },
         "create": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/create",
             "support": {
               "chrome": {
                 "version_added": true
@@ -847,6 +854,7 @@
         },
         "get": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get",
             "support": {
               "chrome": {
                 "version_added": true
@@ -910,6 +918,7 @@
         },
         "getAll": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getAll",
             "support": {
               "chrome": {
                 "version_added": true
@@ -973,6 +982,7 @@
         },
         "getCurrent": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1036,6 +1046,7 @@
         },
         "getLastFocused": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1099,6 +1110,7 @@
         },
         "onCreated": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onCreated",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1120,6 +1132,7 @@
         },
         "onFocusChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1141,6 +1154,7 @@
         },
         "onRemoved": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onRemoved",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1162,6 +1176,7 @@
         },
         "remove": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/remove",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1183,6 +1198,7 @@
         },
         "update": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/update",
             "support": {
               "chrome": {
                 "version_added": true


### PR DESCRIPTION
Add `mdn_url` to WebExtension APIs. Replaces https://github.com/mdn/browser-compat-data/pull/672.