### PR TITLE
Update JS grammar compat data for Chrome (trailing commas for functions)

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -940,10 +940,10 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": false
+                "version_added": "58"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "58"
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
According to this [V8 bug report](https://bugs.chromium.org/p/v8/issues/detail?id=5051), the V8 engine supports trailing commas in function definitions and function calls since version 5.8 (see [comment 15](https://bugs.chromium.org/p/v8/issues/detail?id=5051#c15)).

Based on the [Chrome version history](https://en.wikipedia.org/wiki/Google_Chrome_version_history), V8 5.8 is included in the official Chrome stable channel since version 58. Hence this small update to compat data.

Note: Trailing commas in function calls were tested to work on Chrome Version 58.0.3029.110 (64-bit) on Linux