### PR TITLE
Add compat data for display CSS property

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1,0 +1,800 @@
+{
+  "css": {
+    "properties": {
+      "display": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "list-item": {
+          "__compat": {
+            "description": "<code>list-item</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inline-block": {
+          "__compat": {
+            "description": "<code>inline-block</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "6",
+                "notes": "Until Internet Explorer 8, <code>inline-block</code> is only for natural inline elements."
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inline-table": {
+          "__compat": {
+            "description": "<code>inline-table</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "3"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "table_values": {
+          "__compat": {
+            "description": "<code>table</code>, <code>table-cell</code>, <code>table-column</code>, <code>table-column-group</code>, <code>table-footer-group</code>, <code>table-header-group</code>, <code>table-row</code>, and <code>table-row-group</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "flex": {
+          "__compat": {
+            "description": "<code>flex</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": [
+                {
+                  "version_added": "29"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "21"
+                }
+              ],
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "20",
+                  "notes": "Firefox 28 added multi-line flexbox support."
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "alternative_name": "-ms-flexbox",
+                  "version_added": "8"
+                }
+              ],
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inline-flex": {
+          "__compat": {
+            "description": "<code>inline-flex</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "20",
+                  "notes": "Firefox 28 added multi-line flexbox support."
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": true,
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "alternative_name": "-ms-inline-flexbox",
+                  "version_added": "8"
+                }
+              ],
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "grid": {
+          "__compat": {
+            "description": "<code>grid</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "prefix": "-ms-",
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inline-grid": {
+          "__compat": {
+            "description": "<code>inline-grid</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "prefix": "-ms-",
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "subgrid": {
+          "__compat": {
+            "description": "<code>subgrid</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ruby_values": {
+          "__compat": {
+            "description": "<code>ruby</code>, <code>ruby-base</code>, <code>ruby-base-container</code>, <code>ruby-text</code>, and <code>ruby-text-container</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "34",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.ruby.enabled",
+                  "value_to_set": "true"
+                }
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "run-in": {
+          "__compat": {
+            "description": "<code>run-in</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1",
+                "version_removed": "32",
+                "notes": "Before Chrome 4, <code>run-in</code> was not supported before inline elements."
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7",
+                "version_removed": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1",
+                "version_removed": "8",
+                "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "flow-root": {
+          "__compat": {
+            "description": "<code>flow-root</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "58"
+              },
+              "chrome": {
+                "version_added": "58"
+              },
+              "chrome_android": {
+                "version_added": "58"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "45"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "contents": {
+          "__compat": {
+            "description": "<code>contents</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "58",
+                "flag": {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "37"
+                },
+                {
+                  "version_added": true,
+                  "version_removed": "53",
+                  "flag": {
+                    "type": "preference",
+                    "name": "layout.css.display-contents.enabled",
+                    "value_to_set": "true"
+                  }
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`display`](https://developer.mozilla.org/docs/Web/CSS/display) CSS property. It's a big one. Let me know if you want to see any changes. Thanks!