### PR TITLE
Add compat data for :nth-of-type and :nth-last-of-type pseudo-class selectors

### DIFF
--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "nth-last-of-type": {
+        "__compat": {
+          "description": "<code>:nth-last-of-type()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-of-type",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "3.2"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "nth-of-type": {
+        "__compat": {
+          "description": "<code>:nth-of-type()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-of-type",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": "9.5"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3.1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for:

* [`:nth-last-of-type`](https://developer.mozilla.org/docs/Web/CSS/:nth-last-of-type)
* [`:nth-of-type`](https://developer.mozilla.org/docs/Web/CSS/:nth-of-type)

Let me know if you want to see any changes. Thanks!