### PR TITLE
Trailing commas are supported in Chrome 58 (follow-up for #732)

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -394,10 +394,10 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": "58"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "58"
               },
               "edge": {
                 "version_added": null

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -62,10 +62,10 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": false
+                "version_added": "58"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "58"
               },
               "edge": {
                 "version_added": false

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -63,10 +63,10 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": "58"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "58"
               },
               "edge": {
                 "version_added": null

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1254,10 +1254,10 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": "58"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "58"
               },
               "edge": {
                 "version_added": null


### PR DESCRIPTION
Follow-up for https://github.com/mdn/browser-compat-data/pull/732