### PR TITLE
Add compat data for will-change CSS property

### DIFF
--- a/css/properties/will-change.json
+++ b/css/properties/will-change.json
@@ -1,0 +1,81 @@
+{
+  "css": {
+    "properties": {
+      "will-change": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/will-change",
+          "support": {
+            "webview_android": {
+              "version_added": "37"
+            },
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "36"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "36",
+                "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
+              },
+              {
+                "version_added": "31",
+                "version_removed": "43",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.will-change.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "36",
+                "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
+              },
+              {
+                "version_added": "31",
+                "version_removed": "43",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.will-change.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": "9.1"
+            },
+            "safari_ios": {
+              "version_added": "9.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`will-change`](https://developer.mozilla.org/docs/Web/CSS/will-change) CSS property. Let me know if you want to see any changes. Thanks!