### PR TITLE
Make status properties boolean only

### DIFF
--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -56,9 +56,9 @@
     "status_statement": {
       "type": "object",
       "properties": {
-        "experimental": { "type": ["string", "boolean"] },
-        "standard_track": { "type": ["string", "boolean"] },
-        "deprecated": { "type": ["string", "boolean"] }
+        "experimental": { "type": "boolean" },
+        "standard_track": { "type": "boolean" },
+        "deprecated": { "type": "boolean" }
       },
       "required": ["experimental", "standard_track", "deprecated"],
       "additionalProperties": false


### PR DESCRIPTION
Our schema docs say these should be boolean, and it looks like there are booleans everywhere in the data. So, not sure why the schema allows strings.