### PR TITLE
Correct @page MDN URL

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -3,7 +3,7 @@
     "at-rules": {
       "page": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page",
           "support": {
             "webview_android": {
               "version_added": null


### PR DESCRIPTION
The correct URL is https://developer.mozilla.org/en-US/docs/Web/CSS/@page