### PR TITLE
Add compat data for :indeterminate pseudo-class selector

### DIFF
--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -1,0 +1,215 @@
+{
+  "css": {
+    "selectors": {
+      "indeterminate": {
+        "__compat": {
+          "description": "<code>:indeterminate</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:indeterminate",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "checkbox": {
+          "__compat": {
+            "description": "<code>type=&quot;checkbox&quot;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "10.6"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "radio": {
+          "__compat": {
+            "description": "<code>type=&quot;radio&quot;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "39"
+              },
+              "chrome": {
+                "version_added": "39"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/7124038'>Edge bug 7124038</a>."
+              },
+              "edge_mobile": {
+                "version_added": false,
+                "notes": "See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/7124038'>Edge bug 7124038</a>."
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=156270'>WebKit bug 156270</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=156270'>WebKit bug 156270</a>."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "progress": {
+          "__compat": {
+            "description": "<a href='https://developer.mozilla.org/docs/Web/HTML/Element/progress'><code>&lt;progress&gt;</code></a>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "6"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": {
+                "version_added": "6"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:indeterminate`](https://developer.mozilla.org/docs/Web/CSS/:indeterminate). This one is a little bit odd because I had to infer basic support by the presence of feature values. Let me know if you want to see any changes. Thanks!