### PR TITLE
Add compat data for :scope pseudo-class selector

### DIFF
--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -1,0 +1,129 @@
+{
+  "css": {
+    "selectors": {
+      "scope": {
+        "__compat": {
+          "description": "<code>:scope</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:scope",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scope-pseudo.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "20",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.scope-pseudo.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "dom_api": {
+          "__compat": {
+            "description": "Support in DOM API such as in <code>querySelector()</code> and <code>querySelectorAll()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "27"
+              },
+              "chrome": {
+                "version_added": "27"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": {
+                "version_added": "32"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:scope`](https://developer.mozilla.org/docs/Web/CSS/:scope). Let me know if you want to see any changes. Thanks!