### PR TITLE
Add compat data for object-fit CSS property

### DIFF
--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -1,0 +1,70 @@
+{
+  "css": {
+    "properties": {
+      "object-fit": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-fit",
+          "support": {
+            "webview_android": {
+              "version_added": "31"
+            },
+            "chrome": {
+              "version_added": "31"
+            },
+            "chrome_android": {
+              "version_added": "31"
+            },
+            "edge": {
+              "version_added": "16",
+              "notes": "Edge supports <code>object-fit</code> on <code>img</code> elements only. <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/13603873/#comment-0'>See Edge issue 13603873 for details</a>."
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "36"
+            },
+            "firefox_android": {
+              "version_added": "36"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "19"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.6"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.5"
+              }
+            ],
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`object-fit`](https://developer.mozilla.org/docs/Web/CSS/object-fit) CSS property. Let me know if you want to see any changes. Thanks!