### PR TITLE
Fix missing browser entries in WebGLRenderingContext

### DIFF
--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -992,11 +992,35 @@
               "chrome_android": {
                 "version_added": "60"
               },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
               "opera": {
                 "version_added": "47"
               },
               "opera_android": {
                 "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
             "status": {
@@ -1891,11 +1915,35 @@
               "chrome_android": {
                 "version_added": "60"
               },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
               "opera": {
                 "version_added": "47"
               },
               "opera_android": {
                 "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
             "status": {
@@ -2018,11 +2066,35 @@
                 "chrome_android": {
                   "version_added": "60"
                 },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": "47"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -6265,11 +6337,35 @@
                 "chrome_android": {
                   "version_added": "60"
                 },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": "47"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -6953,11 +7049,35 @@
                 "chrome_android": {
                   "version_added": "60"
                 },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": "47"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -7283,11 +7403,35 @@
                 "chrome_android": {
                   "version_added": "60"
                 },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": "47"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -8227,11 +8371,35 @@
                 "chrome_android": {
                   "version_added": "60"
                 },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": "47"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -8355,11 +8523,35 @@
                 "chrome_android": {
                   "version_added": "60"
                 },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": "47"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -8483,11 +8675,35 @@
                 "chrome_android": {
                   "version_added": "60"
                 },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "ie_mobile": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": "47"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -8715,11 +8931,35 @@
               "chrome_android": {
                 "version_added": "60"
               },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
               "opera": {
                 "version_added": "47"
               },
               "opera_android": {
                 "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
             "status": {
@@ -8844,11 +9084,35 @@
               "chrome_android": {
                 "version_added": "60"
               },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
               "opera": {
                 "version_added": "47"
               },
               "opera_android": {
                 "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
             "status": {
@@ -8973,11 +9237,35 @@
               "chrome_android": {
                 "version_added": "60"
               },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
               "opera": {
                 "version_added": "47"
               },
               "opera_android": {
                 "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
             "status": {
@@ -9102,11 +9390,35 @@
               "chrome_android": {
                 "version_added": "60"
               },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
               "opera": {
                 "version_added": "47"
               },
               "opera_android": {
                 "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             },
             "status": {


### PR DESCRIPTION
The SharedArrayBuffer patch from last week left out many
browsers from the added records, and this currently causes
errors when generating the compatibility tables. PR #646
fixed this for WebGL2RenderingContext; this PR fixes the
problem in WebGLRenderingContext as well.