### PR TITLE
Add compat data for @supports CSS at-rule

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -1,0 +1,80 @@
+{
+  "css": {
+    "at-rules": {
+      "supports": {
+        "__compat": {
+          "description": "<code>@supports</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@supports",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "28"
+            },
+            "chrome_android": {
+              "version_added": "28"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "17",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.supports-rule.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "17",
+                "version_removed": true,
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.supports-rule.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`@supports`](https://developer.mozilla.org/docs/Web/CSS/@supports) CSS at-rule. Let me know if you want to see any changes. Thanks!