### PR TITLE
Add compat data for :focus-within pseudo-class selector

### DIFF
--- a/css/selectors/focus-within.json
+++ b/css/selectors/focus-within.json
@@ -1,0 +1,60 @@
+{
+  "css": {
+    "selectors": {
+      "focus-within": {
+        "__compat": {
+          "description": "<code>:focus-within</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:focus-within",
+          "support": {
+            "webview_android": {
+              "version_added": "60"
+            },
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11725071-implement-focus-within-from-selectors-4'>the enhancement request</a>."
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11725071-implement-focus-within-from-selectors-4'>the enhancement request</a>."
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:focus-within`](https://developer.mozilla.org/docs/Web/CSS/:focus-within). Let me know if you want to see any changes. Thanks!