### PR TITLE
Add formatted descriptions to CSS at-rules

### DIFF
--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -3,6 +3,7 @@
     "at-rules": {
       "counter-style": {
         "__compat": {
+          "description": "<code>@counter-style</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style",
           "support": {
             "webview_android": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -3,6 +3,7 @@
     "at-rules": {
       "font-face": {
         "__compat": {
+          "description": "<code>@font-face</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face",
           "support": {
             "webview_android": {

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -3,6 +3,7 @@
     "at-rules": {
       "keyframes": {
         "__compat": {
+          "description": "<code>@keyframes</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@keyframes",
           "support": {
             "webview_android": [

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -3,6 +3,7 @@
     "at-rules": {
       "page": {
         "__compat": {
+          "description": "<code>@page</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page",
           "support": {
             "webview_android": {


### PR DESCRIPTION
I noticed that not all the CSS at-rules had formatted descriptions, so this PR adds them where they're missing.