### PR TITLE
Add compat data for ::first-letter CSS pseudo-element

### DIFF
--- a/css/selectors/first-letter.json
+++ b/css/selectors/first-letter.json
@@ -1,0 +1,159 @@
+{
+  "css": {
+    "selectors": {
+      "first-letter": {
+        "__compat": {
+          "description": "<code>::first-letter</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::first-letter",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "1"
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": "1"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "1"
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": "1"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "4"
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": "4"
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": "5.5"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "7"
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": "3.5"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "version_added": "1"
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": "1"
+              }
+            ],
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "dutch_ij_digraph": {
+          "__compat": {
+            "description": "Support for the Dutch digraph <code>IJ</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/92176'>bug 92176</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/92176'>bug 92176</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`::first-letter`](https://developer.mozilla.org/docs/Web/CSS/::first-letter) pseudo-element selector. Let me know if you want to see any changes. Thanks!