### PR TITLE
Add CSS variables

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -4,7 +4,7 @@
       "custom-property": {
         "__compat": {
           "description": "--*",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/custom-property",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/--*",
           "support": {
             "webview_android": {
               "version_added": "49"

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -1,0 +1,143 @@
+{
+  "css": {
+    "properties": {
+      "custom-property": {
+        "__compat": {
+          "description": "--*",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/custom-property",
+          "support": {
+            "webview_android": {
+              "version_added": "49"
+            },
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": "29"
+            },
+            "firefox_android": {
+              "version_added": "29"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "36"
+            },
+            "opera_android": {
+              "version_added": "36"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "var": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/var",
+            "description": "<code>var()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "50"
+              },
+              "chrome": [
+                {
+                  "version_added": "49"
+                },
+                {
+                  "version_added": "48",
+                  "flag": {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "edge_mobile": {
+                "version_added": "15"
+              },
+              "firefox": [
+                {
+                  "version_added": "31"
+                },
+                {
+                  "version_added": "29",
+                  "version_removed": "55",
+                  "notes": "From Firefox 29 until Firefox 31, this feature was implemented by the <code>var-variablename</code> syntax.",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.variables.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "31"
+                },
+                {
+                  "version_added": "29",
+                  "version_removed": "55",
+                  "notes": "From Firefox 29 until Firefox 31, this feature was implemented by the <code>var-variablename</code> syntax.",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.variables.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "36"
+              },
+              "opera_android": {
+                "version_added": "37"
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the compat data for the custom property ([`--*`](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)) and variable syntax ([`var()`](https://developer.mozilla.org/en-US/docs/Web/CSS/var)). A couple of notes on these, since they're a bit unusual:

* I named this `custom-property` because I figured naming it something with double dashes would be a kind of a nightmare. I'm open to other names though, if there's a better way to describe this.
* The `var()` syntax could be standalone, but I didn't think it warranted its own type (or a whole extra directory for `values` or something). It's entered as a feature on `--*` instead.
* The existing compat tables used Safari 9.3, but this isn't a valid release; I've changed those values to `true`.