### PR TITLE
Add "display: list-item" to <summary> feature list

### DIFF
--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -52,6 +52,59 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "display_list_item": {
+          "__compat": {
+            "description": "<code>display: list-item</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false,
+                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>Chrome bug 590014</a> for details."
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>Chrome bug 590014</a> for details."
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The `<summary>` element specification states that
display: list-item should be applied to `<summary>` by
default. Chrome doesn't do this yet; nor does Safari.
This update adds an entry to the compat data to cover
this feature.

This lints correctly and looks good in a test render.