### PR TITLE
Firefox 59 allows browserAction set* methods to accept null

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -245,6 +245,7 @@
           },
           "null": {
             "__compat": {
+              "description": "The <code>color</code> property of the <code>details</code> parameter can be set to <code>null</code>.",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -291,6 +292,7 @@
           },
           "null": {
             "__compat": {
+              "description": "The <code>text</code> property of the <code>details</code> parameter can be set to <code>null</code>.",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -358,6 +360,7 @@
           },
           "null": {
             "__compat": {
+              "description": "The <code>path</code> and <code>imageData</code> properties of the <code>details</code> parameter can be set to <code>null</code>.",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -401,6 +404,7 @@
           },
           "null": {
             "__compat": {
+              "description": "The <code>popup</code> property of the <code>details</code> parameter can be set to <code>null</code>.",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -444,6 +448,7 @@
           },
           "null": {
             "__compat": {
+              "description": "The <code>title</code> property of the <code>details</code> parameter can be set to <code>null</code>.",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -242,6 +242,27 @@
                 "version_added": true
               }
             }
+          },
+          "null": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "setBadgeText": {
@@ -265,6 +286,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          },
+          "null": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           }
@@ -313,6 +355,27 @@
                 }
               }
             }
+          },
+          "null": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "setPopup": {
@@ -335,6 +398,27 @@
                 "version_added": true
               }
             }
+          },
+          "null": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "setTitle": {
@@ -355,6 +439,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          },
+          "null": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           }


### PR DESCRIPTION
See [Bug 1419940](https://bugzilla.mozilla.org/show_bug.cgi?id=1419940).