### PR TITLE
Add compat data for ::backdrop CSS pseudo-element

### DIFF
--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -1,0 +1,169 @@
+{
+  "css": {
+    "selectors": {
+      "backdrop": {
+        "__compat": {
+          "description": "<code>::backdrop</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::backdrop",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "32"
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "prefix": "-ms-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-ms-",
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "47"
+            },
+            "firefox_android": {
+              "version_added": "47"
+            },
+            "ie": {
+              "prefix": "-ms-",
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "dialog": {
+          "__compat": {
+            "description": "Support on <code>dialog</code> elements",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "32"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fullscreen": {
+          "__compat": {
+            "description": "Fullscreen support",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "47"
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`::backdrop`](https://developer.mozilla.org/docs/Web/CSS/::backdrop) CSS pseudo-element. Let me know if you want to see any changes. Thanks!