### PR TITLE
Add compat data for resize CSS property

### DIFF
--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -1,0 +1,110 @@
+{
+  "css": {
+    "properties": {
+      "resize": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/resize",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "block_level_support": {
+          "__compat": {
+            "description": "Support on block level, replaced, table cell, or inline block elements",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "5",
+                "notes": "<code>resize</code> doesn't have any effect on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/iframe'><code>&lt;iframe&gt;</code></a>. See <a href='https://bugzil.la/680823'>bug 680823</a>)"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates data for the [`resize`](https://developer.mozilla.org/docs/Web/CSS/resize) CSS property. Let me know if you want to see any changes. Thanks!