### PR TITLE
Add ::grammar-error and ::spelling-error CSS pseudo-elements

### DIFF
--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "grammar-error": {
+        "__compat": {
+          "description": "<code>::grammar-error</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::grammar-error",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "spelling-error": {
+        "__compat": {
+          "description": "<code>::spelling-error</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::spelling-error",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR "migrates"—for lack of a better word—the [`::grammar-error`](https://developer.mozilla.org/docs/Web/CSS/::grammar-error) and [`::spelling-error`](https://developer.mozilla.org/docs/Web/CSS/::spelling-error) CSS pseudo-elements. There's no actual data in the source tables, however, so this is more of a placeholder than anything else. Let me know if you want to see any changes. Thanks!