### PR TITLE
Add compat data for place-* CSS properties

### DIFF
--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "place-content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-content",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "place-items": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-items",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "place-self": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-self",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the following CSS properties:

* [`place-content`](https://developer.mozilla.org/docs/Web/CSS/place-content)
* [`place-items`](https://developer.mozilla.org/docs/Web/CSS/place-items)
* [`place-self`](https://developer.mozilla.org/docs/Web/CSS/place-self)
