### PR TITLE
Update Tabs API setZoomSettings compatability

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2580,7 +2580,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "45"
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
To indicate setZoomSettings  doesn't work in Firefox - as per bug 1286953: returns console message "Unsupported zoom settings: {"mode":"automatic","scope":"per-origin","defaultZoomFactor":null}        ExtensionUtils.jsm:283"