### PR TITLE
Add compat data for deprecated box- CSS properties

### DIFF
--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -1,0 +1,102 @@
+{
+  "css": {
+    "properties": {
+      "box-direction": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-direction",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              },
+              {
+                "prefix": "-khtml-",
+                "version_added": "1.1"
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -1,0 +1,102 @@
+{
+  "css": {
+    "properties": {
+      "box-flex": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-flex",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              },
+              {
+                "prefix": "-khtml-",
+                "version_added": "1.1"
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -1,0 +1,102 @@
+{
+  "css": {
+    "properties": {
+      "box-orient": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-orient",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              },
+              {
+                "prefix": "-khtml-",
+                "version_added": "1.1"
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -1,0 +1,102 @@
+{
+  "css": {
+    "properties": {
+      "box-pack": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-pack",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "edge_mobile": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              },
+              {
+                "prefix": "-khtml-",
+                "version_added": "1.1"
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for:

* [`box-direction`](https://developer.mozilla.org/docs/Web/CSS/box-direction)
* [`box-flex`](https://developer.mozilla.org/docs/Web/CSS/box-flex)
* [`box-orient`](https://developer.mozilla.org/docs/Web/CSS/box-orient)
* [`box-pack`](https://developer.mozilla.org/docs/Web/CSS/box-pack)

They're all alike in terms of data. Let me know if you want to see any changes. Thanks!