### PR TITLE
Add <url> CSS type

### DIFF
--- a/css/types/url.json
+++ b/css/types/url.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "types": {
+      "url": {
+        "__compat": {
+          "description": "<code>&lt;url&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the `url()`/`<url>` [type](https://developer.mozilla.org/en-US/docs/Web/CSS/url#The_url()_functional_notation). Since this is pretty old, I presumed some values were `true` in the absence of data.