### PR TITLE
Add compat data for :root pseudo-class selector

### DIFF
--- a/css/selectors/root.json
+++ b/css/selectors/root.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "root": {
+        "__compat": {
+          "description": "<code>:root</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:root",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:root`](https://developer.mozilla.org/docs/Web/CSS/:root). Let me know if you want to see any changes. Thanks!