### PR TITLE
Add compat data for :disabled and :enabled pseudo-class selectors

### DIFF
--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "selectors": {
+      "disabled": {
+        "__compat": {
+          "description": "<code>:disabled</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:disabled",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9",
+              "notes": "Internet Explorer does not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": "9.5"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "enabled": {
+        "__compat": {
+          "description": "<code>:enabled</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:enabled",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": "9.5"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for:

* [`:disabled`](https://developer.mozilla.org/docs/Web/CSS/:disabled)
* [`:enabled`](https://developer.mozilla.org/docs/Web/CSS/:enabled)

Let me know if you want to see any changes. Thanks!