### PR TITLE
Add compat data for text formatting CSS properties

### DIFF
--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "letter-spacing": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/letter-spacing",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "svg": {
+          "__compat": {
+            "description": "SVG support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -1,0 +1,112 @@
+{
+  "css": {
+    "properties": {
+      "overflow-wrap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-wrap",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "1"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": false
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": false
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "49"
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "3.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "4"
+              }
+            ],
+            "ie": {
+              "alternative_name": "word-wrap",
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "10.5"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "1"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "quotes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/quotes",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "11"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -264,7 +264,7 @@
         },
         "svg_support": {
           "__compat": {
-            "description": "Suppor in SVG",
+            "description": "Support in SVG",
             "support": {
               "webview_android": {
                 "version_added": null

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -1,0 +1,319 @@
+{
+  "css": {
+    "properties": {
+      "white-space": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/white-space",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "pre": {
+          "__compat": {
+            "description": "<code>pre</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "pre-wrap": {
+          "__compat": {
+            "description": "<code>pre-wrap</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "3"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8",
+                "notes": "From Internet Explorer 5.5 to 7, <code>word-wrap: break-word;</code> can be used for line breaks in <code>pre<code> elements."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "8"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "pre-line": {
+          "__compat": {
+            "description": "<code>pre-line</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "textarea_support": {
+          "__compat": {
+            "description": "Support on <code>&lt;textarea&gt;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "36"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "5.5"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "svg_support": {
+          "__compat": {
+            "description": "Suppor in SVG",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "36"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -1,0 +1,167 @@
+{
+  "css": {
+    "properties": {
+      "word-break": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/word-break",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "15"
+            },
+            "firefox_android": {
+              "version_added": "15"
+            },
+            "ie": [
+              {
+                "version_added": "5.5",
+                "notes": "No version of Internet Explorer supports the <code>initial</code> value."
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "8",
+                "notes": "Don't use <code>-ms-word-break</code>, which is a synonym for <code>word-break</code>."
+              }
+            ],
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "keep-all": {
+          "__compat": {
+            "description": "<code>keep-all</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "44"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": {
+                "version_added": "15"
+              },
+              "ie": {
+                "version_added": "5.5"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "31"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "break-word": {
+          "__compat": {
+            "description": "<code>break-word</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "word-spacing": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/word-spacing",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "<code>&lt;<percentage>&gt;</code> values",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -1,0 +1,99 @@
+{
+  "css": {
+    "properties": {
+      "word-wrap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-wrap",
+          "support": {
+            "webview_android": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": true
+              },
+              {
+                "version_added": "1"
+              }
+            ],
+            "chrome": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": true
+              },
+              {
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": "49"
+              },
+              {
+                "version_added": "3.5"
+              }
+            ],
+            "firefox_android": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": "49"
+              },
+              {
+                "version_added": "4"
+              }
+            ],
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": true
+              },
+              {
+                "version_added": "10.5"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": true
+              },
+              {
+                "version_added": "1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": true
+              },
+              {
+                "version_added": "1"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the following text formatting CSS properties:

* [`letter-spacing`](https://developer.mozilla.org/docs/Web/CSS/letter-spacing)
* [`overflow-wrap`](https://developer.mozilla.org/docs/Web/CSS/overflow-wrap)
* [`quotes`](https://developer.mozilla.org/docs/Web/CSS/quotes)
* [`white-space`](https://developer.mozilla.org/docs/Web/CSS/white-space)
* [`word-break`](https://developer.mozilla.org/docs/Web/CSS/word-break)
* [`word-spacing`](https://developer.mozilla.org/docs/Web/CSS/word-spacing)

One thing I was not completely certain about here was `overflow-wrap`, which also goes under the non-standard alias `word-wrap`. I opted to use `alternative_name`s to structure the support for the non-standard alias, though I think there might also be a case for making a separate `word-wrap.json` file. If you would rather to see that happen, let me know and I'll update this PR. Thanks!