### PR TITLE
Add compat for module attr of script element

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -534,10 +534,20 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "dom.moduleScripts.enabled",
+                    "value_to_set": "true"
+                  }
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "dom.moduleScripts.enabled",
+                    "value_to_set": "true"
+                  }
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
Fix: <script type="module"> is available behind the "dom.moduleScripts.enabled"