### PR TITLE
Add compat data for CSS align-* properties

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -1,0 +1,445 @@
+{
+  "css": {
+    "properties": {
+      "align-content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9.2"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7.1"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "space-evenly": {
+          "__compat": {
+            "description": "<code>space-evenly</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "start_end": {
+          "__compat": {
+            "description": "<code>start</code> and <code>end</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "chrome": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "chrome_android": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "opera_android": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "left_right": {
+          "__compat": {
+            "description": "<code>left</code> and <code>right</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "chrome": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "chrome_android": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": true,
+                  "notes": "This value is recognized, but has no effect."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": true,
+                  "notes": "This value is recognized, but has no effect."
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "opera_android": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "baseline": {
+          "__compat": {
+            "description": "<code>baseline</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "first_last_baseline": {
+          "__compat": {
+            "description": "<code>first baseline</code> and <code>last baseline</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "stretch": {
+          "__compat": {
+            "description": "<code>stretch</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -1,0 +1,276 @@
+{
+  "css": {
+    "properties": {
+      "align-items": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "version_added": "21",
+              "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": "Multi-line flexbox has been supported since Firefox 28."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "version_removed": true,
+                "version_added": "18",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "20",
+                "notes": "Multi-line flexbox has been supported since Firefox 28."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "version_removed": true,
+                "version_added": "18",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": "In Internet Explorer 10 and 11, if column flex items have <code>align-items: center;</code> set on them and their content is too large, then they will overflow the bounds of their container. See <a href='https://github.com/philipwalton/flexbugs#2-column-flex-items-set-to-align-itemscenter-overflow-their-container'>Flexbug #2</a>."
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "first_last_baseline": {
+          "__compat": {
+            "description": "<code>first baseline</code> and <code>last baseline</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "start_end": {
+          "__compat": {
+            "description": "<code>start</code> and <code>end</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "left_right": {
+          "__compat": {
+            "description": "<code>left</code> and <code>right</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -1,0 +1,349 @@
+{
+  "css": {
+    "properties": {
+      "align-self": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": "Before Firefox 27, only single-line flexbox is supported."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "start_end": {
+          "__compat": {
+            "description": "<code>start</code> and <code>end</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "left_right": {
+          "__compat": {
+            "description": "<code>left</code> and <code>right</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "baseline": {
+          "__compat": {
+            "description": "<code>baseline</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "first_last_baseline": {
+          "__compat": {
+            "description": "<code>first baseline</code> and <code>last baseline</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "stretch": {
+          "__compat": {
+            "description": "<code>stretch</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates compat data for the following properties:

* [`align-content`](https://developer.mozilla.org/docs/Web/CSS/align-content)
* [`align-items`](https://developer.mozilla.org/docs/Web/CSS/align-items)
* [`align-self`](https://developer.mozilla.org/docs/Web/CSS/align-self)