### PR TITLE
Add compat data for CSS filter properties 

### DIFF
--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "background-blend-mode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-blend-mode",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "30"
+            },
+            "firefox_android": {
+              "version_added": "30"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "22"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": "8"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -1,0 +1,196 @@
+{
+  "css": {
+    "properties": {
+      "filter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "53"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "53"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18",
+                "notes": "In Chrome 18 to 19, the <code>saturate()</code> function only takes integers instead of decimal or percentage values. From Chrome 20, this bug is fixed."
+              }
+            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "35"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.filters.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "46",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.filters.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "46",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false,
+              "notes": "Internet Explorer 4 to 9 implemented a non-standard <code>filter</code> property. The syntax was completely different from this one and is not documented here."
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "40"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "40"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "22"
+              }
+            ],
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "6"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "svg": {
+          "__compat": {
+            "description": "On SVG elements",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/isolation.json
+++ b/css/properties/isolation.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "isolation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/isolation",
+          "support": {
+            "webview_android": {
+              "version_added": "41"
+            },
+            "chrome": {
+              "version_added": "41"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "36"
+            },
+            "firefox_android": {
+              "version_added": "36"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": "8"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "mix-blend-mode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode",
+          "support": {
+            "webview_android": {
+              "version_added": "41"
+            },
+            "chrome": {
+              "version_added": "41"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "32"
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "svg": {
+          "__compat": {
+            "description": "On SVG elements",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": {
+                "version_added": "32"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates compat data for the following properties:

* [`filter`](https://developer.mozilla.org/docs/Web/CSS/filter)
* [`background-blend-mode`](https://developer.mozilla.org/docs/Web/CSS/background-blend-mode)
* [`isolation`](https://developer.mozilla.org/docs/Web/CSS/isolation)
* [`mix-blend-mode`](https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode)

A couple of macOS Safari values were changed to `true` from `7.1` to pass the linter. See the commit messages for details.