### PR TITLE
Add compat data for :required pseudo-class selector

### DIFF
--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "required": {
+        "__compat": {
+          "description": "<code>:required</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:required",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4.4"
+            },
+            "chrome": {
+              "version_added": "10"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "10"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:required`](https://developer.mozilla.org/docs/Web/CSS/:required). Let me know if you want to see any changes. Thanks!