### PR TITLE
Add note to <strong> about interface issue in old Firefox

### DIFF
--- a/html/elements/strong.json
+++ b/html/elements/strong.json
@@ -21,7 +21,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Before Firefox 4, creating a <code>&lt;strong&gt;</code> element incorrectly resulted in an <code>HTMLSpanElement</code> object, instead of the expected <code>HTMLElement</code>."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
In versions of Firefox prior to Firefox 4, these were incorrectly
HTMLSpanElement objects rather than HTMLElement per the
spec. This fix adds a note to that effect.