### PR TITLE
Add compat data for `overflow-` properties

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -1,0 +1,63 @@
+{
+  "css": {
+    "properties": {
+      "overflow-x": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-x",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": [
+              {
+                "version_added": "5"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "8"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -1,0 +1,63 @@
+{
+  "css": {
+    "properties": {
+      "overflow-y": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-y",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": [
+              {
+                "version_added": "5"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "8"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "properties": {
+      "overflow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "After Firefox 3.6, the <code>overflow</code> property is correctly applied to table group elements (<code>&lt;thead&gt;</code>, <code>&lt;tbody&gt;</code>, <code>&lt;tfoot&gt;</code>)."
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4",
+              "notes": "From version 4 to 6, Internet Explorer enlarges an element with <code>overflow: visible</code> (default value) to fit the content inside it. <code>height</code> and <code>width</code> behave like <code>min-height</code> and <code>min-width</code>, respectively."
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates compat data for:

* [`overflow`](https://developer.mozilla.org/docs/Web/CSS/overflow)
* [`overflow-x`](https://developer.mozilla.org/docs/Web/CSS/overflow-x)
* [`overflow-y`](https://developer.mozilla.org/docs/Web/CSS/overflow-y)