### PR TITLE
Update content-security-policy.json

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -276,7 +276,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "15"
               },
               "edge_mobile": {
                 "version_added": false
@@ -531,7 +531,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "15"
               },
               "edge_mobile": {
                 "version_added": false
@@ -582,7 +582,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "15"
               },
               "edge_mobile": {
                 "version_added": false
@@ -940,7 +940,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "15"
               },
               "edge_mobile": {
                 "version_added": false


### PR DESCRIPTION
Update edge compatibility with CSP Level 2, as of Edge 15+
the spec version 2 is supported.

See also https://content-security-policy.com