### PR TITLE
Add compat data for max-inline-size CSS property

### DIFF
--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -1,0 +1,85 @@
+{
+  "css": {
+    "properties": {
+      "max-inline-size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-inline-size",
+          "support": {
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": "6.1"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.vertical-text.enabled",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "prefix": "-webkit-",
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "10.2"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`max-inline-size`](https://developer.mozilla.org/docs/Web/CSS/max-inline-size). Let me know if you want to see any changes. Thanks!