### PR TITLE
Add compat data for ime-mode CSS property

### DIFF
--- a/css/properties/ime-mode.json
+++ b/css/properties/ime-mode.json
@@ -1,0 +1,63 @@
+{
+  "css": {
+    "properties": {
+      "ime-mode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ime-mode",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": [
+              {
+                "version_added": "5"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "8"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`ime-mode`](https://developer.mozilla.org/docs/Web/CSS/ime-mode) CSS property. Let me know if you want to see any changes. Thanks!