### PR TITLE
Add compat data for :any CSS pseudo-class selector

### DIFF
--- a/css/selectors/any.json
+++ b/css/selectors/any.json
@@ -1,0 +1,63 @@
+{
+  "css": {
+    "selectors": {
+      "any": {
+        "__compat": {
+          "description": "<code>:any</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:any",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "12"
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "5"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`:any`](https://developer.mozilla.org/docs/Web/CSS/:any) pseudo-class selector. Let me know if you want to see any changes. Thanks!