### PR TITLE
Update browser compat data for mix-blend-mode CSS property

### DIFF
--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -59,7 +59,7 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": false
+                "version_added": "41"
               },
               "chrome_android": {
                 "version_added": null


### PR DESCRIPTION
Property is supported on SVG elements since Chrome 41.
See https://www.chromestatus.com/feature/6362616360337408