### PR TITLE
Add compat data for :default CSS pseudo-class selector

### DIFF
--- a/css/selectors/default.json
+++ b/css/selectors/default.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "default": {
+        "__compat": {
+          "description": "<code>:default</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:default",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "10"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "10"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`:default`](https://developer.mozilla.org/docs/Web/CSS/:default) pseudo-class selector. Let me know if you want to see any changes. Thanks!