### PR TITLE
Add compat data for :optional pseudo-class selector

### DIFF
--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "optional": {
+        "__compat": {
+          "description": "<code>:optional</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:optional",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "10"
+            },
+            "chrome_android": {
+              "version_added": "4.4"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "10"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:optional`](https://developer.mozilla.org/docs/Web/CSS/:optional). Let me know if you want to see any changes. Thanks!