### PR TITLE
Add compat data for text-size-adjust CSS property

### DIFF
--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -1,0 +1,161 @@
+{
+  "css": {
+    "properties": {
+      "text-size-adjust": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-size-adjust",
+          "support": {
+            "webview_android": {
+              "version_added": "54"
+            },
+            "chrome": [
+              {
+                "version_added": "54"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": false,
+                "notes": "Instead of ignoring the <code>-webkit-text-size-adjust</code> property, a bug prevents desktop Chrome users from zooming in or out. The bug was fixed after Chrome 26."
+              }
+            ],
+            "chrome_android": {
+              "version_added": "54"
+            },
+            "edge": [
+              {
+                "prefix": "-ms-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "edge_mobile": [
+              {
+                "prefix": "-ms-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flag": {
+                  "type": "preference",
+                  "name": "layout.css.prefixes.webkit",
+                  "value_to_set": "true"
+                }
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "ie_mobile": [
+              {
+                "prefix": "-ms-",
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "11"
+              }
+            ],
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "safari": [
+              {
+                "version_added": false
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": false,
+                "notes": "Instead of ignoring the <code>-webkit-text-size-adjust</code> property, a bug prevents desktop Safari users from zooming in or out. The bug was fixed after Safari 5."
+              }
+            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "<code>&lt;percentage&gt;</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "ie_mobile": {
+                "version_added": true,
+                "notes": "If the viewport is set using <a href='https://developer.mozilla.org/docs/Web/HTML/Element/meta'><code>&lt;meta&gt;</code></a> element, the value of the CSS <code>text-size-adjust</code> property is ignored. See <a href='https://msdn.microsoft.com/library/windows/apps/ff462082(v=vs.105).aspx#BKMK_AdjustingTextSizewithCustomCSS'>detailed implementation hints on MSDN</a>."
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`text-size-adjust`](https://developer.mozilla.org/docs/Web/CSS/text-size-adjust). Let me know if you want to see any changes. Thanks!