### PR TITLE
Add classes compatibility wrt Node.js

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -33,7 +33,7 @@
             "version_added": false
           },
           "nodejs": {
-            "version_added": null
+            "version_added": "4"
           },
           "opera": {
             "version_added": "43"
@@ -87,7 +87,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": "43"
@@ -142,7 +142,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": "43"
@@ -197,7 +197,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": "43"


### PR DESCRIPTION
I've tested the examples in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes and they work with Node.js 6, while they don't with Node.js 5.