### PR TITLE
Add compat data for :read-only and :read-write pseudo-class selectors

### DIFF
--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "selectors": {
+      "read-only": {
+        "__compat": {
+          "description": "<code>:read-only</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:read-only",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": true,
+              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
+            },
+            "firefox_android": {
+              "prefix": "-moz-",
+              "version_added": true,
+              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -1,0 +1,107 @@
+{
+  "css": {
+    "selectors": {
+      "read-write": {
+        "__compat": {
+          "description": "<code>:read-write</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:read-write",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": true,
+              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
+            },
+            "firefox_android": {
+              "prefix": "-moz-",
+              "version_added": true,
+              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "matches_editable_elements": {
+          "__compat": {
+            "description": "Matches editable elements that are neither <code>&lt;input&gt;</code> elements nor <code>&lt;textarea&gt;</code> elements",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for:

* [`:read-only`](https://developer.mozilla.org/docs/Web/CSS/:read-only)
* [`:read-write`](https://developer.mozilla.org/docs/Web/CSS/:read-write)

Looking at the HTML spec, the feature concerning editable elements does not seem apply to `:read-only`, only to `:read-write` (some copy and paste mistake, maybe?). I've omitted the feature on `:read-only` selector, but if someone wants to take a careful look at it to make sure that was the right thing to do, I'd appreciate it. Thanks!