### PR TITLE
Add compat data for :target pseudo-class selector

### DIFF
--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "target": {
+        "__compat": {
+          "description": "<code>:target</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:target",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "ie_mobile": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": "9.5"
+            },
+            "safari": {
+              "version_added": "1.3"
+            },
+            "safari_ios": {
+              "version_added": "2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:target`](https://developer.mozilla.org/docs/Web/CSS/:target). Let me know if you want to see any changes. Thanks!