### PR TITLE
Add compat data for <blend-mode> CSS type

### DIFF
--- a/css/types/blend-mode.json
+++ b/css/types/blend-mode.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "types": {
+      "blend-mode": {
+        "__compat": {
+          "description": "<code>lt;blend-modegt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/blend-mode",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "30"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "22"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`<blend-mode>`](https://developer.mozilla.org/docs/Web/CSS/blend-mode). Let me know if you want to see any changes. Thanks!