### PR TITLE
IE11 partially supports `new Map(iterable)`

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -80,7 +80,9 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": false
+                "version_added": false,
+                "partial_implementation": true,
+                "notes": "Supports arrays of key/value pairs, such as <code>new Map([ ['foo', 'bar'] ])</code>."
               },
               "ie_mobile": {
                 "version_added": false

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -82,7 +82,7 @@
               "ie": {
                 "version_added": false,
                 "partial_implementation": true,
-                "notes": "Supports arrays of key/value pairs, such as <code>new Map([ ['foo', 'bar'] ])</code>."
+                "notes": "Only supports arrays of key/value pairs, such as <code>new Map([ ['foo', 'bar'] ])</code>."
               },
               "ie_mobile": {
                 "version_added": false


### PR DESCRIPTION
While IE11 does not support the iterable API, you can create Maps by passing an array of key/value pairs. For example:

```javascript
var map = new Map([ ['foo', 'bar'] ])
map.get('foo') // 'bar'
```