### PR TITLE
Add compat data for ::after and ::before CSS pseudo-element selectors

### DIFF
--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -1,0 +1,161 @@
+{
+  "css": {
+    "selectors": {
+      "after": {
+        "__compat": {
+          "description": "<code>::after</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::after",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": true
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": true
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "1.5",
+                "notes": [
+                  "Before Firefox 57, Firefox had a bug where <code>::after</code> pseudo-elements were still generated, even if the <a href='https://developer.mozilla.org/docs/Web/CSS/content'><code>content</code></a> property value were set to <code>normal</code> or <code>none</code>.",
+                  "Before Firefox 3.5, only the CSS level 2 behavior of <code>:after</code> was supported, which disallowed <a href='https://developer.mozilla.org/docs/Web/CSS/position'><code>position</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/float'><code>float</code></a>, <code>list-style-*</code> and some <code>display</code> properties."
+                ]
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": "1"
+              }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": "8"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "7"
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": "4"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": "4"
+              }
+            ],
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "animation_and_transition_support": {
+          "__compat": {
+            "description": "Animation and transition support",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "26"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -1,0 +1,173 @@
+{
+  "css": {
+    "selectors": {
+      "before": {
+        "__compat": {
+          "description": "<code>::before</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::before",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": true
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": true
+              }
+            ],
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "1.5",
+                "notes": [
+                  "Before Firefox 57, Firefox had a bug where <code>::before</code> pseudo-elements were still generated, even if the <a href='https://developer.mozilla.org/docs/Web/CSS/content'><code>content</code></a> property value were set to <code>normal</code> or <code>none</code>.",
+                  "Before Firefox 3.5, only the CSS level 2 behavior of <code>:before</code> was supported, which disallowed <a href='https://developer.mozilla.org/docs/Web/CSS/position'><code>position</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/float'><code>float</code></a>, <code>list-style-*</code> and some <code>display</code> properties."
+                ]
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": "1"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": true
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": "8"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "7"
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": "4"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": "4"
+              }
+            ],
+            "safari_ios": {
+              "version_added": "5.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "animation_and_transition_support": {
+          "__compat": {
+            "description": "Animation and transition support",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "26"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`::after`](https://developer.mozilla.org/docs/Web/CSS/::after) and [`::before`](https://developer.mozilla.org/docs/Web/CSS/::before) pseudo-element selectors. Let me know if you want to see any changes. Thanks!