### PR TITLE
Add compat data for ::selection CSS pseudo-element

### DIFF
--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "selectors": {
+      "selection": {
+        "__compat": {
+          "description": "<code>::selection</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::selection",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1.1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`::selection`](https://developer.mozilla.org/docs/Web/CSS/::selection) CSS pseudo-element. One caveat: the notes that went along with the table didn't seem particularly helpful (e.g., the one about `text-shadow`), so they're not well-represented in this data. But let me know if you want to see any changes. Thanks!