### PR TITLE
Add compat data for CSS Shapes properties

### DIFF
--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "properties": {
+      "shape-image-threshold": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "59"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/shape-margin.json
+++ b/css/properties/shape-margin.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "properties": {
+      "shape-margin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-margin",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -1,0 +1,247 @@
+{
+  "css": {
+    "properties": {
+      "shape-outside": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-outside",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "partial_implementation": true,
+              "version_added": "53",
+              "flag": {
+                "type": "preference",
+                "name": "layout.css.shape-outside.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "Firefox only supports values <code>&lt;shape-box&gt;</code>, <code>circle()</code>, and <code>ellipse()</code>."
+            },
+            "firefox_android": {
+              "partial_implementation": true,
+              "version_added": "53",
+              "flag": {
+                "type": "preference",
+                "name": "layout.css.shape-outside.enabled",
+                "value_to_set": "true"
+              },
+              "notes": "Firefox only supports values <code>&lt;shape-box&gt;</code>, <code>circle()</code>, and <code>ellipse()</code>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "8"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "gradient": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient",
+            "description": "<code>&lt;gradient&gt;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inset": {
+          "__compat": {
+            "description": "<code>inset()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "54",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.shape-outside.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              "firefox_android": {
+                "version_added": "54",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.shape-outside.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "polygon": {
+          "__compat": {
+            "description": "<code>polygon()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.shape-outside.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              "firefox_android": {
+                "version_added": "55",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.shape-outside.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the following CSS properties:

* [`shape-image-threshold`](https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold)
* [`shape-margin`](https://developer.mozilla.org/docs/Web/CSS/shape-margin)
* [`shape-outside`](https://developer.mozilla.org/docs/Web/CSS/shape-outside)
