### PR TITLE
Add compat data for CSS paged media

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "at-rules": {
+      "page": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "19"
+            },
+            "firefox_android": {
+              "version_added": "19"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "6"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -50,6 +50,162 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "left_pseudo_class": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:left",
+            "description": "<code>:left</code> pseudo-class",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "9.2"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "right_pseudo_class": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:right",
+            "description": "<code>:right</code> pseudo-class",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "9.2"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "first_pseudo_class": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:first",
+            "description": "<code>:first</code> pseudo-class",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "9.2"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -1,15 +1,16 @@
 {
   "css": {
-    "at-rules": {
-      "page": {
+    "selectors": {
+      "first": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page",
+          "description": "First page pseudo-class (<code>:first</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:first",
           "support": {
             "webview_android": {
               "version_added": null
             },
             "chrome": {
-              "version_added": "2"
+              "version_added": null
             },
             "chrome_android": {
               "version_added": null
@@ -21,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "19"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "19"
+              "version_added": false
             },
             "ie": {
               "version_added": "8"
@@ -33,13 +34,13 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "6"
+              "version_added": "9.2"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -1,15 +1,16 @@
 {
   "css": {
-    "at-rules": {
-      "page": {
+    "selectors": {
+      "left": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page",
+          "description": "Left-hand page pseudo-class (<code>:left</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:left",
           "support": {
             "webview_android": {
               "version_added": null
             },
             "chrome": {
-              "version_added": "2"
+              "version_added": null
             },
             "chrome_android": {
               "version_added": null
@@ -21,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "19"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "19"
+              "version_added": false
             },
             "ie": {
               "version_added": "8"
@@ -33,13 +34,13 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "6"
+              "version_added": "9.2"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -1,15 +1,16 @@
 {
   "css": {
-    "at-rules": {
-      "page": {
+    "selectors": {
+      "right": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page",
+          "description": "Right-hand page pseudo-class (<code>:right</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:right",
           "support": {
             "webview_android": {
               "version_added": null
             },
             "chrome": {
-              "version_added": "2"
+              "version_added": null
             },
             "chrome_android": {
               "version_added": null
@@ -21,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "19"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "19"
+              "version_added": false
             },
             "ie": {
               "version_added": "8"
@@ -33,13 +34,13 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "6"
+              "version_added": "9.2"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
This PR migrates compat data for the [`@page`](https://developer.mozilla.org/en-US/docs/Web/CSS/%40page) CSS at-rule and the [`:left`](https://developer.mozilla.org/en-US/docs/Web/CSS/:left) [`:right`](https://developer.mozilla.org/en-US/docs/Web/CSS/:right) and [`:first`](https://developer.mozilla.org/en-US/docs/Web/CSS/:first) pseudo-classes.

I added the pseudo-classes as features of `@page` since the pseudo-classes appear to be only for use with that at-rule. If they belong in their own files somewhere, let me know and I'll move them. Thanks!