### PR TITLE
Update Float32Array() without new throws

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "40"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -86,7 +86,7 @@
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": true

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,7 +80,7 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
@@ -89,7 +89,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -55,10 +55,10 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -62,13 +62,13 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -80,16 +80,16 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
Chrome, Opera and Edge all throw an error on ```Float32Array(5)```. No error is thrown in IE11.