### PR TITLE
Add compat data for CSS clip- properties

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -1,0 +1,372 @@
+{
+  "css": {
+    "properties": {
+      "clip-path": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip-path",
+          "description": "On HTML elements",
+          "support": {
+            "webview_android": {
+              "version_added": "55"
+            },
+            "chrome": [
+              {
+                "version_added": "55"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "24"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "svg": {
+          "__compat": {
+            "description": "On SVG elements",
+            "support": {
+              "webview_android": {
+                "version_added": "55"
+              },
+              "chrome": {
+                "version_added": "55"
+              },
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": {
+                "version_added": "15",
+                "notes": "Edge only supports clip paths defined by <code>url()</code>."
+              },
+              "edge_mobile": {
+                "version_added": "12",
+                "notes": "Edge only supports clip paths defined by <code>url()</code>."
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": true,
+                "notes": "Internet Explorer only supports clip paths defined by <code>url()</code>."
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "42"
+              },
+              "opera_android": {
+                "version_added": "42"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "basic_shape": {
+          "__compat": {
+            "description": "<code>&lt;basic-shape&gt;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "55"
+              },
+              "chrome": {
+                "version_added": "55"
+              },
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "54"
+                },
+                {
+                  "version_added": "47",
+                  "version_removed": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.clip-path-shapes.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "54"
+                },
+                {
+                  "version_added": "47",
+                  "version_removed": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.clip-path-shapes.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "42"
+              },
+              "opera_android": {
+                "version_added": "42"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inset": {
+          "__compat": {
+            "description": "<code>inset()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "55"
+              },
+              "chrome": {
+                "version_added": "55"
+              },
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "54"
+                },
+                {
+                  "version_added": "47",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.clip-path-shapes.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "54"
+                },
+                {
+                  "version_added": "47",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.clip-path-shapes.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "42"
+              },
+              "opera_android": {
+                "version_added": "42"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "animations": {
+          "__compat": {
+            "description": "Animations",
+            "support": {
+              "webview_android": {
+                "version_added": "55"
+              },
+              "chrome": {
+                "version_added": "55"
+              },
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "42"
+              },
+              "opera_android": {
+                "version_added": "42"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fill_and_stroke_box": {
+          "__compat": {
+            "description": "<code>fill-box</code> and <code>stroke-box</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "51",
+                "notes": "This value was supported before Firefox 51, but as an alias to <code>border-box</code>."
+              },
+              "firefox_android": {
+                "version_added": "51",
+                "notes": "This value was supported before Firefox 51, but as an alias to <code>border-box</code>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/clip.json
+++ b/css/properties/clip.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "properties": {
+      "clip": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4",
+              "notes": "Before Internet Explorer 7, Internet Explorer incorrectly interprets <code>clip: auto</code> as <code>clip: rect(auto, auto, auto, auto)</code>."
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1",
+              "notes": "Safari incorrectly interprets <code>clip: auto</code> as <code>clip: rect(auto, auto, auto, auto)</code>."
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds [`clip`](https://developer.mozilla.org/docs/Web/CSS/clip) and [`clip-path`](https://developer.mozilla.org/docs/Web/CSS/clip-path)

I'm a bit concerned about how the data for `clip-path` plays along with the data added in #719. I _think_ these are talking about two different things (i.e., implementation of the type generally versus its application in a property alone), but I'm not certain about that. If the data here should be partly subsumed by the data in #719, let me know and we can take steps to reconcile the two. Thanks!