### PR TITLE
Add compat data for CSS motion path properties

### DIFF
--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -1,0 +1,75 @@
+{
+  "css": {
+    "properties": {
+      "offset-distance": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-distance",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-distance",
+                "version_added": "46"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-distance",
+                "version_added": "46"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-distance",
+                "version_added": "46"
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -1,0 +1,75 @@
+{
+  "css": {
+    "properties": {
+      "offset-path": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-path",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-path",
+                "version_added": "46"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-path",
+                "version_added": "46"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-path",
+                "version_added": "46"
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -1,0 +1,87 @@
+{
+  "css": {
+    "properties": {
+      "offset-rotate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-rotate",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "56"
+              },
+              {
+                "alternative_name": "offset-rotation",
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-rotation",
+                "version_added": "46"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "alternative_name": "offset-rotation",
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-rotation",
+                "version_added": "46"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "56"
+              },
+              {
+                "alternative_name": "offset-rotation",
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "motion-rotation",
+                "version_added": "46"
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -10,7 +10,7 @@
                 "version_added": "55"
               },
               {
-                "alternative_name": "offset",
+                "alternative_name": "motion",
                 "version_added": "46"
               }
             ],
@@ -19,7 +19,7 @@
                 "version_added": "55"
               },
               {
-                "alternative_name": "offset",
+                "alternative_name": "motion",
                 "version_added": "46"
               }
             ],
@@ -28,7 +28,7 @@
                 "version_added": "55"
               },
               {
-                "alternative_name": "offset",
+                "alternative_name": "motion",
                 "version_added": "46"
               }
             ],

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -1,0 +1,75 @@
+{
+  "css": {
+    "properties": {
+      "offset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "offset",
+                "version_added": "46"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "offset",
+                "version_added": "46"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "offset",
+                "version_added": "46"
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds data for:

* [`offset`](https://developer.mozilla.org/docs/Web/CSS/offset)
* [`offset-distance`](https://developer.mozilla.org/docs/Web/CSS/offset-distance)
* [`offset-path`](https://developer.mozilla.org/docs/Web/CSS/offset-path)
* [`offset-rotate`](https://developer.mozilla.org/docs/Web/CSS/offset-rotate)

Let me know if you want to see any changes. Thanks!