### PR TITLE
Add compat data for font-variation-settings CSS property

### DIFF
--- a/css/properties/font-variation-settings.json
+++ b/css/properties/font-variation-settings.json
@@ -1,0 +1,61 @@
+{
+  "css": {
+    "properties": {
+      "font-variation-settings": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variation-settings",
+          "support": {
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/fontvariationpropertieswithopentypevariablefontsupport/'>In development</a>."
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/fontvariationpropertieswithopentypevariablefontsupport/'>In development</a>."
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "49"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
+            "safari": {
+              "version_added": "11",
+              "notes": "Requires macOS 10.13 High Sierra or later."
+            },
+            "safari_ios": {
+              "version_added": "11",
+              "notes": "Requires iOS 11 or later."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`font-variation-settings`](https://developer.mozilla.org/docs/Web/CSS/font-variation-settings). Let me know if you want to see any changes. Thanks!