### PR TITLE
Update compatibility for `options_ui` WebExtension manifest

### DIFF
--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -18,7 +18,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": "27",
+              "notes": [
+                "Does not support inline extension options, it always opens it in a separate tab."
+              ]
             }
           }
         },
@@ -80,10 +83,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false,
-                "notes": [
-                  "Does not support inline extension options, it always opens it in a separate tab."
-                ]
+                "version_added": false
               }
             }
           }

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "40"
             },
             "edge": {
               "version_added": false
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "48"
             },
             "firefox_android": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "27"
             }
           }
         },
@@ -26,7 +26,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "40"
               },
               "edge": {
                 "version_added": false
@@ -38,7 +38,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               }
             }
           }
@@ -60,6 +60,30 @@
               },
               "opera": {
                 "version_added": false
+              }
+            }
+          }
+        },
+        "open_in_tab": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false,
+                "notes": [
+                  "Does not support inline extension options, it always opens it in a separate tab."
+                ]
               }
             }
           }

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -20,7 +20,7 @@
             "opera": {
               "version_added": "27",
               "notes": [
-                "Does not support inline extension options, it always opens it in a separate tab."
+                "Options pages are always opened in a separate browser tab."
               ]
             }
           }


### PR DESCRIPTION
This replaces https://github.com/mdn/browser-compat-data/pull/543 and moves the note up to options_ui.