### PR TITLE
Add compat data for ::first-line CSS pseudo-element

### DIFF
--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -1,0 +1,112 @@
+{
+  "css": {
+    "selectors": {
+      "first-line": {
+        "__compat": {
+          "description": "<code>::first-line</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::first-line",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": [
+              {
+                "version_added": "1",
+                "notes": "Before Chrome 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "1",
+                "notes": "Before Chrome 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": true
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "1"
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "1"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "4"
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "4"
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "5.5"
+              }
+            ],
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "7",
+                "notes": "Before Opera 49, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "3.5",
+                "notes": "Before Opera 49, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "version_added": "1",
+                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work for <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://bugs.webkit.org/show_bug.cgi?id=3409'>WebKit bug 3409</a>."
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "1",
+                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work for <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://bugs.webkit.org/show_bug.cgi?id=3409'>WebKit bug 3409</a>."
+              }
+            ],
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -74,12 +74,12 @@
             "opera": [
               {
                 "version_added": "7",
-                "notes": "Before Opera 49, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
               },
               {
                 "alternative_name": ":first-line",
                 "version_added": "3.5",
-                "notes": "Before Opera 49, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
               }
             ],
             "opera_android": {


### PR DESCRIPTION
This PR migrates the data for the [`::first-line`](https://developer.mozilla.org/docs/Web/CSS/::first-line) pseudo-element selector. Let me know if you want to see any changes. Thanks!