### PR TITLE
Add compat data for @charset CSS at-rule

### DIFF
--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -1,0 +1,60 @@
+{
+  "css": {
+    "at-rules": {
+      "charset": {
+        "__compat": {
+          "description": "<code>@charset</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@charset",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1.5",
+              "notes": "Firefox 1 supported an invalid syntax where the character encoding is not between single or double quotes."
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5.5",
+              "notes": "From Internet Explorer 5.5 to IE 7 (inclusive), Internet Explorer supported an invalid syntax where the character encoding is not between single or double quotes."
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "4"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`@charset`](https://developer.mozilla.org/docs/Web/CSS/@charset) CSS at-rule. Let me know if you want to see any changes. Thanks!