### PR TITLE
Add compat data for all CSS property

### DIFF
--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "all": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/all",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "27"
+            },
+            "firefox_android": {
+              "version_added": "27"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "revert": {
+          "__compat": {
+            "description": "<code>revert</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the [`all`](https://developer.mozilla.org/docs/Web/CSS/all) CSS property.

This is one of several miscellaneous properties in [the big spreadsheet](https://docs.google.com/spreadsheets/d/1ivgyPBr9Lj3Wvj5kyndT1rgGbX-pGggrxuMtrgcOmjM/) that didn't seem related to any others. If you'd like me to bundle together unrelated properties in the future to reduce the number of PRs, let me know.