### PR TITLE
Safari 11 supports Cache-Control: immutable

### DIFF
--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -89,11 +89,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false,
-                "notes": "See WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=167497'>bug 167497</a>."
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               }
             },
             "status": {


### PR DESCRIPTION
Confirmed through manual testing and the webkit changelog: https://trac.webkit.org/browser/webkit/releases/Apple/Safari%2011.0/WebCore/ChangeLog-2017-03-23