### PR TITLE
Add compat data for :empty CSS pseudo-class selector

### DIFF
--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "empty": {
+        "__compat": {
+          "description": "<code>:empty</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:empty",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9.5"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the [`:empty`](https://developer.mozilla.org/docs/Web/CSS/:empty) pseudo-class selector. Let me know if you want to see any changes. Thanks!