### PR TITLE
Add compat data for @import CSS at-rule

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "at-rules": {
+      "import": {
+        "__compat": {
+          "description": "<code>@import</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@import",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "ie_mobile": {
+              "version_added": "5.5"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`@import`](https://developer.mozilla.org/docs/Web/CSS/@import) at-rule. Let me know if you want to see any changes. Thanks!