### PR TITLE
Add compat data for more CSS text formatting properties

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -1,0 +1,109 @@
+{
+  "css": {
+    "properties": {
+      "content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/content",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": "8"
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": "9.5"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "url": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
+            "description": "<code>url()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "direction": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/direction",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": "8"
+            },
+            "safari": {
+              "version_added": "1.3"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -1,0 +1,132 @@
+{
+  "css": {
+    "properties": {
+      "tab-size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/tab-size",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "version_added": "21",
+              "notes": "This property is not yet animatable."
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": "4",
+              "notes": [
+                "See <a href='https://bugzil.la/737785'>bug 737785</a> for the status of unprefixing this property.",
+                "Before Firefox 53, this property was not animatable."
+              ]
+            },
+            "firefox_android": {
+              "prefix": "-moz-",
+              "version_added": "4",
+              "notes": [
+                "See <a href='https://bugzil.la/737785'>bug 737785</a> for the status of unprefixing this property.",
+                "Before Firefox 53, this property was not animatable."
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10.5"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.5"
+              }
+            ],
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "length": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/length",
+            "description": "<code>&lt;length&gt;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "42"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "37"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -1,0 +1,274 @@
+{
+  "css": {
+    "properties": {
+      "unicode-bidi": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/unicode-bidi",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": "8"
+            },
+            "safari": {
+              "version_added": "1.3"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "isolate": {
+          "__compat": {
+            "description": "<code>isolate</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "48"
+              },
+              "chrome": [
+                {
+                  "version_added": "48"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "16",
+                  "notes": [
+                    "Avoiding using <code>-webkit-isolate</code>. It can lock up older versions of Safari (up to version 9) and Chrome (up to version 47).",
+                    "Since Chrome 19, the syntax from a previous version of the specification, where the <code>isolate</code> keyword could be used together with <code>bidi-override</code>, is allowed."
+                  ]
+                }
+              ],
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "50"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "10",
+                  "version_removed": "54",
+                  "notes": "From Firefox 10 to Firefox 16 (inclusive), the <code>isolate</code> keyword could be used together with <code>bidi-override</code>, which was the syntax from a previous version of the specification. From Firefox 17, only one value is allowed. Use <code>isolate-override</code> instead the previous <code>isolate bidi-override</code>."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "50"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "10",
+                  "version_removed": "54",
+                  "notes": "From Firefox 10 to Firefox 16 (inclusive), the <code>isolate</code> keyword could be used together with <code>bidi-override</code>, which was the syntax from a previous version of the specification. From Firefox 17, only one value is allowed. Use <code>isolate-override</code> instead the previous <code>isolate bidi-override</code>."
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "prefix": "-webkit-",
+                "version_added": true,
+                "notes": "Avoiding using <code>-webkit-isolate</code>. It can lock up older versions of Safari (up to version 9) and Chrome (up to version 47)."
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "plaintext": {
+          "__compat": {
+            "description": "<code>plaintext</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "48"
+              },
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "50"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "10",
+                  "version_removed": "54",
+                  "notes": [
+                    "Before Firefox 50, the <code>plaintext</code> value was ignored for vertical writing modes (<a href='https://bugzil.la/1302734'>bug 1302734</a>).",
+                    "Before Firefox 15, <code>plaintext</code> didn't do anything to an inline element. The specification changed and the implementation was changed in Firefox 15."
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "50"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "10",
+                  "version_removed": "54",
+                  "notes": [
+                    "Before Firefox 50, the <code>plaintext</code> value was ignored for vertical writing modes (<a href='https://bugzil.la/1302734'>bug 1302734</a>).",
+                    "Before Firefox 15, <code>plaintext</code> didn't do anything to an inline element. The specification changed and the implementation was changed in Firefox 15."
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "isolate-override": {
+          "__compat": {
+            "description": "<code>isolate-override</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "48"
+              },
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "50"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "17",
+                  "version_removed": "54"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "50"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "17",
+                  "version_removed": "54"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the following properties:

* [`content`](https://developer.mozilla.org/docs/Web/CSS/content)
* [`direction`](https://developer.mozilla.org/docs/Web/CSS/direction)
* [`tab-size`](https://developer.mozilla.org/docs/Web/CSS/tab-size)
* [`unicode-bidi`](https://developer.mozilla.org/docs/Web/CSS/unicode-bidi)