### PR TITLE
Add compat data for backdrop-filter CSS property

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -1,0 +1,66 @@
+{
+  "css": {
+    "properties": {
+      "backdrop-filter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backdrop-filter",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "47",
+              "flag": {
+                "type": "preference",
+                "name": "Enable Experimental Web Platform Features"
+              }
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/backdropfilter/'>In development</a>."
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/backdropfilter/'>In development</a>."
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1178765'>bug 1178765</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1178765'>bug 1178765</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -19,12 +19,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/backdropfilter/'>In development</a>."
+              "version_added": "17"
             },
             "edge_mobile": {
-              "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/backdropfilter/'>In development</a>."
+              "version_added": "17"
             },
             "firefox": {
               "version_added": false,


### PR DESCRIPTION
This PR migrates the data for [`backdrop-filter`](https://developer.mozilla.org/docs/Web/CSS/backdrop-filter). Let me know if you want to see any changes. Thanks!