### PR TITLE
Add compat data for ::marker CSS pseudo-element

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "marker": {
+        "__compat": {
+          "description": "<code>::marker</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::marker",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`::marker`](https://developer.mozilla.org/docs/Web/CSS/::marker) pseudo-element. This one's pretty easy, since nobody seems to support it. Let me know if you see any changes needed. Thanks!