### PR TITLE
Add compat data for ::placeholder CSS pseudo-element

### DIFF
--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -1,0 +1,111 @@
+{
+  "css": {
+    "selectors": {
+      "placeholder": {
+        "__compat": {
+          "description": "<code>::placeholder</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::placeholder",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.1"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "51"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              }
+            ],
+            "ie": {
+              "prefix": "-ms-",
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "prefix": "-ms-",
+              "version_added": "10"
+            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": "37"
+            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "10.3"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.3"
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`::placeholder`](https://developer.mozilla.org/docs/Web/CSS/::placeholder) CSS psuedo-element. The original table was a bit strange because it split up unprefixed and prefixed data in separate rows. I assumed a couple gaps (e.g., Edge mobile support), but this one seems a bit odd in general. Let me know if you want me to change anything. Thanks!