### PR TITLE
Add compat data for :placeholder-shown pseudo-class selector

### DIFF
--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -1,0 +1,125 @@
+{
+  "css": {
+    "selectors": {
+      "placeholder-shown": {
+        "__compat": {
+          "description": "<code>:placeholder-shown</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown",
+          "support": {
+            "webview_android": {
+              "version_added": "51"
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12435951--placeholder-shown-css-pseudo-class'>this enhancement request</a>."
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12435951--placeholder-shown-css-pseudo-class'>this enhancement request</a>."
+            },
+            "firefox": [
+              {
+                "version_added": "51"
+              },
+              {
+                "alternative_name": ":-moz-placeholder",
+                "version_added": "4",
+                "version_removed": "51"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "51"
+              },
+              {
+                "alternative_name": ":-moz-placeholder",
+                "version_added": "4",
+                "version_removed": "51"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "34"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9.2"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "non_text_types": {
+          "__compat": {
+            "description": "Support on non-<code>type=&quot;text&quot;</code> elements (such as <code>type=&quot;number&quot;</code> or <code>type=&quot;time&quot;</code>)",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`:placeholder-shown`](https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown). Let me know if you want to see any changes. Thanks!