### PR TITLE
Add compat data for :link pseudo-class selector

### DIFF
--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "link": {
+        "__compat": {
+          "description": "<code>:link</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:link",
+          "support": {
+            "webview_android": {
+              "version_added": "1.5"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:link`](https://developer.mozilla.org/docs/Web/CSS/:link). Let me know if you want to see any changes. Thanks!