### PR TITLE
Add compat data for :dir() CSS pseudo-class selector

### DIFF
--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -1,0 +1,72 @@
+{
+  "css": {
+    "selectors": {
+      "dir": {
+        "__compat": {
+          "description": "<code>:dir()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:dir",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "49"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "17",
+                "version_removed": "53"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "17",
+                "version_removed": "53"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for the [`:dir()`](https://developer.mozilla.org/docs/Web/CSS/:dir) pseudo-class selector. Let me know if I should change anything. Thanks!