### PR TITLE
Add compat data for CSS table properties

### DIFF
--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -1,0 +1,159 @@
+{
+  "css": {
+    "properties": {
+      "caption-side": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caption-side",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "non_standard_values": {
+          "__compat": {
+            "description": "Non-standard values <code>left</code>, <code>right</code>, <code>top-outside</code>, and <code>bottom-outside</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "writing-mode_relative_values": {
+          "__compat": {
+            "description": "<code>top</code> and <code>bottom</code> are relative to the <code>writing-mode</code> value",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "42"
+              },
+              "firefox_android": {
+                "version_added": "42"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "empty-cells": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/empty-cells",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": "8"
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1.2"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/table-layout.json
+++ b/css/properties/table-layout.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "table-layout": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/table-layout",
+          "support": {
+            "webview_android": {
+              "version_added": "1.5"
+            },
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "9.8"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "vertical-align": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/vertical-align",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -1,0 +1,132 @@
+{
+  "css": {
+    "properties": {
+      "visibility": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/visibility",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4",
+              "notes": [
+                "Internet Explorer doesn't support <code>visibility: initial</code>.",
+                "Up to Internet Explorer 7, descendants of <code>hidden</code> elements will still be invisible even if they have <code>visibility</code> set to <code>visible</code>."
+              ]
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "collapse": {
+          "__compat": {
+            "description": "<code>collapse</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "62",
+                "notes": [
+                  "Chrome treats <code>visibility: collapse</code> like <code>hidden</code>, leaving a white gap.",
+                  "Chrome supports the <code>collapse</code> value only on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead' ><code>&lt;thead&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>, and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a>, but not on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements."
+                ]
+              },
+              "chrome_android": {
+                "version_added": true,
+                "notes": [
+                  "Chrome treats <code>visibility: collapse</code> like <code>hidden</code>, leaving a white gap.",
+                  "Chrome supports the <code>collapse</code> value only on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead' ><code>&lt;thead&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>, and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a>, but not on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements."
+                ]
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true,
+                "notes": "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set."
+              },
+              "firefox_android": {
+                "version_added": true,
+                "notes": "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set."
+              },
+              "ie": {
+                "version_added": true
+              },
+              "ie_mobile": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true,
+                "notes": "In Opera, <code>visibility: collapse</code> works on table elements, but doesn't hide a <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a> if it is adjacent to a visible <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>."
+              },
+              "opera_android": {
+                "version_added": true,
+                "notes": "In Opera, <code>visibility: collapse</code> works on table elements, but doesn't hide a <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a> if it is adjacent to a visible <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>."
+              },
+              "safari": {
+                "version_added": true,
+                "notes": [
+                  "Safari treats <code>visibility: collapse</code> like <code>hidden</code>, leaving a white gap.",
+                  "Safari supports the collapse value only on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead' ><code>&lt;thead&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>, and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a>, but not on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements."
+                ]
+              },
+              "safari_ios": {
+                "version_added": true,
+                "notes": [
+                  "Safari treats <code>visibility: collapse</code> like <code>hidden</code>, leaving a white gap.",
+                  "Safari supports the collapse value only on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead' ><code>&lt;thead&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>, and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a>, but not on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements."
+                ]
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the following table-related CSS properties:

* [`caption-side`](https://developer.mozilla.org/docs/Web/CSS/caption-side)
* [`empty-cells`](https://developer.mozilla.org/docs/Web/CSS/empty-cells)
* [`table-layout`](https://developer.mozilla.org/docs/Web/CSS/table-layout)
* [`vertical-align`](https://developer.mozilla.org/docs/Web/CSS/vertical-align)
* [`visibility`](https://developer.mozilla.org/docs/Web/CSS/visibility)
