### PR TITLE
Add compat data for justify-* CSS properties

### DIFF
--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -1,0 +1,425 @@
+{
+  "css": {
+    "properties": {
+      "justify-content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content",
+          "support": {
+            "webview_android": {
+              "version_added": true,
+              "notes": "Older versions of the specification treat absolutely positioned children as though they are 0 by 0 flex items. Later versions of the specification take them out of the flow and set their positions based on align and justify properties. Versions 52 and later implement the new behavior."
+            },
+            "chrome": [
+              {
+                "version_added": "29",
+                "notes": "Older versions of the specification treat absolutely positioned children as though they are 0 by 0 flex items. Later versions of the specification take them out of the flow and set their positions based on align and justify properties. Versions 52 and later implement the new behavior."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20",
+                "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
+              },
+              {
+                "version_added": "18",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.flexbox.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "space-evenly": {
+          "__compat": {
+            "description": "<code>space-evenly</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "start_end": {
+          "__compat": {
+            "description": "<code>start</code> and <code>end</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "left_right": {
+          "__compat": {
+            "description": "<code>left</code> and <code>left</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": true,
+                  "notes": "This value is recognized, but has no effect."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": true,
+                  "notes": "This value is recognized, but has no effect."
+                }
+              ],
+              "ie": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true,
+                "notes": "This value is recognized, but has no effect."
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "baseline": {
+          "__compat": {
+            "description": "<code>baseline</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "first_last_baseline": {
+          "__compat": {
+            "description": "<code>first baseline</code> and <code>last baseline</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "stretch": {
+          "__compat": {
+            "description": "<code>stretch</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "justify-items": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "justify-self": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates compat data for the following CSS properties:

* [`justify-content`](https://developer.mozilla.org/docs/Web/CSS/justify-content)
* [`justify-items`](https://developer.mozilla.org/docs/Web/CSS/justify-items)
* [`justify-self`](https://developer.mozilla.org/docs/Web/CSS/justify-self)

For `justify-content`, some data for mobile browsers was not retained from the original table. The table was plainly malformed (e.g., Firefox version numbers getting jumbled together with Android), so when I couldn't make sense of the values, I left them as `null`.