### PR TITLE
Add note for tabs.discard

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1043,7 +1043,8 @@
                 "notes": [
                   "Only accepts a single tab ID as a parameter, not an array.",
                   "The tab ID argument is optional: if it is omitted, the browser discards the least important tab.",
-                  "The callback is passed a <code>Tab</code> object representing the tab that was discarded."
+                  "The callback is passed a <code>Tab</code> object representing the tab that was discarded.",
+                  "Tabs whose document contains a <a href='https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent'><code>beforeunload</code></a> listener that displays a prompt will be discarded."
                 ]
               },
               "edge": {
@@ -1060,7 +1061,8 @@
                 "notes": [
                   "Only accepts a single tab ID as a parameter, not an array.",
                   "The tab ID argument is optional: if it is omitted, the browser discards the least important tab.",
-                  "The callback is passed a <code>Tab</code> object representing the tab that was discarded."
+                  "The callback is passed a <code>Tab</code> object representing the tab that was discarded.",
+                  "Tabs whose document contains a <a href='https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent'><code>beforeunload</code></a> listener that displays a prompt will be discarded."
                 ]
               }
             }


### PR DESCRIPTION
Added a note for this comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1322485#c60.

I think the best way to handle this is to document Firefox behavior (don't discard these tabs) as "normal" (i.e. in the main body of the page) and Chrome/Opera's as "abnormal" (i.e. capture in a note.