### PR TITLE
Add compat data for :active CSS pseudo-class selector

### DIFF
--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -1,0 +1,110 @@
+{
+  "css": {
+    "selectors": {
+      "active": {
+        "__compat": {
+          "description": "<code>:active</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:active",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": "5"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "non_a_elements": {
+          "__compat": {
+            "description": "Non-<code>a</code> element support",
+            "support": {
+              "webview_android": {
+                "version_added": "1"
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": true,
+                "notes": "By default, Safari on iOS does not use the <a href='https://developer.mozilla.org/docs/Web/CSS/:active'><code>:active</code></a> state unless there is a <a href='https://developer.mozilla.org/docs/Web/Reference/Events/touchstart'><code>touchstart</code></a> event handler on the relevant element or on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`:active`](https://developer.mozilla.org/docs/Web/CSS/:active) CSS pseudo-class selector. Let me know if you want to see any changes. Thanks!