### PR TITLE
Add note that Firefox uses the wrong interface for <kbd>

### DIFF
--- a/html/elements/kbd.json
+++ b/html/elements/kbd.json
@@ -21,7 +21,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Before Firefox 4, creating a &lt;kbd&gt; element incorrectly resulted in an <code>HTMLSpanElement</code> object, instead of the expected <code>HTMLElement</code>."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
Add note that Firefox uses the wrong interface for `<kbd>` prior to
Firefox 4. Only applies to Desktop, since the first mobile release
was after this.