### PR TITLE
Add compat data for object-position CSS property

### DIFF
--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -1,0 +1,69 @@
+{
+  "css": {
+    "properties": {
+      "object-position": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-position",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4.4"
+            },
+            "chrome": {
+              "version_added": "31"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "36"
+            },
+            "firefox_android": {
+              "version_added": "36"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "19"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.6"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.5"
+              }
+            ],
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`object-position`](https://developer.mozilla.org/docs/Web/CSS/object-position) CSS property. Let me know if you want to see any changes. Thanks!