### PR TITLE
Add compat data for <flex> CSS type

### DIFF
--- a/css/types/flex.json
+++ b/css/types/flex.json
@@ -1,0 +1,81 @@
+{
+  "css": {
+    "types": {
+      "flex": {
+        "__compat": {
+          "description": "<code>lt;flexgt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex_value",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "29",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.grid.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "28",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/flex.json
+++ b/css/types/flex.json
@@ -3,7 +3,7 @@
     "types": {
       "flex": {
         "__compat": {
-          "description": "<code>lt;flexgt;</code>",
+          "description": "<code>&lt;flex&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex_value",
           "support": {
             "webview_android": {

--- a/css/types/flex.json
+++ b/css/types/flex.json
@@ -7,66 +7,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex_value",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "chrome": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "29"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": "12"
+              "version_added": "16"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.grid.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "40"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             }
           },
           "status": {


### PR DESCRIPTION
This PR migrates the data for [`<flex>`](https://developer.mozilla.org/docs/Web/CSS/flex_value), though I think this data here is suspect. By comparison, we have rather complete data for something like [`grid-template-columns`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns), which uses `fr` units, that doesn't line up with this data at all. Happy to make changes on this one. Thanks!