### PR TITLE
Remove no-longer-needed notes from <textarea>

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -130,12 +130,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "59",
-                "notes": "See <a href='https://bugzil.la/1020698'>bug 1020698</a>."
+                "version_added": "59"
               },
               "firefox_android": {
-                "version_added": "59",
-                "notes": "See <a href='https://bugzil.la/1020698'>bug 1020698</a>."
+                "version_added": "59"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Now that Firefox 59 implements the autocomplete attribute on
<textarea>, the notes linking to the bug tracking implementation
of the feature are no longer useful, so this PR removes them.