### PR TITLE
Add compat data for <integer> CSS type

### DIFF
--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "types": {
+      "integer": {
+        "__compat": {
+          "description": "<code>lt;integergt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/integer",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "ie_mobile": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -3,7 +3,7 @@
     "types": {
       "integer": {
         "__compat": {
-          "description": "<code>lt;integergt;</code>",
+          "description": "<code>&lt;integer&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/integer",
           "support": {
             "webview_android": {


### PR DESCRIPTION
This PR migrates the data for [`<integer>`](https://developer.mozilla.org/docs/Web/CSS/integer). I assumed some true values here because seriously who doesn't support integers? 😆 Let me know if you want to see any changes. Thanks!