### PR TITLE
Update data for comma-optional syntax for color

### DIFF
--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -247,12 +247,16 @@
       },
       "62": {
         "release_date": "2017-10-17",
-        "status": "current"
+        "status": "retired"
       },
       "63": {
-        "status": "beta"
+        "release_date": "2017-12-06",
+        "status": "current"
       },
       "64": {
+        "status": "beta"
+      },
+      "65": {
         "status": "nightly"
       }
     }
@@ -1327,6 +1331,9 @@
         "status": "planned"
       },
       "51": {
+        "status": "planned"
+      },
+      "52": {
         "status": "planned"
       }
     }

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -539,7 +539,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": "65"
               },
               "chrome_android": {
                 "version_added": null
@@ -563,7 +563,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "52"
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
Blink added support for comma-optional RGB/HSL syntax in M65 (see https://bugs.chromium.org/p/chromium/issues/detail?id=788707 and https://bugs.chromium.org/p/chromium/issues/detail?id=786139). Also update Chrome and Opera browser versions.