### PR TITLE
Add missing description to the `<image>` CSS type

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -3,6 +3,7 @@
     "types": {
       "image": {
         "__compat": {
+          "description": "<code>&lt;image&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image",
           "support": {
             "webview_android": {


### PR DESCRIPTION
While I was working on #719, I noticed that `<image>` was missing a formatted description, which was the only CSS type to not have one, I think. This fills in that gap.