### PR TITLE
Add compat data for :only-of-type pseudo-class selector

### DIFF
--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "only-of-type": {
+        "__compat": {
+          "description": "<code>:only-of-type</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:only-of-type",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "3.2"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:only-of-type`](https://developer.mozilla.org/docs/Web/CSS/:only-of-type). Let me know if you want to see any changes. Thanks!