### PR TITLE
Add compat data for box-* CSS properties

### DIFF
--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -1,0 +1,78 @@
+{
+  "css": {
+    "properties": {
+      "box-decoration-break": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-decoration-break",
+          "support": {
+            "webview_android": {
+              "version_added": true,
+              "notes": "This property is only supported for inline elements."
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "22",
+              "notes": "This property is only supported for inline elements."
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4",
+              "notes": "This property is only supported for inline elements."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "32"
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "partial_implementation": true,
+                "version_added": "15"
+              },
+              {
+                "version_added": "11.5",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "partial_implementation": true,
+                "version_added": "15"
+              },
+              {
+                "version_added": "11.5",
+                "version_removed": "15"
+              }
+            ],
+            "safari": {
+              "version_added": "6.1",
+              "notes": "This property is only supported for inline elements."
+            },
+            "safari_ios": {
+              "version_added": "7.1",
+              "notes": "This property is only supported for inline elements."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -53,7 +53,7 @@
             },
             "opera": [
               {
-                "partial_implementation": true,
+                "prefix": "-webkit-",
                 "version_added": "15"
               },
               {
@@ -63,7 +63,7 @@
             ],
             "opera_android": [
               {
-                "partial_implementation": true,
+                "prefix": "-webkit-",
                 "version_added": "15"
               },
               {

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -25,12 +25,26 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "32"
-            },
-            "firefox_android": {
-              "version_added": "32"
-            },
+            "firefox": [
+              {
+                "version_added": "32"
+              },
+              {
+                "alternative_name": "-moz-background-inline-policy",
+                "version_added": true,
+                "version_removed": "32"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "alternative_name": "-moz-background-inline-policy",
+                "version_added": true,
+                "version_removed": "32"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -7,11 +7,13 @@
           "support": {
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": true,
+              "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
             },
             "chrome": [
               {
-                "version_added": "10"
+                "version_added": "10",
+                "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
               },
               {
                 "prefix": "-webkit-",
@@ -29,12 +31,26 @@
             },
             "firefox": [
               {
-                "version_added": "4"
+                "version_added": "4",
+                "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
               },
               {
                 "prefix": "-moz-",
                 "version_added": "3.5",
                 "version_removed": "13"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
               }
             ],
             "firefox_android": {
@@ -42,20 +58,26 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
+              "notes": [
+                "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>.",
+                "Since version 5.5, Internet Explorer supports Microsoft's <a href='http://msdn.microsoft.com/en-us/library/ms532985%28VS.85,loband%29.aspx'>DropShadow</a> and <a href='http://msdn.microsoft.com/en-us/library/ms533086%28VS.85,loband%29.aspx'>Shadow Filter</a>. You can use this proprietary extension to cast a drop shadow (though the syntax and the effect are different from CSS3)"
+              ]
             },
             "ie_mobile": {
               "version_added": null
             },
             "opera": {
-              "version_added": "10.5"
+              "version_added": "10.5",
+              "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
             },
             "safari": [
               {
-                "version_added": "5.1"
+                "version_added": "5.1",
+                "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
               },
               {
                 "prefix": "-webkit-",
@@ -64,7 +86,8 @@
             ],
             "safari_ios": [
               {
-                "version_added": "5"
+                "version_added": "5",
+                "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -1,0 +1,318 @@
+{
+  "css": {
+    "properties": {
+      "box-shadow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-shadow",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "10"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "4"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "3.5",
+                "version_removed": "13"
+              }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9",
+              "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": [
+              {
+                "version_added": "5.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multiple_shadows": {
+          "__compat": {
+            "description": "Multiple shadows",
+            "support": {
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "chrome": [
+                {
+                  "version_added": "10"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1"
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "4"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3.5",
+                  "version_removed": "13"
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9",
+                "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": [
+                {
+                  "version_added": "5.1"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "3"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "5"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inset": {
+          "__compat": {
+            "description": "<code>inset</code>",
+            "support": {
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "chrome": [
+                {
+                  "version_added": "10"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1"
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "4"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3.5",
+                  "version_removed": "13"
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9",
+                "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": [
+                {
+                  "version_added": "5.1"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "5"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "5"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "spread_radius": {
+          "__compat": {
+            "description": "Spread radius",
+            "support": {
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "chrome": [
+                {
+                  "version_added": "10"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1"
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "4"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3.5",
+                  "version_removed": "13"
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9",
+                "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": [
+                {
+                  "version_added": "5.1"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "5"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "5"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -1,0 +1,184 @@
+{
+  "css": {
+    "properties": {
+      "box-sizing": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-sizing",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "4",
+                "notes": "<code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.1"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "10",
+                "notes": "<code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1",
+                "notes": "Before Firefox 23, <code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "Before Firefox 23, <code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": "8",
+              "notes": "<code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": [
+              {
+                "version_added": "5.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3",
+                "version_removed": true
+              }
+            ],
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "padding-box": {
+          "__compat": {
+            "description": "<code>padding-box</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "50"
+              },
+              "firefox_android": {
+                "version_added": "4",
+                "version_removed": "50"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the `box-*` properties:

* [`box-decoration-break`](https://developer.mozilla.org/docs/Web/CSS/box-decoration-break)
* [`box-shadow`](https://developer.mozilla.org/docs/Web/CSS/box-shadow)
* [`box-sizing`](https://developer.mozilla.org/docs/Web/CSS/box-sizing)
