### PR TITLE
Add compat data for :visited pseudo-class selector

### DIFF
--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -1,0 +1,109 @@
+{
+  "css": {
+    "selectors": {
+      "visited": {
+        "__compat": {
+          "description": "<code>:visited</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:visited",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "9.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "privacy_measures": {
+          "__compat": {
+            "description": "Restrict CSS properties allowed in a statement using <code>:visited</code> for privacy",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "6"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "ie_mobile": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "5"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:visted`](https://developer.mozilla.org/docs/Web/CSS/:visited). I think the privacy feature description here is a bit wordy (despite my best efforts), so I'm open to suggestions on that front. But let me know if you want to see any changes. Thanks!