### PR TITLE
Add compat data for initial-letter CSS property

### DIFF
--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "properties": {
+      "initial-letter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/initial-letter",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1223880'>bug 1223880</a>"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1223880'>bug 1223880</a>"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`initial-letter`](https://developer.mozilla.org/docs/Web/CSS/initial-letter). Let me know if you want to see any changes. Thanks!