### PR TITLE
Add compat data for @namespace CSS at-rule and related selector

### DIFF
--- a/css/at-rules/namespace.json
+++ b/css/at-rules/namespace.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "at-rules": {
+      "namespace": {
+        "__compat": {
+          "description": "<code>@namespace</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@namespace",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "8"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/namespace.json
+++ b/css/selectors/namespace.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "namespace": {
+        "__compat": {
+          "description": "Namespace selector (<code>|</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@namespace",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "8"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`@namespace`](https://developer.mozilla.org/docs/Web/CSS/@namespace) at-rule. The original table also included data for the namespace selector. I broke the selector data out into its own file in the selectors directory. Let me know if you want to see any changes. Thanks!