### PR TITLE
Add compat data for :first-of-type and :last-of-type pseudo-class selectors

### DIFF
--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "first-of-type": {
+        "__compat": {
+          "description": "<code>:first-of-type</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:first-of-type",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "3.2"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "last-of-type": {
+        "__compat": {
+          "description": "<code>:last-of-type</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:last-of-type",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "3.2"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates data for:

* [`:first-of-type`](https://developer.mozilla.org/docs/Web/CSS/:first-of-type)
* [`:last-of-type`](https://developer.mozilla.org/docs/Web/CSS/:last-of-type)

Let me know if you want to see changes. Thanks!