### PR TITLE
Add compat data for :fullscreen pseudo-class selector

### DIFF
--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -1,0 +1,134 @@
+{
+  "css": {
+    "selectors": {
+      "fullscreen": {
+        "__compat": {
+          "description": "<code>:fullscreen</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:fullscreen",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "alternative_name": "-webkit-full-screen",
+              "version_added": "15"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "alternative_name": "-moz-full-screen",
+                "version_added": "9"
+              },
+              {
+                "version_added": "47",
+                "flag": {
+                  "type": "preference",
+                  "name": "full-screen-api.unprefix.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "alternative_name": "-moz-full-screen",
+                "version_added": "9"
+              },
+              {
+                "version_added": "47",
+                "flag": {
+                  "type": "preference",
+                  "name": "full-screen-api.unprefix.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "prefix": "-ms-",
+              "version_added": "11"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "alternative_name": "-webkit-full-screen",
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "all_elements": {
+          "__compat": {
+            "description": "Select all elements in the fullscreen stack",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "43"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:fullscreen`](https://developer.mozilla.org/docs/Web/CSS/:fullscreen). Let me know if you want to see any changes. Thanks!