### PR TITLE
Add compat data for CSS outline properties

### DIFF
--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -1,0 +1,117 @@
+{
+  "css": {
+    "properties": {
+      "outline-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-color",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1",
+                "version_removed": true
+              }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1.2"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "invert": {
+          "__compat": {
+            "description": "<code>invert</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_removed": "3",
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7",
+                "version_removed": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/outline-offset.json
+++ b/css/properties/outline-offset.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "outline-offset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-offset",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1.2"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -1,0 +1,115 @@
+{
+  "css": {
+    "properties": {
+      "outline-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-style",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1",
+                "version_removed": true
+              }
+            ],
+            "firefox_android": {
+              "version_added": "46"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "1.2"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/outline-width.json
+++ b/css/properties/outline-width.json
@@ -1,0 +1,64 @@
+{
+  "css": {
+    "properties": {
+      "outline-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-width",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1",
+                "version_removed": true
+              }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1.2"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -1,0 +1,65 @@
+{
+  "css": {
+    "properties": {
+      "outline": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "1.5",
+                "notes": "Firefox includes absolutely positioned elements inside the outline (see <a href='https://bugzil.la687311'>bug 687311</a>)."
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1",
+                "version_removed": true
+              }
+            ],
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": "8"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "7"
+            },
+            "safari": {
+              "version_added": "1.2"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates compat data for the following CSS properties:

* [`outline`](https://developer.mozilla.org/docs/Web/CSS/outline)
* [`outline-color`](https://developer.mozilla.org/docs/Web/CSS/outline-color)
* [`outline-offset`](https://developer.mozilla.org/docs/Web/CSS/outline-offset)
* [`outline-style`](https://developer.mozilla.org/docs/Web/CSS/outline-style)
* [`outline-width`](https://developer.mozilla.org/docs/Web/CSS/outline-width)
