### PR TITLE
Add compat data for :hover pseudo-class selector

### DIFF
--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -1,0 +1,217 @@
+{
+  "css": {
+    "selectors": {
+      "hover": {
+        "__compat": {
+          "description": "<code>:hover</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:hover",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "2"
+            },
+            "safari_ios": {
+              "version_added": true,
+              "notes": "As of Safari for iOS 7.1.2, tapping a <a href='https://developer.mozilla.org/docs/Web/Events/click#Safari_Mobile'>clickable element</a> causes the element to enter the <code>:hover</code> state. The element will remain in the <code>:hover</code> state until a different element has entered the <code>:hover</code> state."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "a_elements": {
+          "__compat": {
+            "description": "<code>&lt;a&gt;</code> element support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "2"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "all_elements": {
+          "__compat": {
+            "description": "All elements support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true,
+                "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5381673/'>bug 5381673</a>."
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "7",
+                "notes": [
+                  "In Internet Explorer 8 to Internet Explorer 11, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://connect.microsoft.com/IE/feedbackdetail/view/926665'>bug 926665</a>.",
+                  "In Internet Explorer 9 (and possibly earlier), if a <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>&lt;table&gt;</code></a> has a parent with a non-<code>auto</code> <a href='https://developer.mozilla.org/docs/Web/CSS/width'><code>width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/overflow-x'><code>overflow-x</code></a><code>: auto;</code>, the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>&lt;table&gt;</code></a> has enough content to horizontally overflow its parent, and there are <a href='https://developer.mozilla.org/docs/Web/CSS/:hover'><code>:hover</code></a> styles set on elements within the table, then hovering over said elements will cause the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>&lt;table&gt;</code></a>'s height to increase. See <a href='http://jsbin.com/diwiqe'>a live demo that triggers the bug</a>. One workaround for the bug is to set <code>min-height: 0%;</code> (the <code>%</code> unit must be specified, since unitless and <code>px</code> don't work) on the <code>&lt;table&gt;</code>'s parent element."
+                ]
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "2"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "pseudo_elements": {
+          "__compat": {
+            "description": "Pseudo-element support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "28"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:hover`](https://developer.mozilla.org/docs/Web/CSS/:hover). Let me know if you want to see any changes. Thanks!