### PR TITLE
Add compat data for CSS shape types

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -1,0 +1,163 @@
+{
+  "css": {
+    "types": {
+      "basic-shape": {
+        "__compat": {
+          "description": "<code>&lt;basic-shape&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "47"
+            },
+            "firefox_android": {
+              "version_added": "47"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "inset": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#inset()",
+            "description": "<code>inset()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "animation": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#Interpolation_of_basic_shapes",
+            "description": "Animation",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/shape.json
+++ b/css/types/shape.json
@@ -28,8 +28,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": "5.5",
-              "notes": "For Internet Explorer versions 5.5 through 7, the <code>rect()</code> function uses spaces (instead of commas) to separate parameters. For Internet Explorer 8 and later versions, only the standard comma-separated syntax is supported."
+              "version_added": "5.5"
             },
             "ie_mobile": {
               "version_added": null
@@ -51,6 +50,58 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        },
+        "rect": {
+          "__compat": {
+            "description": "<code>rect()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "5.5",
+                "notes": "For Internet Explorer versions 5.5 through 7, the <code>rect()</code> function uses spaces (instead of commas) to separate parameters. For Internet Explorer 8 and later versions, only the standard comma-separated syntax is supported."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
           }
         }
       }

--- a/css/types/shape.json
+++ b/css/types/shape.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "types": {
+      "shape": {
+        "__compat": {
+          "description": "<code>&lt;shape&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "5.5",
+              "notes": "For Internet Explorer versions 5.5 through 7, the <code>rect()</code> function uses spaces (instead of commas) to separate parameters. For Internet Explorer 8 and later versions, only the standard comma-separated syntax is supported."
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1.3"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the compat data for the [`<shape>`](https://developer.mozilla.org/en-US/docs/Web/CSS/shape) (aka <code>rect()</code>) and [`<basic-shape>`](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape) CSS types.

Honestly, the data here looks a little bit sketchy, since there's significant discrepancies between desktop and mobile browsers. Happy to make any desired changes.