### PR TITLE
Add compat data for :lang() pseudo-class selector

### DIFF
--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "lang": {
+        "__compat": {
+          "description": "<code>:lang()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:lang",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "ie_mobile": {
+              "version_added": "8"
+            },
+            "opera": {
+              "version_added": "8"
+            },
+            "opera_android": {
+              "version_added": "8"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:lang()`](https://developer.mozilla.org/docs/Web/CSS/:lang). Let me know if you want to see any changes. Thanks!