### PR TITLE
Fix issue 546: Allow multiple flags (rename flag to flags)

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -26,11 +26,13 @@
           },
           "firefox": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "dom.webcomponents.enabled",
-              "value_to_set": "true"
-            }
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
             "version_added": false

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -24,11 +24,13 @@
             {
               "version_added": "24",
               "version_removed": "28",
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "ie": {
@@ -96,11 +98,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -169,11 +173,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -242,11 +248,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -297,10 +305,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -343,11 +353,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -397,11 +409,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -463,11 +477,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -536,11 +552,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -609,11 +627,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -670,11 +690,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -736,11 +758,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -24,11 +24,13 @@
             {
               "version_added": "24",
               "version_removed": "28",
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "ie": {
@@ -96,11 +98,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -169,11 +173,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -24,11 +24,13 @@
             {
               "version_added": "24",
               "version_removed": "28",
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "ie": {
@@ -96,11 +98,13 @@
               {
                 "version_added": "24",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -12,11 +12,13 @@
           },
           "firefox": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "dom.gamepad-extensions.enabled",
-              "value_to_set": "true"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              }
+            ],
             "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
           },
           "ie": {
@@ -65,11 +67,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -119,11 +123,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {

--- a/api/GamepadPose.json
+++ b/api/GamepadPose.json
@@ -12,11 +12,13 @@
           },
           "firefox": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "dom.gamepad-extensions.enabled",
-              "value_to_set": "true"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.gamepad-extensions.enabled",
+                "value_to_set": "true"
+              }
+            ],
             "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
           },
           "ie": {
@@ -65,11 +67,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -119,11 +123,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -173,11 +179,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -227,11 +235,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -281,11 +291,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -335,11 +347,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -389,11 +403,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {
@@ -443,11 +459,13 @@
             },
             "firefox": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.gamepad-extensions.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
             },
             "ie": {

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -14,11 +14,13 @@
             {
               "version_added": "53",
               "version_removed": "55",
-              "flag": {
-                "type": "preference",
-                "name": "dom.IntersectionObserver.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             {
               "version_added": "55"
@@ -58,11 +60,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -102,11 +106,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -146,11 +152,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -190,11 +198,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -235,11 +245,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -279,11 +291,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -324,11 +338,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -369,11 +385,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -14,11 +14,13 @@
             {
               "version_added": "53",
               "version_removed": "55",
-              "flag": {
-                "type": "preference",
-                "name": "dom.IntersectionObserver.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.IntersectionObserver.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             {
               "version_added": "55"
@@ -57,11 +59,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -101,11 +105,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -145,11 +151,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -189,11 +197,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -233,11 +243,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -277,11 +289,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"
@@ -321,11 +335,13 @@
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.IntersectionObserver.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55"

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -25,11 +25,13 @@
             },
             {
               "version_added": "41",
-              "flag": {
-                "type": "preference",
-                "name": "dom.w3c_pointer_events.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "firefox_android": [
@@ -38,11 +40,13 @@
             },
             {
               "version_added": "41",
-              "flag": {
-                "type": "preference",
-                "name": "dom.w3c_pointer_events.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "ie": [
@@ -101,11 +105,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -114,11 +120,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [
@@ -177,11 +185,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -190,11 +200,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -245,11 +257,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -258,11 +272,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [
@@ -320,11 +336,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -333,11 +351,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [
@@ -395,11 +415,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -408,11 +430,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [
@@ -470,11 +494,13 @@
               },
               {
                 "version_added": "54",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -483,11 +509,13 @@
               },
               {
                 "version_added": "54",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -538,11 +566,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -551,11 +581,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -606,11 +638,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -619,11 +653,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -674,11 +710,13 @@
               },
               {
                 "version_added": "54",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -687,11 +725,13 @@
               },
               {
                 "version_added": "54",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -742,11 +782,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -755,11 +797,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [
@@ -817,11 +861,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -830,11 +876,13 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -51,10 +53,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -97,10 +101,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -143,10 +149,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -189,10 +197,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -235,10 +245,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -281,10 +293,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -327,10 +341,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -373,10 +389,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -419,10 +437,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -465,10 +485,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -551,10 +573,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -630,10 +654,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -676,10 +702,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -722,10 +750,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -768,10 +798,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -814,10 +846,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -860,10 +894,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -906,10 +942,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -51,10 +53,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -97,10 +101,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -143,10 +149,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -189,10 +197,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -235,10 +245,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -52,10 +54,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -98,10 +102,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -144,10 +150,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -51,10 +53,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -177,10 +181,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -256,10 +262,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -335,10 +343,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -85,10 +87,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -131,10 +135,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -177,10 +183,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -223,10 +231,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -52,10 +54,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -98,10 +102,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -144,10 +150,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -190,10 +198,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -236,10 +246,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -282,10 +294,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -328,10 +342,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -51,10 +53,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -97,10 +101,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -143,10 +149,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -51,10 +53,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -97,10 +101,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -209,10 +215,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -255,10 +263,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -301,10 +311,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -347,10 +359,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": true,
-            "flag": {
-              "type": "preference",
-              "name": "WebVR"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebVR"
+              }
+            ],
             "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
           },
           "edge": {
@@ -51,10 +53,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -97,10 +101,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {
@@ -143,10 +149,12 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "WebVR"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR"
+                }
+              ],
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "edge": {

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -23,11 +23,13 @@
             {
               "version_added": true,
               "version_removed": "53",
-              "flag": {
-                "type": "preference",
-                "name": "webgl.enable-debug-renderer-info",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "webgl.enable-debug-renderer-info",
+                  "value_to_set": "true"
+                }
+              ]
             },
             {
               "version_added": "53"

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -21,11 +21,13 @@
           },
           "firefox": {
             "version_added": "30",
-            "flag": {
-              "type": "preference",
-              "name": "webgl.enable-privileged-extensions",
-              "value_to_set": "true"
-            },
+            "flags": [
+              {
+                "type": "preference",
+                "name": "webgl.enable-privileged-extensions",
+                "value_to_set": "true"
+              }
+            ],
             "notes": [
               "The extension is activated by default to privileged contexts (chrome context)."
             ]
@@ -76,11 +78,13 @@
             },
             "firefox": {
               "version_added": "30",
-              "flag": {
-                "type": "preference",
-                "name": "webgl.enable-privileged-extensions",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "webgl.enable-privileged-extensions",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": [
                 "The extension is activated by default to privileged contexts (chrome context)."
               ]

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -24,11 +24,13 @@
               "prefix": "MOZ_",
               "version_added": true,
               "version_removed": "28",
-              "flag": {
-                "type": "preference",
-                "name": "webgl.enable-draft-extensions",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "webgl.enable-draft-extensions",
+                  "value_to_set": "true"
+                }
+              ]
             },
             {
               "version_added": "28"
@@ -83,11 +85,13 @@
                 "prefix": "MOZ_",
                 "version_added": true,
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "webgl.enable-draft-extensions",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "webgl.enable-draft-extensions",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "28"

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "49",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -77,11 +77,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -1225,11 +1227,13 @@
               },
               "firefox": {
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "gfx.offscreencanvas.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": false
@@ -1614,11 +1618,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -68,11 +68,13 @@
             },
             "firefox": {
               "version_added": "44",
-              "flag": {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/compat-data-schema.md
+++ b/compat-data-schema.md
@@ -228,9 +228,9 @@ In some cases features are named entirely differently and not just prefixed. Exa
 }
 ```
 
-#### `flag`
-An optional object indicating what kind of flags must be set for this feature to work.
-It consists of three properties:
+#### `flags`
+An optional array of objects indicating what kind of flags must be set for this feature to work. Usually this array will have one item, but there are cases where two or more flags can be required to activate a feature.
+An object in the `flags` array consists of three properties:
 * `type` (mandatory): an enum that indicates the flag type:
   * `preference` a flag the user can set (like in `about:config` in Firefox).
   * `compile_flag` a flag to be set before compiling the browser.
@@ -239,14 +239,36 @@ It consists of three properties:
 * `value_to_set` (optional): representing the actual value to set the flag to.
 It is a string, that may be converted to the right type
 (that is `true` or `false` for Boolean value, or `4` for an integer value). It doesn't need to be enclosed in `<code>` tags.
+
+Example for one flag required:
 ```json
 {
   "version_added": true,
-  "flag": {
-    "type": "preference",
-    "name": "browser.flag.name",
-    "value_to_set": "true"
-  }
+  "flags": [
+    {
+      "type": "preference",
+      "name": "browser.flag.name",
+      "value_to_set": "true"
+    }
+  ]
+}
+```
+Example for two flags required:
+```json
+{
+  "version_added": true,
+  "flags": [
+    {
+      "type": "preference",
+      "name": "dom.streams.enabled",
+      "value_to_set": "true"
+    },
+    {
+      "type": "preference",
+      "name": "javascript.options.streams",
+      "value_to_set": "true"
+    },
+  ]
 }
 ```
 

--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -8,14 +8,19 @@
       "properties": {
         "prefix": { "type": "string" },
         "alternative_name": { "type": "string" },
-        "flag": { "type": "object",
-          "properties": {
-            "type": { "type": "string", "enum": ["preference", "compile_flag", "runtime_flag"] },
-            "name": { "type": "string" },
-            "value_to_set": { "type": "string"}
-          },
-          "additionalProperties": false,
-          "required": ["type", "name"]
+        "flags": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["preference", "compile_flag", "runtime_flag"] },
+              "name": { "type": "string" },
+              "value_to_set": { "type": "string"}
+            },
+            "additionalProperties": false,
+            "required": ["type", "name"]
+          }
         },
         "partial_implementation": { "type": "boolean" },
         "version_added": { "$ref": "#/definitions/version_value" },

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -122,11 +122,13 @@
                 },
                 {
                   "version_added": "35",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.downloadable_fonts.woff2.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "gfx.downloadable_fonts.woff2.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -135,11 +137,13 @@
                 },
                 {
                   "version_added": "35",
-                  "flag": {
-                    "type": "preference",
-                    "name": "gfx.downloadable_fonts.woff2.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "gfx.downloadable_fonts.woff2.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -27,11 +27,13 @@
               },
               {
                 "version_added": "24",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -40,11 +42,13 @@
               },
               {
                 "version_added": "24",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -95,11 +99,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -108,11 +114,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -164,11 +172,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -177,11 +187,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -232,11 +244,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -245,11 +259,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -301,11 +317,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -314,11 +332,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -370,11 +390,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -383,11 +405,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -439,11 +463,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -452,11 +478,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -508,11 +536,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -521,11 +551,13 @@
                 },
                 {
                   "version_added": "24",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -51,11 +51,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -73,11 +75,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -28,11 +28,13 @@
               {
                 "version_added": "17",
                 "version_removed": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.supports-rule.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.supports-rule.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -42,11 +44,13 @@
               {
                 "version_added": "17",
                 "version_removed": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.supports-rule.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.supports-rule.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -49,11 +49,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -67,11 +69,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -45,20 +45,24 @@
               {
                 "version_removed": true,
                 "version_added": "18",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -73,20 +77,24 @@
               {
                 "version_removed": true,
                 "version_added": "18",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -40,11 +40,13 @@
               {
                 "version_added": "18",
                 "version_removed": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-webkit-",
@@ -53,11 +55,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": {

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -50,11 +50,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -72,11 +74,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -61,11 +61,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -83,11 +85,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -61,11 +61,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -83,11 +85,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -61,11 +61,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -83,11 +85,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -61,11 +61,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -83,11 +85,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -61,11 +61,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -83,11 +85,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -61,11 +61,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -83,11 +85,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -61,11 +61,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -83,11 +85,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -62,11 +62,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -84,11 +86,13 @@
               {
                 "version_added": "44",
                 "prefix": "-webkit-",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -10,10 +10,12 @@
             },
             "chrome": {
               "version_added": "47",
-              "flag": {
-                "type": "preference",
-                "name": "Enable Experimental Web Platform Features"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": null

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -50,11 +50,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "45",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -72,11 +74,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -18,11 +18,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -32,11 +34,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -44,11 +44,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -44,11 +44,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -57,11 +57,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -82,11 +84,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {
@@ -35,11 +37,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {
@@ -35,11 +37,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {
@@ -35,11 +37,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -30,11 +32,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {
@@ -35,11 +37,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {
@@ -35,11 +37,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               },
               {

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               }
             ],
@@ -31,11 +33,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Enabled by default since Firefox 41."
               }
             ],

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -17,11 +17,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -30,11 +32,13 @@
               },
               {
                 "version_added": "38",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -44,11 +44,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -44,11 +44,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -46,11 +46,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": {

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -62,11 +62,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -85,11 +87,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -138,11 +138,13 @@
                 {
                   "version_added": "47",
                   "version_removed": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-shapes.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-shapes.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -152,11 +154,13 @@
                 {
                   "version_added": "47",
                   "version_removed": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-shapes.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-shapes.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -207,11 +211,13 @@
                 },
                 {
                   "version_added": "47",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-shapes.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-shapes.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -220,11 +226,13 @@
                 },
                 {
                   "version_added": "47",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-shapes.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-shapes.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -453,10 +453,12 @@
                 },
                 {
                   "version_added": "52",
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "chrome_android": {
@@ -479,10 +481,12 @@
               },
               "opera": {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -63,10 +63,12 @@
                 },
                 {
                   "version_added": "48",
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "chrome_android": {
@@ -86,11 +88,13 @@
                   "version_added": "29",
                   "version_removed": "55",
                   "notes": "From Firefox 29 until Firefox 31, this feature was implemented by the <code>var-variablename</code> syntax.",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.variables.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.variables.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -101,11 +105,13 @@
                   "version_added": "29",
                   "version_removed": "55",
                   "notes": "From Firefox 29 until Firefox 31, this feature was implemented by the <code>var-variablename</code> syntax.",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.variables.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.variables.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -274,11 +274,13 @@
                 {
                   "version_added": "18",
                   "version_removed": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.flexbox.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": {
@@ -347,11 +349,13 @@
                 {
                   "version_added": "18",
                   "version_removed": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.flexbox.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": {
@@ -556,11 +560,13 @@
               },
               "firefox": {
                 "version_added": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.ruby.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.ruby.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": null
@@ -698,10 +704,12 @@
               },
               "chrome": {
                 "version_added": "58",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               },
               "chrome_android": {
                 "version_added": null
@@ -719,11 +727,13 @@
                 {
                   "version_added": true,
                   "version_removed": "53",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.display-contents.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.display-contents.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": {

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -52,11 +52,13 @@
               {
                 "partial_implementation": true,
                 "version_added": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.filters.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.filters.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-webkit-",
@@ -65,11 +67,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "46",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -79,11 +83,13 @@
               {
                 "partial_implementation": true,
                 "version_added": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.filters.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.filters.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-webkit-",
@@ -92,11 +98,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "46",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -39,20 +39,24 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "18",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -67,20 +71,24 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "18",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -35,11 +35,13 @@
               {
                 "version_added": "18",
                 "version_removed": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-webkit-",
@@ -48,11 +50,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -31,11 +31,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -49,11 +51,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -35,11 +35,13 @@
               {
                 "version_added": "18",
                 "version_removed": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -50,11 +52,13 @@
               {
                 "version_added": "18",
                 "version_removed": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -42,20 +42,24 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "18",
                 "version_removed": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -73,20 +77,24 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "18",
                 "version_removed": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -59,20 +59,24 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "18",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -28,11 +28,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -42,11 +44,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",
@@ -45,11 +47,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -10,10 +10,12 @@
             },
             "chrome": {
               "version_added": "43",
-              "flag": {
-                "type": "preference",
-                "name": "Enable experimental Web Platform features"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": null
@@ -42,10 +44,12 @@
             },
             "opera": {
               "version_added": "30",
-              "flag": {
-                "type": "preference",
-                "name": "Enable experimental Web Platform features"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "opera_android": {
               "version_added": null

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "33",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": {

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -97,11 +101,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -111,11 +117,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -168,11 +176,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -182,11 +192,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -239,11 +251,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -253,11 +267,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -310,11 +326,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -324,11 +342,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -381,11 +401,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -395,11 +417,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -452,11 +476,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -466,11 +492,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/font-variant-east-asian.json
+++ b/css/properties/font-variant-east-asian.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -39,11 +39,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -53,11 +55,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "24",
                 "version_removed": "34",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.font-features.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-features.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -218,11 +218,13 @@
                 {
                   "version_added": "33",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -232,11 +234,13 @@
                 {
                   "version_added": "33",
                   "version_removed": "34",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-features.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/css/properties/grid-area.json
+++ b/css/properties/grid-area.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": [
@@ -56,11 +60,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -69,11 +75,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -86,10 +94,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-auto-flow.json
+++ b/css/properties/grid-auto-flow.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": [
@@ -56,11 +60,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -69,11 +75,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -86,10 +94,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-column-end.json
+++ b/css/properties/grid-column-end.json
@@ -11,10 +11,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome": [
@@ -23,10 +25,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -35,10 +39,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -53,11 +59,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -66,11 +74,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -82,10 +92,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-column-gap.json
+++ b/css/properties/grid-column-gap.json
@@ -11,10 +11,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome": [
@@ -23,10 +25,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -35,10 +39,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -53,11 +59,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -66,11 +74,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -82,10 +92,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-column-start.json
+++ b/css/properties/grid-column-start.json
@@ -11,10 +11,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome": [
@@ -23,10 +25,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -35,10 +39,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -53,11 +59,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -66,11 +74,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -82,10 +92,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-column.json
+++ b/css/properties/grid-column.json
@@ -11,10 +11,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome": [
@@ -23,10 +25,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -35,10 +39,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -53,11 +59,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -66,11 +74,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -82,10 +92,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-gap.json
+++ b/css/properties/grid-gap.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-row-end.json
+++ b/css/properties/grid-row-end.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-row-gap.json
+++ b/css/properties/grid-row-gap.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-row-start.json
+++ b/css/properties/grid-row-start.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-row.json
+++ b/css/properties/grid-row.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-template-areas.json
+++ b/css/properties/grid-template-areas.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {
@@ -109,10 +119,12 @@
                 },
                 {
                   "version_added": "29",
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "chrome_android": {
@@ -130,11 +142,13 @@
                 },
                 {
                   "version_added": "40",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -143,11 +157,13 @@
                 },
                 {
                   "version_added": "40",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -159,10 +175,12 @@
                 },
                 {
                   "version_added": "28",
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "opera_android": {
@@ -196,10 +214,12 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "chrome_android": {
@@ -218,11 +238,13 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -232,11 +254,13 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -248,10 +272,12 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "opera_android": {

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {
@@ -109,10 +119,12 @@
                 },
                 {
                   "version_added": "29",
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "chrome_android": {
@@ -130,11 +142,13 @@
                 },
                 {
                   "version_added": "40",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -143,11 +157,13 @@
                 },
                 {
                   "version_added": "40",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -159,10 +175,12 @@
                 },
                 {
                   "version_added": "28",
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "opera_android": {
@@ -196,10 +214,12 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "chrome_android": {
@@ -218,11 +238,13 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -232,11 +254,13 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -248,10 +272,12 @@
                 },
                 {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
                 }
               ],
               "opera_android": {

--- a/css/properties/grid-template.json
+++ b/css/properties/grid-template.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,12 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +62,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +80,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/grid.json
+++ b/css/properties/grid.json
@@ -14,10 +14,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "chrome_android": [
@@ -26,10 +28,12 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "edge": {
@@ -44,11 +48,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -57,11 +63,13 @@
               },
               {
                 "version_added": "40",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -73,10 +81,12 @@
               },
               {
                 "version_added": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
               }
             ],
             "opera_android": {

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -48,11 +48,13 @@
               {
                 "version_added": "18",
                 "version_removed": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "prefix": "-webkit-",
@@ -61,11 +63,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": {

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -32,11 +32,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -50,11 +52,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -32,11 +32,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -50,11 +52,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "20",
                 "version_removed": "52",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.masking.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.masking.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "20",
                 "version_removed": "52",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.masking.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.masking.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -30,11 +30,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -44,11 +46,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/offset-block-end.json
+++ b/css/properties/offset-block-end.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/offset-block-start.json
+++ b/css/properties/offset-block-start.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/offset-inline-end.json
+++ b/css/properties/offset-inline-end.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/offset-inline-start.json
+++ b/css/properties/offset-inline-start.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -50,20 +50,24 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "18",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -78,20 +82,24 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "18",
                 "version_removed": "28",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.flexbox.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -30,11 +30,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-padding-end",
@@ -48,11 +50,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-padding-end",

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -30,11 +30,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-padding-start",
@@ -48,11 +50,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "alternative_name": "-moz-padding-start",

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -49,11 +49,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "45",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -71,11 +73,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "45",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -54,11 +54,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "45",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -76,11 +78,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "45",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -125,11 +125,13 @@
                 {
                   "version_added": "26",
                   "version_removed": "48",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.sticky.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.sticky.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": {

--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -10,11 +10,13 @@
             },
             "chrome": {
               "version_added": "61",
-              "flag": {
-                "type": "preference",
-                "name": "Enable experimental web platform features",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental web platform features",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": null
@@ -36,11 +38,13 @@
             },
             "opera": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "Smooth Scrolling",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Smooth Scrolling",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "opera_android": {
               "version_added": false

--- a/css/properties/scroll-snap-coordinate.json
+++ b/css/properties/scroll-snap-coordinate.json
@@ -29,11 +29,13 @@
               },
               {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scroll-snap.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-snap.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -29,11 +29,13 @@
               },
               {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scroll-snap.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-snap.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -29,11 +29,13 @@
               },
               {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scroll-snap.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-snap.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -29,11 +29,13 @@
               },
               {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scroll-snap.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-snap.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/scroll-snap-type-x.json
+++ b/css/properties/scroll-snap-type-x.json
@@ -29,11 +29,13 @@
               },
               {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scroll-snap.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-snap.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/scroll-snap-type-y.json
+++ b/css/properties/scroll-snap-type-y.json
@@ -29,11 +29,13 @@
               },
               {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scroll-snap.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-snap.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -31,11 +31,13 @@
               },
               {
                 "version_added": "39",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scroll-snap.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-snap.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -23,21 +23,25 @@
             "firefox": {
               "partial_implementation": true,
               "version_added": "53",
-              "flag": {
-                "type": "preference",
-                "name": "layout.css.shape-outside.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.shape-outside.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "Firefox only supports values <code>&lt;shape-box&gt;</code>, <code>circle()</code>, and <code>ellipse()</code>."
             },
             "firefox_android": {
               "partial_implementation": true,
               "version_added": "53",
-              "flag": {
-                "type": "preference",
-                "name": "layout.css.shape-outside.enabled",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.shape-outside.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "Firefox only supports values <code>&lt;shape-box&gt;</code>, <code>circle()</code>, and <code>ellipse()</code>."
             },
             "ie": {
@@ -134,19 +138,23 @@
               },
               "firefox": {
                 "version_added": "54",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": "54",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false
@@ -192,19 +200,23 @@
               },
               "firefox": {
                 "version_added": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -12,11 +12,13 @@
               {
                 "version_added": "35",
                 "version_removed": "47",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "47"
@@ -26,11 +28,13 @@
               {
                 "version_added": "35",
                 "version_removed": "47",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "47"

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -35,30 +35,36 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-combine-upright.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-combine-upright.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "31",
                 "version_removed": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "26",
                 "version_removed": "31",
                 "alternative_name": "text-combine-horizontal",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -68,30 +74,36 @@
               },
               {
                 "version_added": "41",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-combine-upright.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-combine-upright.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "31",
                 "version_removed": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "26",
                 "version_removed": "31",
                 "alternative_name": "text-combine-horizontal",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -149,20 +161,24 @@
               },
               "firefox": {
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-combine-upright-digits.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-combine-upright-digits.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'> bug 1258635</a>)."
               },
               "firefox_android": {
                 "version_added": "48",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-combine-upright-digits.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-combine-upright-digits.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'> bug 1258635</a>)."
               },
               "ie": {

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -29,11 +29,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -43,11 +45,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -39,11 +39,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -53,11 +55,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -29,11 +29,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -43,11 +45,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -29,11 +29,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -43,11 +45,13 @@
               {
                 "version_added": "45",
                 "version_removed": "49",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.text-emphasis.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-emphasis.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -10,20 +10,24 @@
             },
             "chrome": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "Enable Experimental Web Platform Features",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "chrome_android": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "Enable Experimental Web Platform Features",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "edge": {
@@ -46,20 +50,24 @@
             },
             "opera": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "Enable Experimental Web Platform Features",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "opera_android": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "Enable Experimental Web Platform Features",
-                "value_to_set": "true"
-              },
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "safari": {

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -45,11 +45,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -59,11 +61,13 @@
               {
                 "version_added": "38",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -56,11 +56,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -28,11 +28,13 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.touch_action.enabled",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.touch_action.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
               }
             ],
@@ -42,11 +44,13 @@
               },
               {
                 "version_added": "29",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.touch_action.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.touch_action.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [
@@ -104,11 +108,13 @@
                 },
                 {
                   "version_added": "29",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.touch_action.enabled",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.touch_action.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
                 }
               ],
@@ -118,11 +124,13 @@
                 },
                 {
                   "version_added": "29",
-                  "flag": {
-                    "type": "preference",
-                    "name": "layout.css.touch_action.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.touch_action.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": [

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -26,20 +26,24 @@
               },
               {
                 "version_added": "43",
-                "flag": {
-                  "type": "preference",
-                  "name": "svg.transform-box.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "svg.transform-box.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "41",
                 "version_removed": "43",
-                "flag": {
-                  "type": "preference",
-                  "name": "svg.transform-origin.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "svg.transform-origin.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -48,20 +52,24 @@
               },
               {
                 "version_added": "43",
-                "flag": {
-                  "type": "preference",
-                  "name": "svg.transform-box.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "svg.transform-box.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "41",
                 "version_removed": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "svg.transform-origin.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "svg.transform-origin.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -48,11 +48,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -70,11 +72,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [
@@ -187,11 +191,13 @@
                 {
                   "version_added": "41",
                   "version_removed": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "svg.transform-origin.enabled",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "svg.transform-origin.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
                 }
               ],

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -49,11 +49,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -71,11 +73,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -42,11 +42,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -60,11 +62,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": [

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -65,11 +65,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -87,11 +89,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -65,11 +65,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -87,11 +89,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -65,11 +65,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -87,11 +89,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -65,11 +65,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -87,11 +89,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -70,11 +70,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -97,11 +99,13 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "44",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.prefixes.webkit",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/will-change.json
+++ b/css/properties/will-change.json
@@ -28,11 +28,13 @@
               {
                 "version_added": "31",
                 "version_removed": "43",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.will-change.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.will-change.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -43,11 +45,13 @@
               {
                 "version_added": "31",
                 "version_removed": "43",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.will-change.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.will-change.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -58,11 +58,13 @@
               {
                 "version_added": "36",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -73,11 +75,13 @@
               {
                 "version_added": "36",
                 "version_removed": "51",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.vertical-text.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -29,11 +29,13 @@
               },
               {
                 "version_added": "47",
-                "flag": {
-                  "type": "preference",
-                  "name": "full-screen-api.unprefix.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -43,11 +45,13 @@
               },
               {
                 "version_added": "47",
-                "flag": {
-                  "type": "preference",
-                  "name": "full-screen-api.unprefix.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -27,11 +27,13 @@
               },
               {
                 "version_added": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scope-pseudo.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scope-pseudo.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -40,11 +42,13 @@
               },
               {
                 "version_added": "20",
-                "flag": {
-                  "type": "preference",
-                  "name": "layout.css.scope-pseudo.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scope-pseudo.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -405,19 +405,23 @@
               },
               "firefox": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "browser.send_pings",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.send_pings",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "browser.send_pings",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.send_pings",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false

--- a/html/elements/content.json
+++ b/html/elements/content.json
@@ -21,20 +21,24 @@
               "version_added": false
             },
             "firefox": {
-              "flag": {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              },
-              "version_added": "33"
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "flag": {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              },
-              "version_added": "33"
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -684,11 +684,13 @@
                 {
                   "version_added": "32",
                   "version_removed": "52",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.image.srcset.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.image.srcset.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -698,11 +700,13 @@
                 {
                   "version_added": "32",
                   "version_removed": "52",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.image.srcset.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.image.srcset.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -32,11 +32,13 @@
             },
             "opera": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "Enable Experimental Web Platform Features",
-                "value_to_set": "true"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "opera_android": {
               "version_added": false

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -258,11 +258,13 @@
               },
               "opera": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "opera_android": {
                 "version_added": false

--- a/html/elements/picture.json
+++ b/html/elements/picture.json
@@ -27,11 +27,13 @@
               {
                 "version_added": "32",
                 "version_removed": "52",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.image.picture.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.image.picture.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,11 +43,13 @@
               {
                 "version_added": "32",
                 "version_removed": "52",
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.image.picture.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.image.picture.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -308,19 +308,23 @@
               },
               "firefox": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.moduleScripts.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.moduleScripts.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "dom.moduleScripts.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.moduleScripts.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false
@@ -505,19 +509,23 @@
                 },
                 "firefox": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.moduleScripts.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.moduleScripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.moduleScripts.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.moduleScripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "ie": {
                   "version_added": false

--- a/html/elements/shadow.json
+++ b/html/elements/shadow.json
@@ -21,20 +21,24 @@
               "version_added": false
             },
             "firefox": {
-              "flag": {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              },
-              "version_added": "33"
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "flag": {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              },
-              "version_added": "33"
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -121,11 +121,13 @@
                 },
                 {
                   "version_added": "33",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.image.picture.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -134,11 +136,13 @@
                 },
                 {
                   "version_added": "33",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.image.picture.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -235,11 +239,13 @@
                 },
                 {
                   "version_added": "33",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.image.picture.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -248,11 +254,13 @@
                 },
                 {
                   "version_added": "33",
-                  "flag": {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.image.picture.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -198,11 +198,13 @@
               "chrome": {
                 "version_added": "19",
                 "version_removed": "35",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable &lt;style scoped&gt;",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable &lt;style scoped&gt;",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "chrome_android": {
                 "version_added": false

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -29,11 +29,13 @@
               {
                 "version_added": "24",
                 "version_removed": "50",
-                "flag": {
-                  "type": "preference",
-                  "name": "media.webvtt.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webvtt.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -43,11 +45,13 @@
               {
                 "version_added": "24",
                 "version_removed": "50",
-                "flag": {
-                  "type": "preference",
-                  "name": "media.webvtt.enabled",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webvtt.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -97,11 +101,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -111,11 +117,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -166,11 +174,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -180,11 +190,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -235,11 +247,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -249,11 +263,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -304,11 +320,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -318,11 +336,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -423,11 +443,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -437,11 +459,13 @@
                 {
                   "version_added": "24",
                   "version_removed": "50",
-                  "flag": {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webvtt.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1139,19 +1139,23 @@
               },
               "firefox": {
                 "version_added": "49",
-                "flag": {
-                  "name": "security.csp.experimentalEnabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "name": "security.csp.experimentalEnabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": "49",
-                "flag": {
-                  "name": "security.csp.experimentalEnabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "name": "security.csp.experimentalEnabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -27,11 +27,13 @@
             "firefox": [
               {
                 "version_added": "57",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
               },
               {
@@ -41,21 +43,25 @@
               {
                 "version_added": "46",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
               {
                 "version_added": "57",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
               },
               {
@@ -65,11 +71,13 @@
               {
                 "version_added": "46",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -124,11 +132,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -138,21 +148,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -162,11 +176,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -222,11 +238,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -236,21 +254,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -260,11 +282,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -320,11 +344,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -334,21 +360,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -358,11 +388,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -418,11 +450,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -432,21 +466,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -456,11 +494,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -516,11 +556,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -530,21 +572,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -554,11 +600,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -614,11 +662,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -628,21 +678,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -652,11 +706,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -712,11 +768,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -726,21 +784,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -750,11 +812,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -810,11 +874,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -824,21 +890,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -848,11 +918,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -908,11 +980,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -922,21 +996,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -946,11 +1024,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -1006,11 +1086,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -1020,21 +1102,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -1044,11 +1130,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -1104,11 +1192,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -1118,21 +1208,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -1142,11 +1236,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -1202,11 +1298,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -1216,21 +1314,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -1240,11 +1342,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -675,10 +675,12 @@
                   {
                     "version_added": "55",
                     "version_removed": "60",
-                    "flag": {
-                      "type": "runtime_flag",
-                      "name": "--datetime-format-to-parts"
-                    }
+                    "flags": [
+                      {
+                        "type": "runtime_flag",
+                        "name": "--datetime-format-to-parts"
+                      }
+                    ]
                   }
                 ],
                 "chrome_android": {
@@ -1037,18 +1039,22 @@
                 },
                 "chrome": {
                   "version_added": "63",
-                  "flag": {
-                    "type": "runtime_flag",
-                    "name": "harmony-number-format-to-parts"
-                  },
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "harmony-number-format-to-parts"
+                    }
+                  ],
                   "notes": "Need to set the flag on the commandline via --js-flags"
                 },
                 "chrome_android": {
                   "version_added": "63",
-                  "flag": {
-                    "type": "runtime_flag",
-                    "name": "harmony-number-format-to-parts"
-                  },
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "harmony-number-format-to-parts"
+                    }
+                  ],
                   "notes": "Need to set the flag on the commandline via --js-flags"
                 },
                 "edge": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -27,11 +27,13 @@
             "firefox": [
               {
                 "version_added": "57",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
               },
               {
@@ -41,21 +43,25 @@
               {
                 "version_added": "46",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
               {
                 "version_added": "57",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                },
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
               },
               {
@@ -65,11 +71,13 @@
               {
                 "version_added": "46",
                 "version_removed": "55",
-                "flag": {
-                  "type": "preference",
-                  "name": "javascript.options.shared_memory",
-                  "value_to_set": "true"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.shared_memory",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {
@@ -124,11 +132,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -136,23 +146,27 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "53",
+                  "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -160,13 +174,15 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "53",
+                  "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -222,11 +238,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -236,21 +254,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -260,11 +282,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -320,11 +344,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -334,21 +360,25 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -358,11 +388,13 @@
                 {
                   "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {
@@ -418,11 +450,13 @@
               "firefox": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -430,23 +464,27 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "52",
+                  "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
                 {
                   "version_added": "57",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  },
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
                 },
                 {
@@ -454,13 +492,15 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "52",
+                  "version_added": "46",
                   "version_removed": "55",
-                  "flag": {
-                    "type": "preference",
-                    "name": "javascript.options.shared_memory",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "ie": {

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -19,10 +19,12 @@
             },
             "edge_mobile": {
               "version_added": true,
-              "flag": {
-                "type": "preference",
-                "name": "Experimental JavaScript Features"
-              }
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript Features"
+                }
+              ]
             },
             "firefox": {
               "version_added": "52",
@@ -75,10 +77,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -132,10 +136,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -188,10 +194,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -245,10 +253,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -303,10 +313,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -360,10 +372,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -416,10 +430,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -473,10 +489,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -530,10 +548,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -588,10 +608,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -644,10 +666,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -701,10 +725,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -758,10 +784,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -815,10 +843,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -873,10 +903,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -930,10 +962,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -986,10 +1020,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1043,10 +1079,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1100,10 +1138,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1157,10 +1197,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1214,10 +1256,12 @@
                 },
                 "edge_mobile": {
                   "version_added": true,
-                  "flag": {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Experimental JavaScript Features"
+                    }
+                  ]
                 },
                 "firefox": {
                   "version_added": "52",
@@ -1272,10 +1316,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -1380,10 +1426,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",
@@ -1488,10 +1536,12 @@
               },
               "edge_mobile": {
                 "version_added": true,
-                "flag": {
-                  "type": "preference",
-                  "name": "Experimental JavaScript Features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript Features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "52",

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -120,17 +120,21 @@
               },
               "edge": {
                 "version_added": "14",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Javascript features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Javascript features"
+                  }
+                ]
               },
               "edge_mobile": {
                 "version_added": "14",
-                "flag": {
-                  "type": "preference",
-                  "name": "Enable experimental Javascript features"
-                }
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Javascript features"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "34"

--- a/javascript/operators/pipeline.json
+++ b/javascript/operators/pipeline.json
@@ -23,17 +23,21 @@
             },
             "firefox": {
               "version_added": "58",
-              "flag": {
-                "name": "--enable-pipeline-operator",
-                "type": "compile_flag"
-              }
+              "flags": [
+                {
+                  "name": "--enable-pipeline-operator",
+                  "type": "compile_flag"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "58",
-              "flag": {
-                "name": "--enable-pipeline-operator",
-                "type": "compile_flag"
-              }
+              "flags": [
+                {
+                  "name": "--enable-pipeline-operator",
+                  "type": "compile_flag"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -596,10 +596,12 @@
                 },
                 {
                   "version_added": "15",
-                  "flag": {
-                    "name": "Experimental JavaScript Features",
-                    "type": "preference"
-                  }
+                  "flags": [
+                    {
+                      "name": "Experimental JavaScript Features",
+                      "type": "preference"
+                    }
+                  ]
                 }
               ],
               "edge_mobile": {
@@ -607,17 +609,21 @@
               },
               "firefox": {
                 "version_added": "54",
-                "flag": {
-                  "name": "dom.moduleScripts.enabled",
-                  "type": "preference"
-                }
+                "flags": [
+                  {
+                    "name": "dom.moduleScripts.enabled",
+                    "type": "preference"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": "54",
-                "flag": {
-                  "name": "dom.moduleScripts.enabled",
-                  "type": "preference"
-                }
+                "flags": [
+                  {
+                    "name": "dom.moduleScripts.enabled",
+                    "type": "preference"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false
@@ -769,10 +775,12 @@
               },
               {
                 "version_added": "15",
-                "flag": {
-                  "name": "Experimental JavaScript Features",
-                  "type": "preference"
-                }
+                "flags": [
+                  {
+                    "name": "Experimental JavaScript Features",
+                    "type": "preference"
+                  }
+                ]
               }
             ],
             "edge_mobile": {
@@ -780,17 +788,21 @@
             },
             "firefox": {
               "version_added": "54",
-              "flag": {
-                "name": "dom.moduleScripts.enabled",
-                "type": "preference"
-              }
+              "flags": [
+                {
+                  "name": "dom.moduleScripts.enabled",
+                  "type": "preference"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "54",
-              "flag": {
-                "name": "dom.moduleScripts.enabled",
-                "type": "preference"
-              }
+              "flags": [
+                {
+                  "name": "dom.moduleScripts.enabled",
+                  "type": "preference"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -1508,10 +1520,12 @@
               },
               {
                 "version_added": "15",
-                "flag": {
-                  "name": "Experimental JavaScript Features",
-                  "type": "preference"
-                }
+                "flags": [
+                  {
+                    "name": "Experimental JavaScript Features",
+                    "type": "preference"
+                  }
+                ]
               }
             ],
             "edge_mobile": {
@@ -1519,17 +1533,21 @@
             },
             "firefox": {
               "version_added": "54",
-              "flag": {
-                "name": "dom.moduleScripts.enabled",
-                "type": "preference"
-              }
+              "flags": [
+                {
+                  "name": "dom.moduleScripts.enabled",
+                  "type": "preference"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "54",
-              "flag": {
-                "name": "dom.moduleScripts.enabled",
-                "type": "preference"
-              }
+              "flags": [
+                {
+                  "name": "dom.moduleScripts.enabled",
+                  "type": "preference"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -134,11 +134,13 @@
                 {
                   "version_added": "35",
                   "version_removed": "47",
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable Experimental Web Platform Features",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 {
                   "version_added": "47",
@@ -153,11 +155,17 @@
                     "First note for a flag",
                     "Second note for a flag"
                   ],
-                  "flag": {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features",
-                    "value_to_set": "true"
-                  }
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable Experimental Web Platform Features",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "runtime_flag",
+                      "name": "--js-enable-cookies"
+                    }
+                  ]
                 },
                 {
                   "version_added": "47"


### PR DESCRIPTION
This renames the `flag` property to `flags` and changes it to an array of objects.
Fixes https://github.com/mdn/browser-compat-data/issues/546

**Please do not merge!** We will coordinate merge and release with a corresponding KumaScript PR so that MDN table generation doesn't break.

Please do review the data, semantic, and documentation changes, though (r+ but no merge).