### PR TITLE
Add compat data for :in-range and :out-of-range pseudo-class selectors

### DIFF
--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -1,0 +1,65 @@
+{
+  "css": {
+    "selectors": {
+      "in-range": {
+        "__compat": {
+          "description": "<code>:in-range</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:in-range",
+          "support": {
+            "webview_android": {
+              "version_added": "2.3",
+              "notes": "Before version 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In version 52, it was changed to only match enabled read-write inputs."
+            },
+            "chrome": {
+              "version_added": "10",
+              "notes": "Before Chrome 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Chrome 52, it was changed to only match enabled read-write inputs."
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "29",
+              "notes": "Before Firefox 50, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://bugzil.la/1264157'>bug 1264157</a>). In Firefox 50, it was changed to only match enabled read-write inputs."
+            },
+            "firefox_android": {
+              "version_added": "16"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "11",
+              "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
+            },
+            "opera_android": {
+              "version_added": true,
+              "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
+            },
+            "safari": {
+              "version_added": true,
+              "notes": "In Safari, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://bugs.webkit.org/show_bug.cgi?id=156530'>bug 156530</a>). It was later changed to only match enabled read-write inputs."
+            },
+            "safari_ios": {
+              "version_added": true,
+              "notes": "In Safari, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://bugs.webkit.org/show_bug.cgi?id=156530'>bug 156530</a>). It was later changed to only match enabled read-write inputs."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/out-of-range.json
+++ b/css/selectors/out-of-range.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "out-of-range": {
+        "__compat": {
+          "description": "<code>:out-of-range</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:out-of-range",
+          "support": {
+            "webview_android": {
+              "version_added": "2.3"
+            },
+            "chrome": {
+              "version_added": "10"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "29"
+            },
+            "firefox_android": {
+              "version_added": "16"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for

* [`:in-range`](https://developer.mozilla.org/docs/Web/CSS/:in-range)
* [`:out-of-range`](https://developer.mozilla.org/docs/Web/CSS/:out-of-range)

Let me know if you want to see any changes. Thanks!