### PR TITLE
identity API is not supported on Firefox for Android

### DIFF
--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -16,7 +16,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "53"
+                "version_added": false
               },
               "opera": {
                 "version_added": false
@@ -38,7 +38,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "53"
+                "version_added": false
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
See https://github.com/mozilla/addons/issues/611#issuecomment-356025664.